### PR TITLE
Adds new lookup method for the Portal Network

### DIFF
--- a/packages/browser-client/src/Components/AddressBookManager.tsx
+++ b/packages/browser-client/src/Components/AddressBookManager.tsx
@@ -1,7 +1,7 @@
 import { Button, Heading, HStack, Input, Text, VStack, Wrap, useToast } from '@chakra-ui/react'
-import { PortalNetwork } from 'portalnetwork'
+import { PortalNetwork, SubNetworkIds } from 'portalnetwork'
+import { generateRandomNodeIdAtDistance } from 'portalnetwork/dist/util'
 import { HistoryNetworkContentKeyUnionType } from 'portalnetwork/dist/historySubnetwork/types'
-import { SubNetworkIds } from 'portalnetwork/dist/wire'
 import { randUint16 } from 'portalnetwork/dist/wire/utp'
 import React from 'react'
 import { toHexString } from './ShowInfo'
@@ -41,6 +41,10 @@ const AddressBookManager: React.FC<NodeManagerProps> = ({ portal, network }) => 
     updateAddressBook()
   }
 
+  const handleFindRandom = () => {
+    const lookupNode = generateRandomNodeIdAtDistance(portal.client.enr.nodeId, 240)
+    portal.lookup(lookupNode)
+  }
   const handlePing = (nodeId: string) => {
     portal.sendPing(nodeId, network)
   }
@@ -102,6 +106,7 @@ const AddressBookManager: React.FC<NodeManagerProps> = ({ portal, network }) => 
       <Input value={enr} placeholder={'Node ENR'} onChange={(evt) => setEnr(evt.target.value)} />
       <HStack>
         <Button onClick={handleClick}>Add Node</Button>
+        <Button onClick={handleFindRandom}>Lookup Node</Button>
       </HStack>
 
       {peers.length > 0 && (

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -221,7 +221,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       value: findNodesMsg,
     })
     try {
-      log(`Sending FINDNODES to ${shortId(dstId)} for ${SubNetworkIds.StateNetwork} subnetwork`)
+      log(`Sending FINDNODES to ${shortId(dstId)} for ${networkId} subnetwork`)
       const res = await this.sendPortalNetworkMessage(dstId, Buffer.from(payload), networkId)
       if (parseInt(res.slice(0, 1).toString('hex')) === MessageCodes.NODES) {
         log(`Received NODES from ${shortId(dstId)}`)

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -41,7 +41,6 @@ import {
 } from '../historySubnetwork/types'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { getContentId, getContentIdFromSerializedKey } from '../historySubnetwork'
-import { nodeId } from '@chainsafe/discv5/src/enr/v4'
 const level = require('level-mem')
 
 const log = debug('portalnetwork')

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -819,12 +819,14 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       .map((bucket, idx) => {
         return { bucket: bucket, distance: idx }
       })
-      .filter((pair) => pair.bucket.size() < 16)
-    const randomNotFullBucket = Math.trunc(Math.random() * 10)
-    log(`Refreshing bucket at distance ${randomNotFullBucket}`)
-    const distance = notFullBuckets[randomNotFullBucket].distance
-    const randomNodeAtDistance = generateRandomNodeIdAtDistance(this.client.enr.nodeId, distance)
-    this.lookup(randomNodeAtDistance)
+      .filter((pair) => pair.distance > 239 && pair.bucket.size() < 16)
+    if (notFullBuckets.length > 0) {
+      const randomDistance = Math.trunc(Math.random() * 10)
+      const distance = notFullBuckets[randomDistance].distance ?? notFullBuckets[0].distance
+      log(`Refreshing bucket at distance ${distance}`)
+      const randomNodeAtDistance = generateRandomNodeIdAtDistance(this.client.enr.nodeId, distance)
+      this.lookup(randomNodeAtDistance)
+    }
   }
 
   /**

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -828,12 +828,18 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     this.lookup(randomNodeAtDistance)
   }
 
+  /**
+   * Queries the 5 nearest nodes in the history network routing table for nodes in the kbucket and recursively
+   * requests peers closer to the `nodeSought` until either the node is found or there are no more peers to query
+   * @param nodeSought nodeId of node sought in lookup
+   */
   private lookup = async (nodeSought: NodeId) => {
     const closestPeers = this.historyNetworkRoutingTable.nearest(nodeSought, 5)
     const newPeers: ENR[] = []
     let finished = false
     while (!finished && closestPeers.length > 0) {
       const nearestPeer = closestPeers.shift()
+      // Calculates log2distance between queried peer and `nodeSought`
       const distanceToSoughtPeer = log2Distance(nearestPeer!.nodeId, nodeSought)
       // Request nodes in the given kbucket (i.e. log2distance) on the receiving peer's routing table for the `nodeSought`
       const res = await this.sendFindNodes(

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -857,6 +857,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
             ) {
               // if peer received is closer than peer that sent ENR, add to front of `closestPeers` list
               closestPeers.unshift(decodedEnr)
+              // Add newly found peers to list for storing in routing table
               newPeers.push(decodedEnr)
             }
           }


### PR DESCRIPTION
This is a first draft of a lookup method that sequentially seeks nodes closer to some specified `nodeSought`.  This doesn't recreate the full functionality of the [discv5 lookup](https://github.com/ethereumjs/ultralight/blob/master/packages/discv5/src/kademlia/lookup.ts) but it is likely good enough for now.  Needs some thorough testing to see if it works.
Todo list:
- [x] Add handler in browser-client to trigger node lookup
- [ ] test thoroughly