### PR TITLE
Fix content lookups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24798,14 +24798,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "node_modules/rlp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-3.0.0.tgz",
-      "integrity": "sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw==",
-      "bin": {
-        "rlp": "bin/rlp"
-      }
-    },
     "node_modules/rollup": {
       "version": "1.32.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
@@ -30918,7 +30910,7 @@
         "react-dom": "^17.0.2",
         "react-icons": "^3.0.0",
         "react-scripts": "4.0.3",
-        "rlp": "^3.0.0",
+        "rlp": "2.2.4",
         "typescript": "^4.4.2",
         "web-vitals": "^0.2.2"
       },
@@ -31025,6 +31017,11 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "packages/browser-client/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "packages/browser-client/node_modules/chalk": {
       "version": "4.1.2",
@@ -31220,6 +31217,17 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "packages/browser-client/node_modules/rlp": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+      "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+      "dependencies": {
+        "bn.js": "^4.11.1"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
+      }
+    },
     "packages/browser-client/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -31256,7 +31264,7 @@
         "peer-id": "^0.15.2",
         "portalnetwork": "^0.0.1",
         "prom-client": "^14.0.1",
-        "rlp": "^3.0.0",
+        "rlp": "2.2.4",
         "yargs": "^17.3.0"
       },
       "devDependencies": {
@@ -31355,6 +31363,11 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "packages/cli/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "packages/cli/node_modules/chalk": {
       "version": "4.1.2",
@@ -31549,6 +31562,17 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "packages/cli/node_modules/rlp": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+      "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+      "dependencies": {
+        "bn.js": "^4.11.1"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
+      }
     },
     "packages/cli/node_modules/supports-color": {
       "version": "7.2.0",
@@ -32211,7 +32235,7 @@
         "multiaddr": "^10.0.1",
         "peer-id": "^0.16.0",
         "prom-client": "^14.0.1",
-        "rlp": "^3.0.0",
+        "rlp": "2.2.4",
         "strict-event-emitter-types": "^2.0.0"
       },
       "devDependencies": {
@@ -32323,6 +32347,11 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "packages/portalnetwork/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "packages/portalnetwork/node_modules/caching-transform": {
       "version": "4.0.0",
@@ -32895,6 +32924,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/portalnetwork/node_modules/rlp": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+      "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+      "dependencies": {
+        "bn.js": "^4.11.1"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
       }
     },
     "packages/portalnetwork/node_modules/source-map": {
@@ -39638,7 +39678,7 @@
         "react-dom": "^17.0.2",
         "react-icons": "^3.0.0",
         "react-scripts": "4.0.3",
-        "rlp": "^3.0.0",
+        "rlp": "2.2.4",
         "ts-node": "^10.3.1",
         "typescript": "^4.4.2",
         "web-vitals": "^0.2.2"
@@ -39704,6 +39744,11 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -39852,6 +39897,14 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
+        },
+        "rlp": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -40460,7 +40513,7 @@
         "portalnetwork": "^0.0.1",
         "prettier": "^2.5.1",
         "prom-client": "^14.0.1",
-        "rlp": "^3.0.0",
+        "rlp": "2.2.4",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
         "typescript": "^4.4.2",
@@ -40527,6 +40580,11 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -40675,6 +40733,14 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
+        },
+        "rlp": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -50887,8 +50953,8 @@
         "nyc": "^15.1.0",
         "peer-id": "^0.16.0",
         "prettier": "^2.5.1",
-        "prom-client": "*",
-        "rlp": "^3.0.0",
+        "prom-client": "^14.0.1",
+        "rlp": "2.2.4",
         "strict-event-emitter-types": "^2.0.0",
         "tape": "^5.3.1",
         "testdouble": "^3.16.3",
@@ -50968,6 +51034,11 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "caching-transform": {
           "version": "4.0.0",
@@ -51401,6 +51472,14 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
+        },
+        "rlp": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -54186,11 +54265,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
-    },
-    "rlp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-3.0.0.tgz",
-      "integrity": "sha512-PD6U2PGk6Vq2spfgiWZdomLvRGDreBLxi5jv5M8EpRo3pU6VEm31KO+HFxE18Q3vgqfDrQ9pZA3FP95rkijNKw=="
     },
     "rollup": {
       "version": "1.32.1",

--- a/packages/browser-client/package.json
+++ b/packages/browser-client/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^17.0.2",
     "react-icons": "^3.0.0",
     "react-scripts": "4.0.3",
-    "rlp": "^3.0.0",
+    "rlp": "2.2.4",
     "web-vitals": "^0.2.2",
     "typescript": "^4.4.2"
   },

--- a/packages/browser-client/src/Components/SelectTx.tsx
+++ b/packages/browser-client/src/Components/SelectTx.tsx
@@ -1,4 +1,3 @@
-import { toHex } from '@chainsafe/discv5'
 import {
   Menu,
   MenuButton,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "peer-id": "^0.15.2",
     "portalnetwork": "^0.0.1",
     "prom-client": "^14.0.1",
-    "rlp": "^3.0.0",
+    "rlp": "2.2.4",
     "yargs": "^17.3.0"
   },
   "scripts": {

--- a/packages/cli/prettier.config.js
+++ b/packages/cli/prettier.config.js
@@ -1,1 +1,1 @@
-module.exports = require('./config/prettier.config')
+module.exports = require('../../config/prettier.config')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,12 +63,12 @@ const setupMetrics = () => {
     knownDiscv5Nodes: new PromClient.Gauge({
       name: 'ultralight_known_discv5_peers',
       help: 'how many peers are in discv5 routing table',
-      async collect() { },
+      async collect() {},
     }),
     knownHistoryNodes: new PromClient.Gauge({
       name: 'ultralight_known_history_peers',
       help: 'how many peers are in discv5 routing table',
-      async collect() { },
+      async collect() {},
     }),
     totalContentLookups: new PromClient.Gauge<string>({
       name: 'ultralight_total_content_lookups',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,12 +63,12 @@ const setupMetrics = () => {
     knownDiscv5Nodes: new PromClient.Gauge({
       name: 'ultralight_known_discv5_peers',
       help: 'how many peers are in discv5 routing table',
-      async collect() {},
+      async collect() { },
     }),
     knownHistoryNodes: new PromClient.Gauge({
       name: 'ultralight_known_history_peers',
       help: 'how many peers are in discv5 routing table',
-      async collect() {},
+      async collect() { },
     }),
     totalContentLookups: new PromClient.Gauge<string>({
       name: 'ultralight_total_content_lookups',
@@ -100,7 +100,7 @@ const run = async () => {
       transport: 'wss',
       proxyAddress: 'ws://127.0.0.1:5050',
     },
-    1,
+    2n ** 256n,
     undefined,
     metrics
   )

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -1,7 +1,7 @@
 import { ENR, fromHex } from '@chainsafe/discv5'
 import debug from 'debug'
 import { PortalNetwork, getContentId, SubNetworkIds, reassembleBlock } from 'portalnetwork'
-import rlp from 'rlp'
+import * as rlp from 'rlp'
 import { addRLPSerializedBlock } from 'portalnetwork/dist/util'
 const log = debug('ultralight:RPC')
 
@@ -38,23 +38,18 @@ export class RPCManager {
       // If block isn't in local DB, request block from network
       try {
         header = await this._client.contentLookup(0, blockHash)
-        console.log('header', header)
         if (!header) {
           return 'Block not found'
         }
         body = includeTransactions
           ? await this._client.contentLookup(1, blockHash)
           : rlp.encode([[], []])
-        console.log('body', body)
         // TODO: Figure out why block body isn't coming back as Uint8Array
         block = reassembleBlock(header as Uint8Array, body)
-        console.log(block)
         return block
-      } catch (err) {
-        console.log(err)
-      return 'Block not found'
+      } catch {
+        return 'Block not found'
       }
-
     },
     portal_addBootNode: async (params: [string]) => {
       const [enr] = params

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -38,14 +38,23 @@ export class RPCManager {
       // If block isn't in local DB, request block from network
       try {
         header = await this._client.contentLookup(0, blockHash)
+        console.log('header', header)
+        if (!header) {
+          return 'Block not found'
+        }
         body = includeTransactions
           ? await this._client.contentLookup(1, blockHash)
           : rlp.encode([[], []])
+        console.log('body', body)
         // TODO: Figure out why block body isn't coming back as Uint8Array
-        block = reassembleBlock(header as Uint8Array, Uint8Array.from(body as Uint8Array))
+        block = reassembleBlock(header as Uint8Array, body)
+        console.log(block)
         return block
-      } catch { }
+      } catch (err) {
+        console.log(err)
       return 'Block not found'
+      }
+
     },
     portal_addBootNode: async (params: [string]) => {
       const [enr] = params

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -29,7 +29,7 @@
     "multiaddr": "^10.0.1",
     "peer-id": "^0.16.0",
     "prom-client": "^14.0.1",
-    "rlp": "^3.0.0",
+    "rlp": "2.2.4",
     "strict-event-emitter-types": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -45,7 +45,6 @@ import {
   HistoryNetworkContentTypes,
 } from '../historySubnetwork/types'
 import { Block, BlockHeader } from '@ethereumjs/block'
-import rlp from 'rlp'
 import { getContentId, getContentIdFromSerializedKey } from '../historySubnetwork'
 import { Lookup } from '../wire'
 const level = require('level-mem')
@@ -417,7 +416,6 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     switch (contentType) {
       case HistoryNetworkContentTypes.BlockHeader: {
         try {
-          console.log('adding header', value)
           _deserializedValue = BlockHeader.fromRLPSerializedHeader(
             Buffer.from(fromHexString(toHexString(value)))
           )

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -45,6 +45,7 @@ import {
   HistoryNetworkContentTypes,
 } from '../historySubnetwork/types'
 import { Block, BlockHeader } from '@ethereumjs/block'
+import rlp from 'rlp'
 import { getContentId, getContentIdFromSerializedKey } from '../historySubnetwork'
 import { Lookup } from '../wire'
 const level = require('level-mem')
@@ -56,7 +57,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   stateNetworkRoutingTable: StateNetworkRoutingTable
   historyNetworkRoutingTable: PortalNetworkRoutingTable
   uTP: UtpProtocol
-  nodeRadius: number
+  nodeRadius: bigint
   db: LevelUp
   private refreshListener?: ReturnType<typeof setInterval>
   metrics: PortalNetworkMetrics | undefined
@@ -80,7 +81,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         transport: 'wss',
         proxyAddress: proxyAddress,
       },
-      1
+      2n ** 256n
     )
   }
 
@@ -93,7 +94,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
    */
   constructor(
     config: IDiscv5CreateOptions,
-    radius = 1,
+    radius = 2n ** 256n,
     db?: LevelUp,
     metrics?: PortalNetworkMetrics
   ) {
@@ -187,9 +188,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
    * @param value number representing the new radius
    * @throws if `value` is outside correct range
    */
-  public set radius(value: number) {
-    if (value > 256 || value < 0) {
-      throw new Error('radius must be between 0 and 256')
+  public set radius(value: bigint) {
+    if (value < 0n) {
+      throw new Error('radius must be greater than 0')
     }
     this.nodeRadius = value
   }
@@ -416,7 +417,10 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     switch (contentType) {
       case HistoryNetworkContentTypes.BlockHeader: {
         try {
-          _deserializedValue = BlockHeader.fromRLPSerializedHeader(Buffer.from(value))
+          console.log('adding header', value)
+          _deserializedValue = BlockHeader.fromRLPSerializedHeader(
+            Buffer.from(fromHexString(toHexString(value)))
+          )
         } catch (err: any) {
           this.logger(`Invalid value provided for block header: ${err.toString()}`)
           return

--- a/packages/portalnetwork/src/wire/lookup.ts
+++ b/packages/portalnetwork/src/wire/lookup.ts
@@ -47,7 +47,7 @@ export class Lookup {
     try {
       const res = await this.client.db.get(this.contentId)
       return res
-    } catch {}
+    } catch { }
     this.client.historyNetworkRoutingTable.nearest(this.contentId, 5).forEach((peer) => {
       const dist = distance(peer.nodeId, this.contentId)
       this.lookupPeers.push({ nodeId: peer.nodeId, distance: dist })
@@ -81,7 +81,10 @@ export class Lookup {
         }
         case 1: {
           // findContent returned data sought
-          this.log(`received content corresponding to ${shortId(this.blockHash)}`)
+          this.log(
+            `received content corresponding to ${Object.keys(HistoryNetworkContentTypes)[this.contentType]
+            }${shortId(this.blockHash)}`
+          )
           finished = true
           this.client.metrics?.successfulContentLookups.inc()
           return res.value

--- a/packages/portalnetwork/src/wire/lookup.ts
+++ b/packages/portalnetwork/src/wire/lookup.ts
@@ -47,7 +47,7 @@ export class Lookup {
     try {
       const res = await this.client.db.get(this.contentId)
       return res
-    } catch { }
+    } catch {}
     this.client.historyNetworkRoutingTable.nearest(this.contentId, 5).forEach((peer) => {
       const dist = distance(peer.nodeId, this.contentId)
       this.lookupPeers.push({ nodeId: peer.nodeId, distance: dist })
@@ -82,7 +82,8 @@ export class Lookup {
         case 1: {
           // findContent returned data sought
           this.log(
-            `received content corresponding to ${Object.keys(HistoryNetworkContentTypes)[this.contentType]
+            `received content corresponding to ${
+              Object.keys(HistoryNetworkContentTypes)[this.contentType]
             }${shortId(this.blockHash)}`
           )
           finished = true

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -35,7 +35,7 @@ const setupNetwork = async () => {
       transport: 'wss',
       proxyAddress: 'ws://127.0.0.1:5050',
     },
-    1
+    2n ** 256n
   )
   const portal2 = new PortalNetwork(
     {
@@ -45,7 +45,7 @@ const setupNetwork = async () => {
       transport: 'wss',
       proxyAddress: 'ws://127.0.0.1:5050',
     },
-    1
+    2n ** 256n
   )
   return [portal1, portal2]
 }


### PR DESCRIPTION
- Revert `rlp` to 2.2.4 version since  3.0 uses `Uint8Array` for both input and outpus while `ethereumjs/block` is still dependent on `Buffer` inputs which makes construction of blocks retrieved from network quite painful
- Revise related code in content lookup and management to resolve these issues