### PR TITLE
Replace BN.js. with bigints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14111,12 +14111,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-      "extraneous": true
-    },
     "node_modules/immer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
@@ -31999,7 +31993,6 @@
         "yargs": "^17.3.0"
       },
       "devDependencies": {
-        "@types/bn.js": "^5.1.0",
         "@types/debug": "^4.1.7",
         "@types/tape": "^4.13.2",
         "@types/yargs": "^17.0.7",
@@ -32128,14 +32121,12 @@
         "@chainsafe/ssz": "^0.8.19",
         "@ethereumjs/block": "^3.6.0",
         "@types/levelup": "^4.3.3",
-        "bn.js": "^5.2.0",
         "debug": "^4.3.2",
         "level-mem": "^6.0.1",
         "strict-event-emitter-types": "^2.0.0",
         "tape": "^5.3.1"
       },
       "devDependencies": {
-        "@types/bn.js": "^5.1.0",
         "@types/debug": "^4.1.7",
         "@types/tape": "^4.13.2",
         "nyc": "^15.1.0",
@@ -32145,9 +32136,6 @@
         "typedoc": "^0.22.5",
         "typedoc-plugin-markdown": "^3.11.3",
         "typescript": "^4.4.2"
-      },
-      "peerDependencies": {
-        "bn.js": "^5.2.0"
       }
     },
     "packages/portalnetwork/node_modules/ansi-styles": {
@@ -39487,7 +39475,6 @@
       "version": "file:packages/cli",
       "requires": {
         "@chainsafe/discv5": "^0.6.6",
-        "@types/bn.js": "^5.1.0",
         "@types/debug": "^4.1.7",
         "@types/tape": "^4.13.2",
         "@types/yargs": "^17.0.7",
@@ -43786,11 +43773,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-    },
-    "immediate": {
-      "version": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
-      "extraneous": true
     },
     "immer": {
       "version": "8.0.1",
@@ -49958,11 +49940,9 @@
         "@chainsafe/discv5": "^0.6.6",
         "@chainsafe/ssz": "^0.8.19",
         "@ethereumjs/block": "^3.6.0",
-        "@types/bn.js": "^5.1.0",
         "@types/debug": "^4.1.7",
         "@types/levelup": "^4.3.3",
         "@types/tape": "^4.13.2",
-        "bn.js": "^5.2.0",
         "debug": "^4.3.2",
         "level-mem": "^6.0.1",
         "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postinstall": "npm run build --workspaces --if-present",
     "start-proxy": "npm run run-proxy -w=proxy",
     "start-browser-client": "npm run start -w=browser-client",
-    "start-cli": "npm run start -w=cli"
+    "start-cli": "npm run start -w=cli",
+    "clean": "bash ./scripts/clean-root.sh"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,6 @@
     "node": "^15"
   },
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.7",
     "@types/tape": "^4.13.2",
     "@types/yargs": "^17.0.7",

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -20,17 +20,12 @@
     "@chainsafe/ssz": "^0.8.19",
     "@ethereumjs/block": "^3.6.0",
     "@types/levelup": "^4.3.3",
-    "bn.js": "^5.2.0",
     "debug": "^4.3.2",
     "level-mem": "^6.0.1",
     "strict-event-emitter-types": "^2.0.0",
     "tape": "^5.3.1"
   },
-  "peerDependencies": {
-    "bn.js": "^5.2.0"
-  },
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.7",
     "@types/tape": "^4.13.2",
     "nyc": "^15.1.0",

--- a/packages/portalnetwork/src/stateSubnetwork/routingTable.ts
+++ b/packages/portalnetwork/src/stateSubnetwork/routingTable.ts
@@ -1,5 +1,4 @@
-import { BN } from 'bn.js';
-import { ENR, KademliaRoutingTable, NodeId } from '@chainsafe/discv5'
+import { ENR, NodeId } from '@chainsafe/discv5'
 import { distance } from './util'
 import { PortalNetworkRoutingTable } from '../client';
 
@@ -17,9 +16,9 @@ export class StateNetworkRoutingTable extends PortalNetworkRoutingTable {
             results.push(...bucket.values());
         });
         results.sort((a, b) => {
-            const diff = distance(new BN(id, 16), new BN(a.nodeId, 16)).sub(distance(new BN(id, 16), new BN(b.nodeId, 16)));
-            if (diff.isNeg()) return -1;
-            if (diff.isZero()) return 0;
+            const diff = distance(BigInt(id), BigInt(a.nodeId)) - distance(BigInt(id), BigInt(b.nodeId));
+            if (diff < 0) return -1;
+            if (diff === 0n) return 0;
             return 1;
         })
         return results.slice(0, limit);

--- a/packages/portalnetwork/src/stateSubnetwork/util.ts
+++ b/packages/portalnetwork/src/stateSubnetwork/util.ts
@@ -1,19 +1,16 @@
-import _BN from 'bn.js';
-const BN = _BN
-
-export const MODULO = new BN(2).pow(new BN(256))
-const MID = new BN(2).pow(new BN(255))
+export const MODULO = 2n ** 256n
+const MID = 2n ** 255n
 
 /** 
  * Calculates the distance between two ids using the distance function defined here 
  * https://github.com/ethereum/portal-network-specs/blob/master/state-network.md#distance-function
  */
-export const distance = (id1: _BN, id2: _BN): _BN => {
-    if (id1.gte(MODULO) || id2.gte(MODULO)) {
+export const distance = (id1: bigint, id2: bigint): bigint => {
+    if (id1 >= MODULO || id2 >= MODULO) {
         throw new Error('numeric representation of node id cannot be greater than 2^256')
     }
-    let diff: _BN
-    id1.gt(id2) ? diff = id1.sub(id2) : diff = id2.sub(id1)
-    diff.gt(MID) ? diff = MODULO.sub(diff) : diff
+    let diff: bigint
+    id1 > id2 ? diff = id1 - id2 : diff = id2 - id1
+    diff > MID ? diff = MODULO - diff : diff
     return diff
 }

--- a/packages/portalnetwork/test/stateSubnetwork/utils.spec.ts
+++ b/packages/portalnetwork/test/stateSubnetwork/utils.spec.ts
@@ -1,17 +1,16 @@
 import tape from 'tape';
 import { distance, MODULO } from '../../src/stateSubnetwork/util'
-import BN from 'bn.js'
 
 tape('distance()', (t) => {
 
     t.test('should calculate distance between two values', (st) => {
-        st.ok(distance(new BN(10), new BN(10)).eq(new BN(0)), 'calculates correct distance')
-        st.ok(distance(new BN(5), MODULO.subn(1)).eq(new BN(6)), 'calculates correct distance')
-        st.ok(distance(MODULO.subn(1), new BN(6)).eq(new BN(7)), 'calculates correct distance')
-        st.ok(distance(new BN(5), new BN(1)).eq(new BN(4)), 'calculates correct distance')
-        st.ok(distance(new BN(1), new BN(5)).eq(new BN(4)), 'calculates correct distance')
-        st.ok(distance(new BN(0), new BN(2).pow(new BN(255))).eq(new BN(2).pow(new BN(255))), 'calculates correct distance')
-        st.ok(distance(new BN(0), new BN(2).pow(new BN(255)).addn(1)).eq(new BN(2).pow(new BN(255)).subn(1)), 'calculates correct distance')
+        st.ok(distance(10n, 10n) === 0n, 'calculates correct distance')
+        st.ok(distance(5n, MODULO - 1n) === 6n, 'calculates correct distance')
+        st.ok(distance(MODULO - 1n, 6n) === 7n, 'calculates correct distance')
+        st.ok(distance(5n, 1n) === 4n, 'calculates correct distance')
+        st.ok(distance(1n, 5n) === 4n, 'calculates correct distance')
+        st.ok(distance(0n, 2n ** 255n) === 2n ** 255n, 'calculates correct distance')
+        st.ok(distance(0n, 2n ** 255n + 1n) === 2n ** 255n - 1n, 'calculates correct distance')
         st.end()
     })
     t.end()


### PR DESCRIPTION
Replace bn.js with bigints everywhere except `discv5` (to maintain minimal changes from upstream dependency)