### PR TITLE
Add Offer/FindNodes RPC messages

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,7 +104,7 @@ const run = async () => {
     undefined,
     metrics
   )
-  portal.enableLog('*ultralight*, *portalnetwork*, proxy*')
+  portal.enableLog('*ultralight*, *portalnetwork*, proxy*, *<uTP>*')
   const metricsServer = http.createServer(reportMetrics)
 
   if (args.metrics) {

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -8,7 +8,7 @@ import {
   HistoryNetworkContentKeyUnionType,
 } from 'portalnetwork'
 import * as rlp from 'rlp'
-import { addRLPSerializedBlock } from 'portalnetwork/dist/util'
+import { addRLPSerializedBlock, shortId } from 'portalnetwork/dist/util'
 import { isValidId } from './util'
 
 export class RPCManager {
@@ -96,21 +96,21 @@ export class RPCManager {
       this.log(`response received to findNodes ${res?.toString()}`)
       return `${res?.total ?? 0} nodes returned`
     },
-    portal_offer: async (params: [string, string]) => {
-      const [dstId, blockHash] = params
-      if (!isValidId(dstId)) {
+    portal_offer: async (params: [string, string, number]) => {
+      const [dstId, blockHash, contentType] = params
+      if (!isValidId(dstId) || contentType < 0 || contentType > 2) {
         return 'invalid parameters'
       }
       const contentKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: 0,
+        selector: contentType,
         value: {
           chainId: 1,
           blockHash: fromHex(blockHash.slice(2)),
         },
       })
       const res = await this._client.sendOffer(dstId, [contentKey], SubNetworkIds.HistoryNetwork)
-      this.log(`response received to Offer ${res?.toString()}`)
-      return res
+      this.log(`response received to offer ${res?.toString()}`)
+      return `${shortId(dstId)} ${res ? 'accepted' : 'rejected'} offer`
     },
   }
 

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -71,14 +71,30 @@ export class RPCManager {
       }
     },
     portal_nodeEnr: async () => {
+      this.log(`portal_nodeEnr request received`)
       const enr = this._client.client.enr.encodeTxt()
       return enr
+    },
+    portal_findNodes: async (params: [string, number[]]) => {
+      const [dstId, distances] = params
+      if (/[^a-z0-9\s]+/.test(dstId) || dstId.length !== 64) {
+        // Check for invalid characters in dstId and invalid length
+        return 'invalid node id'
+      }
+      this.log(`portal_findNodes request received with these distances ${distances.toString()}`)
+      const res = await this._client.sendFindNodes(
+        dstId,
+        Uint16Array.from(distances),
+        SubNetworkIds.HistoryNetwork
+      )
+      this.log(`response received to findNodes ${res?.toString()}`)
+      return `${res?.total ?? 0} nodes returned`
     },
   }
 
   constructor(client: PortalNetwork) {
     this._client = client
-    this.log = debug(this._client.client.enr.nodeId.slice(0, 5)).extend('ultralight', ':')
+    this.log = debug(this._client.client.enr.nodeId.slice(0, 5)).extend('ultralight:RPC')
   }
 
   public getMethods() {

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -1,0 +1,3 @@
+export const isValidId = (nodeId: string) => {
+  return /[^a-z0-9\s]+/.test(nodeId) || nodeId.length !== 64 ? false : true
+}

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -831,6 +831,10 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     networkId: SubNetworkIds
   ): Promise<Buffer> => {
     const enr = this.historyNetworkRoutingTable.getValue(dstId)
+    if (!enr) {
+      this.logger(`${shortId(dstId)} not found in routing table`)
+      return Buffer.from([0])
+    }
     try {
       const res = await this.client.sendTalkReq(dstId, payload, fromHexString(networkId), enr)
       return res


### PR DESCRIPTION
Adds new `offer` and `findNodes` message handlers to the RPC to expose low level functionality to `cli` client for network testing.  Resolves outstanding items on #86.