### PR TITLE
Add basic prometheus metrics reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7533,6 +7533,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "node_modules/blakejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
@@ -22990,6 +22995,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/promise": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
@@ -27156,6 +27172,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dependencies": {
+        "bintrees": "1.0.1"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -31231,6 +31255,7 @@
         "multiaddr": "^10.0.0",
         "peer-id": "^0.15.2",
         "portalnetwork": "^0.0.1",
+        "prom-client": "^14.0.1",
         "rlp": "^3.0.0",
         "yargs": "^17.3.0"
       },
@@ -39462,6 +39487,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "blakejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
@@ -40428,6 +40458,7 @@
         "peer-id": "^0.15.2",
         "portalnetwork": "^0.0.1",
         "prettier": "^2.5.1",
+        "prom-client": "*",
         "rlp": "^3.0.0",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
@@ -52613,6 +52644,14 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
+    "prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
@@ -56103,6 +56142,14 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "temp-dir": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "multiaddr": "^10.0.0",
     "peer-id": "^0.15.2",
     "portalnetwork": "^0.0.1",
+    "prom-client": "^14.0.1",
     "rlp": "^3.0.0",
     "yargs": "^17.3.0"
   },


### PR DESCRIPTION
Adds the most basic of prometheus metrics reporting from a running client (just number of peers connected for both discv5 and history network routing table)