### PR TITLE
ci: add concurrency

### DIFF
--- a/.github/workflows/portalnetwork-build.yml
+++ b/.github/workflows/portalnetwork-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/portalnetwork
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-portalnetwork:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I just added this to the monorepo (https://github.com/ethereumjs/ethereumjs-monorepo/pull/1667) and thought it would be nice to add to the workflow file here.

Not so important today since you only have one pretty speedy workflow file, but when additional ones are added if these lines are included you'll get the benefits of cancelling old runs on new commits to PRs.