### PR TITLE
Proxy updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ultralight",
       "hasInstallScript": true,
       "workspaces": [
         "./packages/*"
@@ -24268,6 +24267,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -32834,18 +32834,18 @@
       "dependencies": {
         "@chainsafe/discv5": "^0.6.6",
         "debug": "^4.3.3",
-        "eslint": "^8.6.0",
         "jayson": "^3.6.6",
         "multiaddr": "^10.0.0",
         "peer-id": "^0.15.2",
         "portalnetwork": "^0.0.1",
-        "prettier": "^2.5.1",
         "yargs": "^17.3.0"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/tape": "^4.13.2",
         "@types/yargs": "^17.0.7",
+        "eslint": "^8.6.0",
+        "prettier": "^2.5.1",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
         "typescript": "^4.4.2"
@@ -33880,8 +33880,10 @@
     "packages/proxy": {
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.3",
+        "debug": "^4.3.3",
         "stun": "^2.1.0",
-        "ws": "^8.2.2"
+        "ws": "^8.2.2",
+        "yargs": "^17.3.0"
       },
       "devDependencies": {
         "@types/ws": "^7.4.7",
@@ -53391,7 +53393,8 @@
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -53563,12 +53566,14 @@
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.3",
         "@types/ws": "^7.4.7",
+        "debug": "^4.3.3",
         "eslint": "^8.6.0",
         "prettier": "^2.5.1",
         "stun": "^2.1.0",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.3",
-        "ws": "^8.2.2"
+        "ws": "^8.2.2",
+        "yargs": "^17.3.0"
       }
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preinstall": "npm run checkNpmVersion",
     "checkNpmVersion": "bash ./scripts/check-npm-version.sh",
     "postinstall": "npm run build --workspaces --if-present",
-    "start-proxy": "npm run run-proxy -w=proxy",
+    "start-proxy": "npm run run-proxy -w=proxy -- --localhost",
     "start-browser-client": "npm run start -w=browser-client",
     "start-cli": "npm run start -w=cli",
     "lint": "npm run lint -w=cli -w=portalnetwork -w=proxy",

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -12,6 +12,8 @@ import {
   RadioGroup,
   Radio,
   Stack,
+  Input,
+  Button,
 } from '@chakra-ui/react'
 import { ColorModeSwitcher } from './ColorModeSwitcher'
 import { ENR } from '@chainsafe/discv5'
@@ -23,23 +25,26 @@ import AddressBookManager from './Components/AddressBookManager'
 
 import { ContentManager } from './Components/ContentManager'
 export const App = () => {
-  const [portal, setDiscv5] = React.useState<PortalNetwork>()
+  const [portal, setPortal] = React.useState<PortalNetwork>()
   const [enr, setENR] = React.useState<string>('')
   const [network, setNetwork] = React.useState<SubNetworkIds>(SubNetworkIds.HistoryNetwork)
-
+  const [proxy, setProxy] = React.useState('127.0.0.1')
   const { onCopy } = useClipboard(enr) // eslint-disable-line
 
   const init = async () => {
+    if (portal?.client.isStarted()) {
+      await portal.stop()
+    }
     const id = await PeerId.create({ keyType: 'secp256k1' })
     const enr = ENR.createFromPeerId(id)
     enr.setLocationMultiaddr(new Multiaddr('/ip4/127.0.0.1/udp/0'))
-    const portal = new PortalNetwork(
+    const node = new PortalNetwork(
       {
         enr: enr,
         peerId: id,
         multiaddr: new Multiaddr('/ip4/127.0.0.1/udp/0'),
         transport: 'wss',
-        proxyAddress: 'ws://127.0.0.1:5050',
+        proxyAddress: `ws://${proxy}:5050`,
       },
       1
     )
@@ -49,19 +54,19 @@ export const App = () => {
     ;(window as any).Multiaddr = Multiaddr
     // eslint-disable-next-line no-undef
     ;(window as any).ENR = ENR
-    setDiscv5(portal)
-    portal.client.on('multiaddrUpdated', () =>
-      setENR(portal.client.enr.encodeTxt(portal.client.keypair.privateKey))
+    setPortal(node)
+    node.client.on('multiaddrUpdated', () =>
+      setENR(node.client.enr.encodeTxt(node.client.keypair.privateKey))
     )
-    await portal.start()
+    await node.start()
 
-    portal.enableLog('portalnetwork*, <uTP>*')
+    node.enableLog('portalnetwork*, <uTP>*,discv5*')
   }
 
-  React.useEffect(() => {
-    init()
-  }, [])
-
+  const stopNode = async () => {
+    await portal?.stop()
+    setPortal(undefined)
+  }
   const copy = async () => {
     await setENR(portal?.client.enr.encodeTxt(portal.client.keypair.privateKey) ?? '')
     onCopy()
@@ -96,6 +101,19 @@ export const App = () => {
             <Heading paddingBottom={2} size="lg">
               Local Node Management
             </Heading>
+            <Stack direction="row">
+              <Input
+                onChange={(evt) => {
+                  setProxy(evt.target.value)
+                }}
+                placeholder="Proxy IP Address"
+              />
+              {portal ? (
+                <Button onClick={stopNode}>Stop Node</Button>
+              ) : (
+                <Button onClick={init}>Start Node</Button>
+              )}
+            </Stack>
             <RadioGroup onChange={updateNetwork} value={network} spacing={1}>
               <Stack direction="row">
                 <Radio value={SubNetworkIds.StateNetwork}>State Network</Radio>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,17 +12,17 @@
     "@types/yargs": "^17.0.7",
     "ts-node": "^10.4.0",
     "tslib": "^2.3.1",
-    "typescript": "^4.4.2"
+    "typescript": "^4.4.2",
+    "prettier": "^2.5.1",
+    "eslint": "^8.6.0"
   },
   "dependencies": {
     "@chainsafe/discv5": "^0.6.6",
     "debug": "^4.3.3",
-    "eslint": "^8.6.0",
     "jayson": "^3.6.6",
     "multiaddr": "^10.0.0",
     "peer-id": "^0.15.2",
     "portalnetwork": "^0.0.1",
-    "prettier": "^2.5.1",
     "yargs": "^17.3.0"
   },
   "scripts": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,9 +24,9 @@ const args: any = yargs(hideBin(process.argv))
   })
   .option('nat', {
     describe: 'NAT Traversal options for proxy',
-    choices: ['none', 'extip'],
-    default: 'none',
-    string: true,
+    choices: ['localhost', 'lan', 'extip'],
+    default: 'localhost',
+    array: true,
   })
   .option('rpc', {
     describe: 'Enable the JSON-RPC server with HTTP endpoint',
@@ -113,7 +113,7 @@ const main = async () => {
   if (args.proxy === true) {
     // Spawn a child process that runs the proxy
     const file = require.resolve('../../proxy/dist/index.js')
-    child = spawn(process.execPath, [file, args.nat])
+    child = spawn(process.execPath, [file, '--nat', args.nat])
     child.stdout.on('data', async (data) => {
       // Prints all proxy logs to the console
       console.log(data.toString())

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -10,9 +10,11 @@ So, when a message received containing `[127,0,0,1,122,73,28,96...` is received 
  The first 4 bytes are parsed to an ip address of: 127.0.0.1 and the port (represented by `[122, 73]`) is parsed to 31305.  The proxy then sends the remainder of the message (i.e. all bytes starting with the 7th element of the message) to the address 127.0.0.1:31305.
 ## Usage
 
-To run a proxy on a local network, run `npm run start`.
+To run a proxy on a local network, run `npm run run-proxy`.  
 
-To make your proxy public facing, run `npm run start extip` and the proxy will get its public IP address from a STUN server and route all traffic via the external IP address.
+By default, it only listens on `localhost`/`127.0.0.1`.  To have your proxy listen on a LAN IP address, pass the `--nat lan` parameter and the `--ip [your ip here]`
+
+To make your proxy public facing, run `npm run run-proxy --nat extip` and the proxy will get its public IP address from a STUN server and route all traffic via the external IP address.
 
 
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@leichtgewicht/ip-codec": "^2.0.3",
     "stun": "^2.1.0",
-    "ws": "^8.2.2"
+    "ws": "^8.2.2",
+    "yargs": "^17.3.0",
+    "debug": "^4.3.3"
   },
   "scripts": {
     "run-proxy": "ts-node src/index.ts",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,18 +1,27 @@
 import WS from 'ws'
 import * as dgram from 'dgram'
 import ipCodec from '@leichtgewicht/ip-codec'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
 const stun = require('stun')
 
 // TODO - replace console logs with debug logger
 
 const MAX_PACKET_SIZE = 1280
 
-const ws = new WS.Server({ host: '127.0.0.1', port: 5050, clientTracking: true })
+const servers: WS.Server[] = []
 
-const main = async () => {
-  const args = process.argv.slice(2)
-  let remoteAddr = '127.0.0.1'
-  if (args[0] === 'extip') {
+const args: any = yargs(hideBin(process.argv)).option('nat', {
+  describe: 'NAT Traversal options for proxy',
+  choices: ['extip', 'localhost', 'lan'],
+  default: 'localhost',
+  array: true,
+  string: true,
+}).argv
+
+const startServer = async (ws: WS.Server, extip = false) => {
+  let remoteAddr = ws.options.host
+  if (extip) {
     try {
       const res = await stun.request('stun.l.google.com:19302')
       remoteAddr = res.getXorAddress().address
@@ -46,7 +55,7 @@ const main = async () => {
       }
     }
     // Send external IP address/port to websocket client to update ENR
-    const bAddress = ipCodec.encode(remoteAddr)
+    const bAddress = ipCodec.encode(remoteAddr!)
     const bPort = Buffer.alloc(2)
     bPort.writeUIntBE(udpsocket.address().port, 0, 2)
     websocket.send(Buffer.concat([bAddress, bPort]))
@@ -71,12 +80,30 @@ const main = async () => {
 
 function stop(): void {
   console.log('proxy server shutting down...')
-  ws.removeAllListeners()
-  ws.close()
+  servers.forEach((server) => {
+    server.removeAllListeners()
+    server.close()
+  })
   process.exit(0)
 }
 
 process.on('SIGTERM', () => stop())
 process.on('SIGINT', () => stop())
 
-main()
+args.nat.forEach((arg: string) => {
+  switch (arg) {
+    case 'localhost':
+      {
+        const ws = new WS.Server({ host: '127.0.0.1', port: 5050, clientTracking: true })
+        startServer(ws, args.nat.includes('extip'))
+        servers.push(ws)
+      }
+      break
+    case 'lan':
+      {
+        const ws = new WS.Server({ host: '192.168.0.194', port: 5050, clientTracking: true })
+        startServer(ws, args.nat.includes('extip'))
+      }
+      break
+  }
+})

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -11,13 +11,19 @@ const MAX_PACKET_SIZE = 1280
 
 const servers: WS.Server[] = []
 
-const args: any = yargs(hideBin(process.argv)).option('nat', {
-  describe: 'NAT Traversal options for proxy',
-  choices: ['extip', 'localhost', 'lan'],
-  default: 'localhost',
-  array: true,
-  string: true,
-}).argv
+const args: any = yargs(hideBin(process.argv))
+  .option('nat', {
+    describe: 'NAT Traversal options for proxy',
+    choices: ['extip', 'localhost', 'lan'],
+    default: 'localhost',
+    array: true,
+    string: true,
+  })
+  .option('ip', {
+    describe: 'IP address on local network',
+    string: true,
+    optional: true,
+  }).argv
 
 const startServer = async (ws: WS.Server, extip = false) => {
   let remoteAddr = ws.options.host
@@ -101,7 +107,12 @@ args.nat.forEach((arg: string) => {
       break
     case 'lan':
       {
-        const ws = new WS.Server({ host: '192.168.0.194', port: 5050, clientTracking: true })
+        if (!args.ip) {
+          console.error('Must provide IP address for LAN option')
+          console.log('Exiting...')
+          process.exit(1)
+        }
+        const ws = new WS.Server({ host: args.ip, port: 5050, clientTracking: true })
         startServer(ws, args.nat.includes('extip'))
       }
       break


### PR DESCRIPTION
## Proxy updates
- Adds new options for proxy to allow websocket server to run on localhost or LAN IP 
- Add option to specify ENR with public IP (taken from STUN server)

## Browser Client updates
- Adds new options to "Local Node Management" to set proxy address (defaults to `localhost`)
- Adds new start/stop node functionality

## Client updates
- Updates args parsing to correctly start proxy with localhost setting