### PR TITLE
Fix socket key handling

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -613,9 +613,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
 
   private sendAccept = async (srcId: string, message: ITalkReqMessage) => {
     const id = randUint16()
-    const connectionId = await this.uTP.awaitConnectionRequest(srcId, id).then((_res) => {
-      return this.uTP.sockets[srcId].sndConnectionId
-    })
+    const connectionId = await this.uTP.awaitConnectionRequest(srcId, id)
     const payload: AcceptMessage = {
       connectionId: new Uint8Array(2).fill(connectionId),
       contentKeys: [true],

--- a/packages/portalnetwork/src/wire/utp/Protocol/utp_protocol.ts
+++ b/packages/portalnetwork/src/wire/utp/Protocol/utp_protocol.ts
@@ -39,11 +39,10 @@ export class UtpProtocol {
         await this.handleResetPacket
         break
       case PacketType.ST_FIN:
-        if (this.sockets[srcId].writing) {
+        if (this.sockets[srcId + packet.header.connectionId]?.writing) {
           log(`received unexpected FIN packet while sending data to ${srcId}`)
           break
-        }
-        {
+        } else {
           const content = await this.handleFinPacket(packet, srcId, msgId)
           log(`content received over uTP ${toHexString(content)}`)
         }
@@ -57,6 +56,7 @@ export class UtpProtocol {
     log(`Opening uTP socket to send DATA to ${remoteAddr}`)
     // Creates a new uTP socket for remoteAddr
     const socket = new _UTPSocket(this, remoteAddr, 'writing')
+    // Retrieve content corresponding to first contentKey
     const value = await this.portal.db.get(getContentIdFromSerializedKey(contentKeys[0]))
     // Loads database content to socket
     socket.content = fromHexString(value)
@@ -66,16 +66,17 @@ export class UtpProtocol {
     // Sends Syn Packet to begin uTP connection process using connectionId
     await this.sockets[remoteAddr + connectionId].sendSynPacket(connectionId)
   }
+
   async initiateUtpTest(remoteAddr: string, connectionId: number) {
     // Client received connectionId in an ACCEPT talkresp from a node at:  remoteAddr
     log(`Requesting uTP stream connection with ${remoteAddr}...`)
     log(`Opening uTP socket to send DATA to ${remoteAddr}`)
     // Creates a new uTP socket for remoteAddr
     const socket = new _UTPSocket(this, remoteAddr, 'writing')
-    const value = new Uint8Array(2000)
+    /*const value = new Uint8Array(2000)
     value.fill(1)
     // Loads database content to socket
-    socket.content = value
+    socket.content = value*/
     // Adds this socket to 'sockets' registry, wtih remoteAddr as key
     this.sockets[remoteAddr + connectionId] = socket
 
@@ -93,6 +94,7 @@ export class UtpProtocol {
     // Sends Syn Packet to begin uTP connection process using connectionId
     return this.sockets[remoteAddr + connectionId].sndConnectionId
   }
+
   async initiateConnectionRequest(remoteAddr: string, connectionId: number): Promise<void> {
     // Client received connectionId in a talkreq or talkresp from a node at:  remoteAddr
     log(`Requesting uTP stream connection with ${remoteAddr}...`)
@@ -105,40 +107,44 @@ export class UtpProtocol {
   }
 
   async handleSynPacket(packet: Packet, remoteAddr: string, _msgId: bigint): Promise<void> {
-    if (this.sockets[remoteAddr + packet.header.connectionId]) {
+    const socketKey = this.getSocketKey(remoteAddr, packet.header.connectionId)
+    if (this.sockets[socketKey]) {
       log(`Accepting uTP stream request...  Sending SYN ACK...  Listening for data...`)
-      await this.sockets[remoteAddr + packet.header.connectionId].handleIncomingStreamRequest(
-        packet
-      )
+      await this.sockets[socketKey].handleIncomingStreamRequest(packet)
     } else {
       log(`Received incoming ST_SYN packet...uTP connection requested by ${remoteAddr}`)
       // Creates a new socket for remoteAddr
       const socket = new _UTPSocket(this, remoteAddr, 'writing')
       // Adds this socket to 'sockets' registry wtih remoteAddr as key
-      this.sockets[remoteAddr + packet.header.connectionId] = socket
+      this.sockets[socketKey] = socket
       // Passes content from "Database" to the socket
-      this.sockets[remoteAddr + packet.header.connectionId].content =
-        this.contents[remoteAddr + packet.header.connectionId]
+      this.sockets[socketKey].content = this.contents[socketKey]
       // Socket processes the SYN packet
       // Accepts connection by sending a SYN ACK - which is a STATE packet
       log(
         `Accepting uTP stream request...  Sending SYN ACK...  Preparing to send ${this.contents}...`
       )
-      await this.sockets[remoteAddr + packet.header.connectionId].handleIncomingConnectionRequest(
-        packet
-      )
+      await this.sockets[socketKey].handleIncomingConnectionRequest(packet)
     }
   }
 
   async handleStatePacket(packet: Packet, remoteAddr: string, _msgId: bigint): Promise<void> {
+    const socketKey = this.getSocketKey(remoteAddr, packet.header.connectionId)
     // STATE packets, also known as ACK packets, are sent as response to SYN or DATA packets
     // And in some cases to STATE or FIN packets.
     log('Received ST_STATE packet from ' + remoteAddr)
     log('seqnr: ' + packet.header.seqNr + 'acknr:' + packet.header.ackNr)
     // Socket will decode and process packet
-    this.sockets[remoteAddr + packet.header.connectionId].handleStatePacket(packet)
+    try {
+      this.sockets[socketKey].handleStatePacket(packet)
+    } catch (err: any) {
+      log(`Error parsing ST_STATE packet.  ${err.message}`)
+    }
   }
+
   async handleFinPacket(packet: Packet, remoteAddr: string, _msgId: bigint): Promise<Uint8Array> {
+    const socketKey = this.getSocketKey(remoteAddr, packet.header.connectionId)
+
     // FIN packet is sent when sending node has sent all DATA packets.
     log(
       'Received ST_FIN packet from ' +
@@ -146,30 +152,24 @@ export class UtpProtocol {
         '.  Socket will close when all packets have been processed.'
     )
     // Socket should remain open untill all DATA packets have been received.
-    await this.sockets[remoteAddr + packet.header.connectionId].handleFinPacket(packet)
+    await this.sockets[socketKey].handleFinPacket(packet)
     // Socket will compile Packets, and reassemble the full payload.
-    this.contents[remoteAddr + packet.header.connectionId] =
-      this.sockets[remoteAddr + packet.header.connectionId].content
+    this.contents[socketKey] = this.sockets[socketKey].content
     // TODO -- Test reader with out of order packets/ lost packets
     log(
-      `${this.contents[remoteAddr + packet.header.connectionId].length} 
-      bytes received. ${this.contents[remoteAddr + packet.header.connectionId]
-        .toString()
-        .slice(0, 20)} ...`
+      `${this.contents[socketKey].length} 
+      bytes received. ${this.contents[socketKey].toString().slice(0, 20)} ...`
     )
-    log(
-      `${this.sockets[remoteAddr + packet.header.connectionId].readerContent
-        .toString()
-        .slice(0, 20)}`
-    )
+    log(`${this.sockets[socketKey].readerContent.toString().slice(0, 20)}`)
     // Closes socket (deletes from registry)
-    const compiledData = this.contents[remoteAddr + packet.header.connectionId]
-    delete this.sockets[remoteAddr + packet.header.connectionId]
-    delete this.contents[remoteAddr + packet.header.connectionId]
+    const compiledData = this.contents[socketKey]
+    delete this.sockets[socketKey]
+    delete this.contents[socketKey]
     return compiledData
   }
 
   async handleDataPacket(packet: Packet, remoteAddr: string, _msgId: bigint): Promise<void> {
+    const socketKey = this.getSocketKey(remoteAddr, packet.header.connectionId)
     // Socket will read seqNr from Packet Header.
     // If packet arrived in expected order, will respond with ACK (STATE Packet)
     // If packet arrived out of order, will respond with SELECTIVE ACK (STATE Packet)
@@ -181,13 +181,23 @@ export class UtpProtocol {
         packet.payload.length
       } Bytes: ${packet.payload.slice(0, 10)}... `
     )
-    await this.sockets[remoteAddr + (packet.header.connectionId - 1)].handleDataPacket(packet)
+    await this.sockets[socketKey].handleDataPacket(packet)
   }
 
   async handleResetPacket(packet: Packet, remoteAddr: string, _msgId: bigint) {
     // Closes socket (deletes from registry)
-    delete this.sockets[remoteAddr + packet.header.connectionId]
-    delete this.contents[remoteAddr + packet.header.connectionId]
+    const socketKey = this.getSocketKey(remoteAddr, packet.header.connectionId)
+    delete this.sockets[socketKey]
+    delete this.contents[socketKey]
     log('Got Reset Packet...Deleting socket from registry.')
+  }
+
+  getSocketKey = (remoteAddr: string, connectionId: number) => {
+    if (this.sockets[remoteAddr + connectionId]) {
+      return remoteAddr + connectionId
+    } else if (this.sockets[remoteAddr + (connectionId - 1)]) {
+      return remoteAddr + (connectionId - 1)
+    }
+    return ''
   }
 }


### PR DESCRIPTION
- Adds new `getSocketKey` helper in `utp_protocol` to abstract socketKey identification
- Implement logic that new socket keys are always either `connectionId` (for the node initiating a connection) or else `connectionId -1)` for the node sending data
- Miscellaneous clean-up