### PR TITLE
Insert 5 digits of NodeId as prefix for debug logs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,7 +104,7 @@ const run = async () => {
     undefined,
     metrics
   )
-  portal.enableLog('*discv5*, *ultralight*, *portalnetwork*, proxy*')
+  portal.enableLog('*ultralight*, *portalnetwork*, proxy*')
   const metricsServer = http.createServer(reportMetrics)
 
   if (args.metrics) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,6 @@ import http from 'http'
 import * as PromClient from 'prom-client'
 import debug from 'debug'
 import { RPCManager } from './rpc'
-const log = debug('ultralight')
 
 const args: any = yargs(hideBin(process.argv))
   .option('bootnode', {
@@ -89,6 +88,8 @@ const setupMetrics = () => {
 const run = async () => {
   const id = await PeerId.create({ keyType: 'secp256k1' })
   const enr = ENR.createFromPeerId(id)
+  const log = debug(enr.nodeId.slice(0, 5)).extend('ultralight')
+
   enr.setLocationMultiaddr(new Multiaddr('/ip4/127.0.0.1/udp/0'))
   const metrics = setupMetrics()
   const portal = new PortalNetwork(
@@ -103,7 +104,7 @@ const run = async () => {
     undefined,
     metrics
   )
-  portal.enableLog('discv5*, ultralight*, portalnetwork*, proxy*')
+  portal.enableLog('*discv5*, *ultralight*, *portalnetwork*, proxy*')
   const metricsServer = http.createServer(reportMetrics)
 
   if (args.metrics) {

--- a/packages/portalnetwork/src/wire/utp/Protocol/utp_protocol.ts
+++ b/packages/portalnetwork/src/wire/utp/Protocol/utp_protocol.ts
@@ -18,7 +18,7 @@ export class UtpProtocol {
     this.client = portal.client
     this.sockets = {}
     this.contents = {}
-    this.log = debug('<uTP>')
+    this.log = debug(this.client.enr.nodeId.slice(0, 5)).extend('<uTP>')
   }
   /**
    * Reads PacketType from Header and sends to hanlder


### PR DESCRIPTION
For the purpose of distinguishing the different logs of many nodes running in one console.  Each unique log name will be colored uniquely, and the nodeId prefix will allow for easier reading of the debug printout.