### PR TITLE
Add contentId func and types to history network

### DIFF
--- a/packages/portalnetwork/src/historySubnetwork/index.ts
+++ b/packages/portalnetwork/src/historySubnetwork/index.ts
@@ -1,1 +1,2 @@
 export { HistoryNetworkContentKey, HistoryNetworkContentKeyUnionType } from './types'
+export * from "./util"

--- a/packages/portalnetwork/src/historySubnetwork/types.ts
+++ b/packages/portalnetwork/src/historySubnetwork/types.ts
@@ -17,3 +17,9 @@ export const BlockBodyType = BlockHeaderType
 export const ReceiptType = BlockHeaderType
 
 export const HistoryNetworkContentKeyUnionType = new UnionType<Union<HistoryNetworkContentKey>>({ types: [BlockHeaderType, BlockBodyType, ReceiptType] })
+
+export enum HistoryNetworkContentTypes {
+    BlockHeader = 0,
+    BlockBody = 1,
+    Receipt = 2
+}

--- a/packages/portalnetwork/src/historySubnetwork/util.ts
+++ b/packages/portalnetwork/src/historySubnetwork/util.ts
@@ -1,0 +1,15 @@
+import SHA256 from "@chainsafe/as-sha256";
+import { toHexString } from "@chainsafe/ssz";
+import { HistoryNetworkContentKey, HistoryNetworkContentKeyUnionType } from ".";
+import { HistoryNetworkContentTypes } from "./types";
+
+/**
+ * Generates the Content ID used to calculate the distance between a node ID and the content Key
+ * @param contentKey an object containing the `chainId` and `blockHash` used to generate the content Key
+ * @param contentType a number identifying the type of content (block header, block body, receipt)
+ * @returns the hex encoded string representation of the SHA256 hash of the serialized contentKey
+ */
+export const getContentId = (contentKey: HistoryNetworkContentKey, contentType: HistoryNetworkContentTypes) => {
+    const encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: contentType, value: contentKey })
+    return toHexString(SHA256.digest(encodedKey))
+}

--- a/packages/portalnetwork/test/historySubnetwork/types.spec.ts
+++ b/packages/portalnetwork/test/historySubnetwork/types.spec.ts
@@ -1,23 +1,27 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import tape from 'tape'
-import { HistoryNetworkContentKeyUnionType } from "../../src/historySubnetwork"
+import { getContentId, HistoryNetworkContentKeyUnionType } from "../../src/historySubnetwork"
 import SHA256 from '@chainsafe/as-sha256'
+import { HistoryNetworkContentTypes } from '../../src/historySubnetwork/types'
 
 tape('History Subnetwork contentKey serialization/deserialization', async t => {
     let chainId = 15
     let blockHash = "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
-    let encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: 0, value: { chainId: chainId, blockHash: fromHexString(blockHash) } })
+    let encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: HistoryNetworkContentTypes.BlockHeader, value: { chainId: chainId, blockHash: fromHexString(blockHash) } })
+    let contentId = getContentId({ chainId, blockHash: fromHexString(blockHash) }, HistoryNetworkContentTypes.BlockHeader)
     t.equals(toHexString(encodedKey), "0x000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d", 'blockheader content key equals expected output')
-    t.equals(toHexString(SHA256.digest(encodedKey)), "0x2137f185b713a60dd1190e650d01227b4f94ecddc9c95478e2c591c40557da99", 'block header content ID matches')
+    t.equals(contentId, "0x2137f185b713a60dd1190e650d01227b4f94ecddc9c95478e2c591c40557da99", 'block header content ID matches')
     chainId = 20
     blockHash = "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
-    encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: 1, value: { chainId, blockHash: fromHexString(blockHash) } })
+    encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: HistoryNetworkContentTypes.BlockBody, value: { chainId, blockHash: fromHexString(blockHash) } })
+    contentId = getContentId({ chainId, blockHash: fromHexString(blockHash) }, HistoryNetworkContentTypes.BlockBody)
     t.equals(toHexString(encodedKey), "0x011400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d", 'blockbody content key equals expected output')
-    t.equals(toHexString(SHA256.digest(encodedKey)), "0x1c6046475f0772132774ab549173ca8487bea031ce539cad8e990c08df5802ca", 'block body content ID matches')
+    t.equals(contentId, "0x1c6046475f0772132774ab549173ca8487bea031ce539cad8e990c08df5802ca", 'block body content ID matches')
     chainId = 4
     blockHash = "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
-    encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: 2, value: { chainId, blockHash: fromHexString(blockHash) } })
+    encodedKey = HistoryNetworkContentKeyUnionType.serialize({ selector: HistoryNetworkContentTypes.Receipt, value: { chainId, blockHash: fromHexString(blockHash) } })
+    contentId = getContentId({ chainId, blockHash: fromHexString(blockHash) }, HistoryNetworkContentTypes.Receipt)
     t.equals(toHexString(encodedKey), "0x020400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d", 'receipt content key equals expected output')
-    t.equals(toHexString(SHA256.digest(encodedKey)), "0xaa39e1423e92f5a667ace5b79c2c98adbfd79c055d891d0b9c49c40f816563b2", 'receipt content ID matches')
+    t.equals(contentId, "0xaa39e1423e92f5a667ace5b79c2c98adbfd79c055d891d0b9c49c40f816563b2", 'receipt content ID matches')
     t.end()
 })  


### PR DESCRIPTION
- Add `getContentId` helper method to calculate history network `content-id`
- Add `enum` for History Network `content-type`
- Update tests to use new helper and enum