### PR TITLE
Enhance routing table management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2998,9 +2998,9 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.1.tgz",
-      "integrity": "sha512-K3/6Y+J/sIAjplf3uIteWLhPuOyuMNnE+iyYnTF/m294vc6IL90kTHp7y8ldZYbpKlP17rpOWDKM9DvTcrOmNQ==",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
+      "integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/plugin-syntax-jsx": "^7.12.13",
@@ -5871,9 +5871,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-      "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+      "version": "12.20.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+      "integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -7081,9 +7081,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1046.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1046.0.tgz",
-      "integrity": "sha512-ocwHclMXdIA+NWocUyvp9Ild3/zy2vr5mHp3mTyodf0WU5lzBE8PocCVLSWhMAXLxyia83xv2y5f5AzAcetbqA==",
+      "version": "2.1048.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1048.0.tgz",
+      "integrity": "sha512-mVwWo+Udiuc/yEZ/DgJQGqOEtfiQjgUdtshx/t6ISe3+jW3TF9hUACwADwx2Sr/fuJyyJ3QD5JYLt5Cw35wQpA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -8343,9 +8343,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001291",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-      "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+      "version": "1.0.30001292",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -9126,9 +9126,9 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.1.tgz",
-      "integrity": "sha512-At4Ms7dDDxhfCLCg5D4HDO+B/7hl8mLZs+cjtbNIAb3sv+g7Piu1ryR5K9MpmWUVZkoCXN4mck9vx8ITcqfdvQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.2.tgz",
+      "integrity": "sha512-27ZehvijYqAKVzta5xtZBS3PAliC8CmnWkGXN0vgxAZz7yqxpMjf3aG7flxF5rEiu8FAD7nZZXtOI+xUGn+bVg==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^7",
@@ -9136,7 +9136,7 @@
       },
       "engines": {
         "node": ">=12",
-        "npm": ">=7"
+        "npm": ">=6"
       },
       "peerDependencies": {
         "@types/node": "*",
@@ -10525,9 +10525,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.24",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.24.tgz",
-      "integrity": "sha512-erwx5r69B/WFfFuF2jcNN0817BfDBdC4765kQ6WltOMuwsimlQo3JTEq0Cle+wpHralwdeX3OfAtw/mHxPK0Wg=="
+      "version": "1.4.26",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.26.tgz",
+      "integrity": "sha512-cA1YwlRzO6TGp7yd3+KAqh9Tt6Z4CuuKqsAJP6uF/H5MQryjAGDhMhnY5cEXo8MaRCczpzSBhMPdqRIodkbZYw=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -22881,9 +22881,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.7.tgz",
-      "integrity": "sha512-U+b/Deoi4I/UmE6KOVPpnhS7I7AYdKbhGcat+qTQ27gycvaACvNEw11ba6RrkwVmDVRW7sigWgLj4/KbbJjeDA==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
+      "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23176,9 +23176,9 @@
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.1.tgz",
-      "integrity": "sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ=="
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
+      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA=="
     },
     "node_modules/protocols": {
       "version": "1.4.8",
@@ -34356,9 +34356,9 @@
       }
     },
     "@emotion/babel-plugin": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.1.tgz",
-      "integrity": "sha512-K3/6Y+J/sIAjplf3uIteWLhPuOyuMNnE+iyYnTF/m294vc6IL90kTHp7y8ldZYbpKlP17rpOWDKM9DvTcrOmNQ==",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
+      "integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/plugin-syntax-jsx": "^7.12.13",
@@ -36596,9 +36596,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
-      "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+      "version": "12.20.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+      "integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -37544,9 +37544,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sdk": {
-      "version": "2.1046.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1046.0.tgz",
-      "integrity": "sha512-ocwHclMXdIA+NWocUyvp9Ild3/zy2vr5mHp3mTyodf0WU5lzBE8PocCVLSWhMAXLxyia83xv2y5f5AzAcetbqA==",
+      "version": "2.1048.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1048.0.tgz",
+      "integrity": "sha512-mVwWo+Udiuc/yEZ/DgJQGqOEtfiQjgUdtshx/t6ISe3+jW3TF9hUACwADwx2Sr/fuJyyJ3QD5JYLt5Cw35wQpA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -38229,7 +38229,7 @@
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-proposal-optional-chaining": "^7.16.0",
         "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "*",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
         "@chainsafe/discv5": "^0.6.6",
         "@chakra-ui/react": "^1.0.0",
         "@craco/craco": "^6.3.0",
@@ -38591,9 +38591,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001291",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-      "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA=="
+      "version": "1.0.30001292",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -39240,9 +39240,9 @@
       }
     },
     "cosmiconfig-typescript-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.1.tgz",
-      "integrity": "sha512-At4Ms7dDDxhfCLCg5D4HDO+B/7hl8mLZs+cjtbNIAb3sv+g7Piu1ryR5K9MpmWUVZkoCXN4mck9vx8ITcqfdvQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.2.tgz",
+      "integrity": "sha512-27ZehvijYqAKVzta5xtZBS3PAliC8CmnWkGXN0vgxAZz7yqxpMjf3aG7flxF5rEiu8FAD7nZZXtOI+xUGn+bVg==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7",
@@ -40358,9 +40358,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.4.24",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.24.tgz",
-      "integrity": "sha512-erwx5r69B/WFfFuF2jcNN0817BfDBdC4765kQ6WltOMuwsimlQo3JTEq0Cle+wpHralwdeX3OfAtw/mHxPK0Wg=="
+      "version": "1.4.26",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.26.tgz",
+      "integrity": "sha512-cA1YwlRzO6TGp7yd3+KAqh9Tt6Z4CuuKqsAJP6uF/H5MQryjAGDhMhnY5cEXo8MaRCczpzSBhMPdqRIodkbZYw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -50391,9 +50391,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.7.tgz",
-      "integrity": "sha512-U+b/Deoi4I/UmE6KOVPpnhS7I7AYdKbhGcat+qTQ27gycvaACvNEw11ba6RrkwVmDVRW7sigWgLj4/KbbJjeDA==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
+      "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -50606,9 +50606,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.1.tgz",
-          "integrity": "sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ=="
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
+          "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA=="
         }
       }
     },

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -30,7 +30,7 @@ export const App = () => {
   const [portal, setDiscv5] = React.useState<PortalNetwork>();
   const [enr, setENR] = React.useState<string>("");
   const [network, setNetwork] = React.useState<SubNetworkIds>(
-    SubNetworkIds.HistoryNetworkId
+    SubNetworkIds.HistoryNetwork
   );
   const [radius, setRadius] = React.useState("");
 
@@ -78,11 +78,11 @@ export const App = () => {
 
   const updateNetwork = (val: string) => {
     switch (val) {
-      case SubNetworkIds.HistoryNetworkId:
-        setNetwork(SubNetworkIds.HistoryNetworkId);
+      case SubNetworkIds.HistoryNetwork:
+        setNetwork(SubNetworkIds.HistoryNetwork);
         break;
-      case SubNetworkIds.StateNetworkId:
-        setNetwork(SubNetworkIds.StateNetworkId);
+      case SubNetworkIds.StateNetwork:
+        setNetwork(SubNetworkIds.StateNetwork);
         break;
     }
   };
@@ -132,10 +132,10 @@ export const App = () => {
               </Center>
               <RadioGroup onChange={updateNetwork} value={network} spacing={1}>
                 <Stack direction="row">
-                  <Radio value={SubNetworkIds.StateNetworkId}>
+                  <Radio value={SubNetworkIds.StateNetwork}>
                     State Network
                   </Radio>
-                  <Radio value={SubNetworkIds.HistoryNetworkId}>
+                  <Radio value={SubNetworkIds.HistoryNetwork}>
                     History Network
                   </Radio>
                 </Stack>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -56,14 +56,14 @@ const run = async () => {
             case 'p': {
                 if (!bootnodeId) return;
                 console.log('Sending PING to', bootnodeId);
-                const res = await portal.sendPing(bootnodeId, SubNetworkIds.HistoryNetworkId)
+                const res = await portal.sendPing(bootnodeId, SubNetworkIds.HistoryNetwork)
                 console.log('Received PONG response', res);
                 break;
             }
             case 'n': {
                 if (!bootnodeId) return;
                 console.log('Sending FINDNODES to ', bootnodeId)
-                const res = await portal.sendFindNodes(bootnodeId, Uint16Array.from([0, 1, 2]), SubNetworkIds.HistoryNetworkId)
+                const res = await portal.sendFindNodes(bootnodeId, Uint16Array.from([0, 1, 2]), SubNetworkIds.HistoryNetwork)
                 console.log(res)
             }
             case 'e': {

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -850,5 +850,6 @@ export class Discv5 extends (EventEmitter as { new(): Discv5EventEmitter }) {
     this.connectionUpdated(srcId, undefined, EntryStatus.Disconnected);
     clearInterval(this.connectedPeers.get(srcId) as NodeJS.Timer);
     this.connectedPeers.delete(srcId);
+    this.emit("sessionEnded", srcId)
   };
 }

--- a/packages/discv5/src/service/types.ts
+++ b/packages/discv5/src/service/types.ts
@@ -32,6 +32,11 @@ export interface IDiscv5Events {
    * The message object is returned.
    */
   talkRespReceived: (srcId: NodeId, enr: ENR | null, message: ITalkRespMessage) => void;
+
+  /**
+   * A session is terminated with a connected peer
+   */
+  sessionEnded: (srcId: NodeId) => void;
 }
 
 export type Discv5EventEmitter = StrictEventEmitter<EventEmitter, IDiscv5Events>;

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -121,7 +121,7 @@ export class PortalNetwork extends (EventEmitter as { new(): PortalNetworkEventE
     /**
      * Updates the node's radius for interested content
      * @param value number representing the new radius
-     * @throws if `value` is greater than 256
+     * @throws if `value` is outside correct range
      */
     public set radius(value: number) {
         if (value > 256 || value < 0) {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -82,8 +82,8 @@ export class PortalNetwork extends (EventEmitter as { new(): PortalNetworkEventE
             "0x02": Buffer.from('efg'),
             "0x03": testArray
         }
-
         this.historyNetworkDB = db ?? level()
+
     }
 
     log = (msg: any) => {
@@ -182,14 +182,17 @@ export class PortalNetwork extends (EventEmitter as { new(): PortalNetworkEventE
                     decoded.enrs.forEach((enr) => {
                         const decodedEnr = ENR.decode(Buffer.from(enr))
                         this.log(decodedEnr.nodeId)
-                        // TODO: Update routing table corresponding to `networkId` 
-                        if (!this.historyNetworkRoutingTable.getValue(decodedEnr.nodeId)) {
-                            // Add node to History Subnetwork Routing Table if we don't already know it
-                            this.sendPing(decodedEnr.nodeId, SubNetworkIds.HistoryNetwork)
-                        }
-                        if (!this.stateNetworkRoutingTable.getValue(decodedEnr.nodeId)) {
-                            // Add node to State Subnetwork Routing Table if we don't already know it
-                            this.sendPing(decodedEnr.nodeId, SubNetworkIds.StateNetwork)
+                        switch (networkId) {
+                            case SubNetworkIds.StateNetwork: if (!this.stateNetworkRoutingTable.getValue(decodedEnr.nodeId)) {
+                                // Add node to State Subnetwork Routing Table if we don't already know it
+                                this.sendPing(decodedEnr.nodeId, SubNetworkIds.StateNetwork)
+                            }
+                                break;
+                            case SubNetworkIds.HistoryNetwork: if (!this.historyNetworkRoutingTable.getValue(decodedEnr.nodeId)) {
+                                // Add node to History Subnetwork Routing Table if we don't already know it
+                                this.sendPing(decodedEnr.nodeId, SubNetworkIds.HistoryNetwork)
+                            };
+                                break;
                         }
                     })
                 }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -196,13 +196,11 @@ export class PortalNetwork extends (EventEmitter as { new(): PortalNetworkEventE
                             case SubNetworkIds.StateNetwork: if (!this.stateNetworkRoutingTable.getValue(decodedEnr.nodeId)) {
                                 // Add node to State Subnetwork Routing Table if we don't already know it
                                 this.stateNetworkRoutingTable.add(decodedEnr)
-                                this.sendPing(decodedEnr.nodeId, SubNetworkIds.StateNetwork)
                             }
                                 break;
                             case SubNetworkIds.HistoryNetwork: if (!this.historyNetworkRoutingTable.getValue(decodedEnr.nodeId)) {
                                 // Add node to History Subnetwork Routing Table if we don't already know it
                                 this.historyNetworkRoutingTable.add(decodedEnr)
-                                this.sendPing(decodedEnr.nodeId, SubNetworkIds.HistoryNetwork)
                             };
                                 break;
                         }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -426,7 +426,9 @@ export class PortalNetwork extends (EventEmitter as { new(): PortalNetworkEventE
         const contentKey = toHexString(decodedContentMessage.contentKey)
         let value = Uint8Array.from([])
         switch (toHexString(message.protocol)) {
-            case SubNetworkIds.StateNetwork: value = this.stateNetworkState[contentKey]; break;
+            case SubNetworkIds.StateNetwork: {
+                value = this.stateNetworkState[contentKey] ?? value; break;
+            }
             case SubNetworkIds.HistoryNetwork: {
                 try {
                     value = await this.historyNetworkDB.get(contentKey);
@@ -434,9 +436,8 @@ export class PortalNetwork extends (EventEmitter as { new(): PortalNetworkEventE
                 catch (err) {
                     console.log('Error retrieving content', err)
                 }
-            }
+            }; break;
         }
-
 
         if (value.length === 0) {
             // TODO: Replace with correct FINDCONTENT response (e.g. nodes closer to content from routing table)

--- a/packages/portalnetwork/src/wire/types.ts
+++ b/packages/portalnetwork/src/wire/types.ts
@@ -3,12 +3,12 @@ import { ContainerType, ByteVector, BigIntUintType, UnionType, ListType, byteTyp
 
 // Subnetwork IDs
 export enum SubNetworkIds {
-    StateNetworkId = '0x500a',
-    HistoryNetworkId = '0x500b',
-    TxGossipNetworkId = '0x500c',
-    HeaderGossipNetworkId = '0x500d',
-    CanonIndicesNetworkId = '0x500e',
-    UTPNetworkId = '0x757470'
+    StateNetwork = '0x500a',
+    HistoryNetwork = '0x500b',
+    TxGossipNetwork = '0x500c',
+    HeaderGossipNetwork = '0x500d',
+    CanonIndicesNetwork = '0x500e',
+    UTPNetwork = '0x757470'
 }
 
 // Ping/Pong Custom Data type -- currently identical for State and History networks

--- a/packages/portalnetwork/src/wire/utp/Socket/_UTPSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/_UTPSocket.ts
@@ -82,7 +82,7 @@ export class _UTPSocket extends EventEmitter {
     await this.client.sendTalkReq(
       this.remoteAddress,
       msg,
-      fromHexString(SubNetworkIds.UTPNetworkId)
+      fromHexString(SubNetworkIds.UTPNetwork)
     );
     log(`${PacketType[type]} packet sent to ${this.remoteAddress}.`);
     type === 1 && log("uTP stream clsed.");

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -19,28 +19,28 @@ tape('Client unit tests', async (t) => {
     const findContentResponse = Uint8Array.from([5, 1, 97, 98, 99])
     node.sendPortalNetworkMessage = td.func<any>()
     td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(pongResponse, null, findNodesResponse, null, findContentResponse)
-    let res = await node.sendPing('abc', SubNetworkIds.HistoryNetworkId)
+    let res = await node.sendPing('abc', SubNetworkIds.HistoryNetwork)
     t.ok(res.enrSeq === 5n && res.customPayload[0] === 1, 'received expected PONG response')
-    res = await node.sendPing('abc', SubNetworkIds.HistoryNetworkId)
+    res = await node.sendPing('abc', SubNetworkIds.HistoryNetwork)
     t.ok(res === undefined, 'received undefined when no valid PONG message received')
-    res = await node.sendFindNodes('abc', [0, 1, 2], SubNetworkIds.HistoryNetworkId)
+    res = await node.sendFindNodes('abc', [0, 1, 2], SubNetworkIds.HistoryNetwork)
     t.ok(res.total === 1, 'received 1 ENR from FINDNODES')
-    res = await node.sendFindNodes('abc', [], SubNetworkIds.HistoryNetworkId)
+    res = await node.sendFindNodes('abc', [], SubNetworkIds.HistoryNetwork)
     t.ok(res === undefined, 'received undefined when no valid NODES response received')
-    res = await node.sendFindContent('abc', Uint8Array.from([1]), SubNetworkIds.HistoryNetworkId)
+    res = await node.sendFindContent('abc', Uint8Array.from([1]), SubNetworkIds.HistoryNetwork)
     t.ok(Buffer.from(res).toString() === 'abc', 'received expected content from FINDCONTENT')
 
     // Testdouble apparently has an upper limit of 5 on the number of return values that can be passed from `thenResolve` 
     // so have to provide a new list here
     const acceptResponse = Uint8Array.from([7, 229, 229, 6, 0, 0, 0, 3])
     td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(null, acceptResponse, null)
-    res = await node.sendFindContent('abc', '', SubNetworkIds.HistoryNetworkId)
+    res = await node.sendFindContent('abc', '', SubNetworkIds.HistoryNetwork)
     t.ok(res === undefined, 'received undefined when no valid FOUNDCONTENT message received')
     node.sendUtpStreamRequest = td.func<any>()
     td.when(node.sendUtpStreamRequest(td.matchers.contains('abc'), td.matchers.anything())).thenResolve(undefined)
-    res = await node.sendOffer('abc', [Uint8Array.from([1])], SubNetworkIds.HistoryNetworkId)
+    res = await node.sendOffer('abc', [Uint8Array.from([1])], SubNetworkIds.HistoryNetwork)
     t.ok(res.contentKeys[0] === true, 'received valid ACCEPT response to OFFER')
-    res = await node.sendOffer('abc', [Uint8Array.from([0])], SubNetworkIds.HistoryNetworkId)
+    res = await node.sendOffer('abc', [Uint8Array.from([0])], SubNetworkIds.HistoryNetwork)
     t.ok(res === undefined, 'received undefined when no valid ACCEPT message received')
 
     node.sendPong = td.func<any>()
@@ -53,7 +53,7 @@ tape('Client unit tests', async (t) => {
             customPayload: payload
         }
     })
-    node.handlePing('abc', { request: pingMsg, protocol: SubNetworkIds.HistoryNetworkId })
+    node.handlePing('abc', { request: pingMsg, protocol: SubNetworkIds.HistoryNetwork })
     
     node.client.sendTalkResp = td.func<any>()
     const findNodesMessageWithDistance = Uint8Array.from([2, 4, 0, 0, 0, 0, 0])
@@ -62,8 +62,8 @@ tape('Client unit tests', async (t) => {
     td.when(node.client.sendTalkResp('abc', td.matchers.anything(), td.matchers.argThat((arg: Uint8Array) => arg.length > 3))).thenDo(() => t.pass('correctly handle findNodes message with ENRs'))
     td.when(node.client.sendTalkResp('abc', td.matchers.anything(), td.matchers.argThat((arg: Uint8Array) => arg.length === 0))).thenDo(() => t.pass('correctly handle findNodes message with no ENRs'))
     td.when(node.client.enr.encode()).thenReturn(Uint8Array.from([0, 1, 2]))
-    node.handleFindNodes('abc', { request: findNodesMessageWithDistance, protocol: SubNetworkIds.HistoryNetworkId })
-    node.handleFindNodes('abc', { request: findNodesMessageWithoutDistance, protocol: SubNetworkIds.HistoryNetworkId })
+    node.handleFindNodes('abc', { request: findNodesMessageWithDistance, protocol: SubNetworkIds.HistoryNetwork })
+    node.handleFindNodes('abc', { request: findNodesMessageWithoutDistance, protocol: SubNetworkIds.HistoryNetwork })
 
     // TODO: Construct better findContent tests since these will break when introduce an actual content database
     const findContentMessageWithShortContent = Uint8Array.from([4, 4, 0, 0, 0, 1])

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -72,9 +72,9 @@ tape('Client unit tests', async (t) => {
     td.when(node.client.sendTalkResp('def', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg[1] === 1))).thenDo(() => t.pass('correctly handle findContent with small content request'))
     td.when(node.client.sendTalkResp('ghi', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg.length === 0))).thenDo(() => t.pass('correctly handle findContent where no matching content'))
     td.when(node.client.sendTalkResp('jkl', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg[1] === 0))).thenDo(() => t.pass('correctly handle findContent with large content request'))
-    node.handleFindContent('def', { request: findContentMessageWithShortContent })
-    node.handleFindContent('ghi', { request: findContentMessageWithNoContent })
-    node.handleFindContent('jkl', { request: findContentMessageWithLongContent })
+    node.handleFindContent('def', { protocol: SubNetworkIds.StateNetwork, request: findContentMessageWithShortContent })
+    node.handleFindContent('ghi', { protocol: SubNetworkIds.StateNetwork, request: findContentMessageWithNoContent })
+    node.handleFindContent('jkl', { protocol: SubNetworkIds.StateNetwork, request: findContentMessageWithLongContent })
     td.reset();
 
     t.end()

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -1,80 +1,99 @@
 import tape from 'tape'
 import { MessageCodes, PingPongCustomDataType, PortalNetwork, PortalWireMessageType, SubNetworkIds } from '../../src/'
 import td from 'testdouble'
+import { fromHexString } from '@chainsafe/ssz'
 
 tape('Client unit tests', async (t) => {
+
     const node = await PortalNetwork.createPortalNetwork('192.168.0.1', 'ws://192.168.0.2:5050') as any
-    t.ok(node.client.enr.getLocationMultiaddr('udp')!.toString().includes('192.168.0.1'), 'created portal network node with correct ip address')
+    t.test('node initialization/startup', async (st) => {
+        st.plan(4)
+        st.ok(node.client.enr.getLocationMultiaddr('udp')!.toString().includes('192.168.0.1'), 'created portal network node with correct ip address')
 
-    node.client.start = td.func<any>()
-    td.when(node.client.start()).thenResolve(undefined)
-    await node.start();
-    t.pass('client should start')
+        node.client.start = td.func<any>()
+        td.when(node.client.start()).thenResolve(undefined)
+        await node.start();
+        st.pass('client should start')
 
-    t.throws(() => node.radius = 257, 'should not be able to set radius greater than 256')
-    t.throws(() => node.radius = -1, 'radius cannot be negative');
-
-    const pongResponse = Uint8Array.from([1, 5, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-    const findNodesResponse = Uint8Array.from([3, 1, 5, 0, 0, 0, 4, 0, 0, 0, 248, 132, 184, 64, 98, 28, 68, 73, 123, 43, 66, 88, 148, 220, 175, 197, 99, 155, 158, 245, 113, 112, 19, 145, 242, 62, 9, 177, 46, 127, 179, 172, 15, 214, 73, 120, 117, 10, 84, 236, 35, 36, 1, 7, 157, 133, 186, 53, 153, 250, 87, 144, 208, 228, 233, 233, 190, 215, 71, 114, 119, 169, 10, 2, 182, 117, 100, 246, 5, 130, 105, 100, 130, 118, 52, 130, 105, 112, 132, 127, 0, 0, 1, 137, 115, 101, 99, 112, 50, 53, 54, 107, 49, 161, 2, 166, 64, 119, 30, 57, 36, 215, 222, 189, 27, 126, 14, 93, 46, 164, 80, 142, 10, 84, 179, 46, 141, 1, 3, 181, 22, 178, 254, 0, 158, 156, 232, 131, 117, 100, 112, 130, 158, 250])
-    const findContentResponse = Uint8Array.from([5, 1, 97, 98, 99])
-    node.sendPortalNetworkMessage = td.func<any>()
-    td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(pongResponse, null, findNodesResponse, null, findContentResponse)
-    let res = await node.sendPing('abc', SubNetworkIds.HistoryNetwork)
-    t.ok(res.enrSeq === 5n && res.customPayload[0] === 1, 'received expected PONG response')
-    res = await node.sendPing('abc', SubNetworkIds.HistoryNetwork)
-    t.ok(res === undefined, 'received undefined when no valid PONG message received')
-    res = await node.sendFindNodes('abc', [0, 1, 2], SubNetworkIds.HistoryNetwork)
-    t.ok(res.total === 1, 'received 1 ENR from FINDNODES')
-    res = await node.sendFindNodes('abc', [], SubNetworkIds.HistoryNetwork)
-    t.ok(res === undefined, 'received undefined when no valid NODES response received')
-    res = await node.sendFindContent('abc', Uint8Array.from([1]), SubNetworkIds.HistoryNetwork)
-    t.ok(Buffer.from(res).toString() === 'abc', 'received expected content from FINDCONTENT')
-
-    // Testdouble apparently has an upper limit of 5 on the number of return values that can be passed from `thenResolve` 
-    // so have to provide a new list here
-    const acceptResponse = Uint8Array.from([7, 229, 229, 6, 0, 0, 0, 3])
-    td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(null, acceptResponse, null)
-    res = await node.sendFindContent('abc', '', SubNetworkIds.HistoryNetwork)
-    t.ok(res === undefined, 'received undefined when no valid FOUNDCONTENT message received')
-    node.sendUtpStreamRequest = td.func<any>()
-    td.when(node.sendUtpStreamRequest(td.matchers.contains('abc'), td.matchers.anything())).thenResolve(undefined)
-    res = await node.sendOffer('abc', [Uint8Array.from([1])], SubNetworkIds.HistoryNetwork)
-    t.ok(res.contentKeys[0] === true, 'received valid ACCEPT response to OFFER')
-    res = await node.sendOffer('abc', [Uint8Array.from([0])], SubNetworkIds.HistoryNetwork)
-    t.ok(res === undefined, 'received undefined when no valid ACCEPT message received')
-
-    node.sendPong = td.func<any>()
-    td.when(node.sendPong('abc', td.matchers.anything())).thenDo(() => t.pass('correctly handled PING message'))
-    node.updateSubnetworkRoutingTable = td.func<any>()
-    const payload = PingPongCustomDataType.serialize({ radius: BigInt(1) })
-    const pingMsg = PortalWireMessageType.serialize({
-        selector: MessageCodes.PING, value: {
-            enrSeq: node.client.enr.seq,
-            customPayload: payload
-        }
+        st.throws(() => node.radius = 257, 'should not be able to set radius greater than 256')
+        st.throws(() => node.radius = -1, 'radius cannot be negative');
     })
-    node.handlePing('abc', { request: pingMsg, protocol: SubNetworkIds.HistoryNetwork })
-    
-    node.client.sendTalkResp = td.func<any>()
-    const findNodesMessageWithDistance = Uint8Array.from([2, 4, 0, 0, 0, 0, 0])
-    const findNodesMessageWithoutDistance = Uint8Array.from([2, 4, 0, 0, 0])
-    node.client.enr.encode = td.func<any>()
-    td.when(node.client.sendTalkResp('abc', td.matchers.anything(), td.matchers.argThat((arg: Uint8Array) => arg.length > 3))).thenDo(() => t.pass('correctly handle findNodes message with ENRs'))
-    td.when(node.client.sendTalkResp('abc', td.matchers.anything(), td.matchers.argThat((arg: Uint8Array) => arg.length === 0))).thenDo(() => t.pass('correctly handle findNodes message with no ENRs'))
-    td.when(node.client.enr.encode()).thenReturn(Uint8Array.from([0, 1, 2]))
-    node.handleFindNodes('abc', { request: findNodesMessageWithDistance, protocol: SubNetworkIds.HistoryNetwork })
-    node.handleFindNodes('abc', { request: findNodesMessageWithoutDistance, protocol: SubNetworkIds.HistoryNetwork })
 
-    // TODO: Construct better findContent tests since these will break when introduce an actual content database
-    const findContentMessageWithShortContent = Uint8Array.from([4, 4, 0, 0, 0, 1])
-    const findContentMessageWithNoContent = Uint8Array.from([4, 4, 0, 0, 0])
-    const findContentMessageWithLongContent = Uint8Array.from([4, 4, 0, 0, 0, 3])
-    td.when(node.client.sendTalkResp('def', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg[1] === 1))).thenDo(() => t.pass('correctly handle findContent with small content request'))
-    td.when(node.client.sendTalkResp('ghi', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg.length === 0))).thenDo(() => t.pass('correctly handle findContent where no matching content'))
-    td.when(node.client.sendTalkResp('jkl', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg[1] === 0))).thenDo(() => t.pass('correctly handle findContent with large content request'))
-    node.handleFindContent('def', { protocol: SubNetworkIds.StateNetwork, request: findContentMessageWithShortContent })
-    node.handleFindContent('ghi', { protocol: SubNetworkIds.StateNetwork, request: findContentMessageWithNoContent })
-    node.handleFindContent('jkl', { protocol: SubNetworkIds.StateNetwork, request: findContentMessageWithLongContent })
+    t.test('PING/PONG message handlers', async (st) => {
+        const pongResponse = Uint8Array.from([1, 5, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        node.sendPortalNetworkMessage = td.func<any>()
+        td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(pongResponse, null)
+        let res = await node.sendPing('abc', SubNetworkIds.HistoryNetwork)
+        st.ok(res.enrSeq === 5n && res.customPayload[0] === 1, 'received expected PONG response')
+        res = await node.sendPing('abc', SubNetworkIds.HistoryNetwork)
+        st.ok(res === undefined, 'received undefined when no valid PONG message received')
+
+        node.sendPong = td.func<any>()
+        td.when(node.sendPong('abc', td.matchers.anything())).thenDo(() => st.pass('correctly handled PING message'))
+        node.updateSubnetworkRoutingTable = td.func<any>()
+        const payload = PingPongCustomDataType.serialize({ radius: BigInt(1) })
+        const pingMsg = PortalWireMessageType.serialize({
+            selector: MessageCodes.PING, value: {
+                enrSeq: node.client.enr.seq,
+                customPayload: payload
+            }
+        })
+        node.handlePing('abc', { request: pingMsg, protocol: SubNetworkIds.HistoryNetwork })
+    })
+
+    t.test('FINDNODES/NODES message handlers', async (st) => {
+        st.plan(4)
+        const findNodesResponse = Uint8Array.from([3, 1, 5, 0, 0, 0, 4, 0, 0, 0, 248, 132, 184, 64, 98, 28, 68, 73, 123, 43, 66, 88, 148, 220, 175, 197, 99, 155, 158, 245, 113, 112, 19, 145, 242, 62, 9, 177, 46, 127, 179, 172, 15, 214, 73, 120, 117, 10, 84, 236, 35, 36, 1, 7, 157, 133, 186, 53, 153, 250, 87, 144, 208, 228, 233, 233, 190, 215, 71, 114, 119, 169, 10, 2, 182, 117, 100, 246, 5, 130, 105, 100, 130, 118, 52, 130, 105, 112, 132, 127, 0, 0, 1, 137, 115, 101, 99, 112, 50, 53, 54, 107, 49, 161, 2, 166, 64, 119, 30, 57, 36, 215, 222, 189, 27, 126, 14, 93, 46, 164, 80, 142, 10, 84, 179, 46, 141, 1, 3, 181, 22, 178, 254, 0, 158, 156, 232, 131, 117, 100, 112, 130, 158, 250])
+        td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(findNodesResponse, null)
+        let res = await node.sendFindNodes('abc', [0, 1, 2], SubNetworkIds.HistoryNetwork)
+        st.ok(res.total === 1, 'received 1 ENR from FINDNODES')
+        res = await node.sendFindNodes('abc', [], SubNetworkIds.HistoryNetwork)
+        st.ok(res === undefined, 'received undefined when no valid NODES response received')
+
+        node.client.sendTalkResp = td.func<any>()
+        const findNodesMessageWithDistance = Uint8Array.from([2, 4, 0, 0, 0, 0, 0])
+        const findNodesMessageWithoutDistance = Uint8Array.from([2, 4, 0, 0, 0])
+        node.client.enr.encode = td.func<any>()
+        td.when(node.client.sendTalkResp('abc', td.matchers.anything(), td.matchers.argThat((arg: Uint8Array) => arg.length > 3))).thenDo(() => st.pass('correctly handle findNodes message with ENRs'))
+        td.when(node.client.sendTalkResp('abc', td.matchers.anything(), td.matchers.argThat((arg: Uint8Array) => arg.length === 0))).thenDo(() => st.pass('correctly handle findNodes message with no ENRs'))
+        td.when(node.client.enr.encode()).thenReturn(Uint8Array.from([0, 1, 2]))
+        node.handleFindNodes('abc', { request: findNodesMessageWithDistance, protocol: SubNetworkIds.HistoryNetwork })
+        node.handleFindNodes('abc', { request: findNodesMessageWithoutDistance, protocol: SubNetworkIds.HistoryNetwork })
+    })
+
+    t.test('FINDCONTENT/FOUNDCONTENT message handlers', async (st) => {
+        st.plan(4)
+        const findContentResponse = Uint8Array.from([5, 1, 97, 98, 99])
+        td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(findContentResponse)
+        const res = await node.sendFindContent('abc', Uint8Array.from([1]), SubNetworkIds.HistoryNetwork)
+        st.ok(Buffer.from(res).toString() === 'abc', 'received expected content from FINDCONTENT')
+
+        // TODO: Construct better findContent tests since these will break when introduce an actual content database
+        const findContentMessageWithShortContent = Uint8Array.from([4, 4, 0, 0, 0, 1])
+        const findContentMessageWithNoContent = Uint8Array.from([4, 4, 0, 0, 0, 6])
+        const findContentMessageWithLongContent = Uint8Array.from([4, 4, 0, 0, 0, 3])
+        td.when(node.client.sendTalkResp('def', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg[1] === 1))).thenDo(() => st.pass('correctly handle findContent with small content request'))
+        td.when(node.client.sendTalkResp('ghi', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg.length === 0))).thenDo(() => st.pass('correctly handle findContent where no matching content'))
+        td.when(node.client.sendTalkResp('jkl', td.matchers.anything(), td.matchers.argThat((arg: Buffer) => arg[1] === 0))).thenDo(() => st.pass('correctly handle findContent with large content request'))
+        node.handleFindContent('def', { protocol: fromHexString(SubNetworkIds.StateNetwork), request: findContentMessageWithShortContent })
+        node.handleFindContent('ghi', { protocol: fromHexString(SubNetworkIds.StateNetwork), request: findContentMessageWithNoContent })
+        node.handleFindContent('jkl', { protocol: fromHexString(SubNetworkIds.StateNetwork), request: findContentMessageWithLongContent })
+    })
+
+    t.test('OFFER/ACCEPT message handlers', async (st) => {
+        st.plan(3)
+        const acceptResponse = Uint8Array.from([7, 229, 229, 6, 0, 0, 0, 3])
+        td.when(node.sendPortalNetworkMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything())).thenResolve(null, acceptResponse, null)
+        let res = await node.sendFindContent('abc', '', SubNetworkIds.HistoryNetwork)
+        st.ok(res === undefined, 'received undefined when no valid FOUNDCONTENT message received')
+        node.sendUtpStreamRequest = td.func<any>()
+        td.when(node.sendUtpStreamRequest(td.matchers.contains('abc'), td.matchers.anything())).thenResolve(undefined)
+        res = await node.sendOffer('abc', [Uint8Array.from([1])], SubNetworkIds.HistoryNetwork)
+        st.ok(res.contentKeys[0] === true, 'received valid ACCEPT response to OFFER')
+        res = await node.sendOffer('abc', [Uint8Array.from([0])], SubNetworkIds.HistoryNetwork)
+        st.ok(res === undefined, 'received undefined when no valid ACCEPT message received')
+    })
+
     td.reset();
 
     t.end()

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -48,7 +48,7 @@ tape('Client start-up', async (t) => {
         t.pass('updated second multiaddr')
         portal1.client.addEnr(portal2.client.enr);
 
-        const res = await portal1.sendPing(portal2.client.enr.nodeId, SubNetworkIds.HistoryNetworkId)
+        const res = await portal1.sendPing(portal2.client.enr.nodeId, SubNetworkIds.HistoryNetwork)
         console.log(res)
         child.kill()
         await portal1.client.stop();


### PR DESCRIPTION
- Add new `SessionEnded` event to `discv5` events when an active session is terminated with a node that fails a liveness check
- Add new routing table management to call the Portal Network FINDNODES message handler for all supported subnetworks when a new node is added to the `discv5` routing table
- Evict nodes from subnetwork routing tables when a liveness check is failed