### PR TITLE
Use history routing tables instead of discv5

### DIFF
--- a/packages/browser-client/src/Components/AddressBookManager.tsx
+++ b/packages/browser-client/src/Components/AddressBookManager.tsx
@@ -19,21 +19,13 @@ const AddressBookManager: React.FC<NodeManagerProps> = ({ portal, network }) => 
   const [distance, setDistance] = React.useState<string>('0')
   const toast = useToast()
 
-  React.useEffect(() => {
-    portal.client.on('enrAdded', () => {
-      const peerENRs = portal.client.kadValues()
-      const newPeers = peerENRs.map((peer) => peer.nodeId)
-      setPeers(newPeers)
-    })
-  }, [])
-
   const log = debug('discv5:service')
 
   const handleClick = () => {
     if (enr) {
-      portal.client.addEnr(enr)
+      portal.sendPing(enr, network)
       setEnr('')
-      const peerENRs = portal.client.kadValues()
+      const peerENRs = portal.historyNetworkRoutingTable.values()
       const newPeers = peerENRs.map((peer) => peer.nodeId)
       setPeers(newPeers)
     }

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -360,9 +360,14 @@ export class Discv5 extends (EventEmitter as { new(): Discv5EventEmitter }) {
   /**
    * Send TALKREQ message to dstId and returns response
    */
-  public async sendTalkReq(dstId: string, payload: Buffer, protocol: string | Uint8Array): Promise<Buffer> {
+  public async sendTalkReq(
+    dstId: string,
+    payload: Buffer,
+    protocol: string | Uint8Array,
+    remoteEnr?: ENR
+  ): Promise<Buffer> {
     return await new Promise((resolve, reject) => {
-      const enr = this.findEnr(dstId);
+      const enr = remoteEnr ?? this.findEnr(dstId);
       if (!enr) {
         log("Talkreq requested an unknown ENR, node: %s", dstId);
         return;
@@ -385,9 +390,9 @@ export class Discv5 extends (EventEmitter as { new(): Discv5EventEmitter }) {
   /**
    * Send TALKRESP message to requesting node
    */
-  public async sendTalkResp(srcId: NodeId, requestId: RequestId, payload: Uint8Array): Promise<void> {
+  public async sendTalkResp(srcId: NodeId, requestId: RequestId, payload: Uint8Array, remoteEnr?: ENR): Promise<void> {
     const msg = createTalkResponseMessage(requestId, payload);
-    const enr = this.findEnr(srcId);
+    const enr = remoteEnr ?? this.findEnr(srcId);
     const addr = enr?.getLocationMultiaddr("udp");
     if (enr && addr) {
       log(`Sending TALKRESP message to node ${enr.id}`);

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -804,7 +804,6 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     networkId: SubNetworkIds
   ): Promise<Buffer> => {
     const enr = this.historyNetworkRoutingTable.getValue(dstId)
-    console.log('found enr to send to', enr)
     try {
       const res = await this.client.sendTalkReq(dstId, payload, fromHexString(networkId), enr)
       return res

--- a/packages/portalnetwork/src/wire/utp/Socket/_UTPSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/_UTPSocket.ts
@@ -83,7 +83,11 @@ export class _UTPSocket extends EventEmitter {
 
   async sendPacket(packet: Packet, type: PacketType): Promise<Buffer> {
     const msg = packet.encodePacket()
-    await this.client.sendTalkReq(this.remoteAddress, msg, fromHexString(SubNetworkIds.UTPNetwork))
+    await this.utp.portal.sendPortalNetworkMessage(
+      this.remoteAddress,
+      msg,
+      SubNetworkIds.UTPNetwork
+    )
     log(`${PacketType[type]} packet sent to ${this.remoteAddress}.`)
     type === 1 && log('uTP stream closed.')
     return msg

--- a/packages/portalnetwork/src/wire/utp/Socket/_UTPSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/_UTPSocket.ts
@@ -17,7 +17,6 @@ import { ConnectionState } from '.'
 
 import EventEmitter from 'events'
 import { Discv5 } from '@chainsafe/discv5'
-import { fromHexString } from '@chainsafe/ssz'
 import { SubNetworkIds } from '../..'
 import { debug } from 'debug'
 import Writer from '../Protocol/write/Writer'


### PR DESCRIPTION
Makes small modifications to `discv5` to allow ENRs to be passed to the `sendTalkReq` and `sendTalkResp` messages.  Allows us to use the `historyNetworkRoutingTable` as the basis for our node lookups and routing table updates (rather than piggybacking on discv5).