### PR TITLE
Add simulated packet loss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33080,6 +33080,7 @@
     "packages/proxy": {
       "dependencies": {
         "debug": "^4.3.3",
+        "prom-client": "^14.0.1",
         "stun": "^2.1.0",
         "ws": "^8.2.2",
         "yargs": "^17.3.0"
@@ -52825,6 +52826,7 @@
         "debug": "^4.3.3",
         "eslint": "^8.6.0",
         "prettier": "^2.5.1",
+        "prom-client": "*",
         "stun": "^2.1.0",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.3",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,7 +104,7 @@ const run = async () => {
     undefined,
     metrics
   )
-  portal.enableLog('*ultralight*, *portalnetwork*, proxy*, *<uTP>*')
+  portal.enableLog('*ultralight*, *discv5:service*, *portalnetwork*, proxy*, *<uTP>*')
   const metricsServer = http.createServer(reportMetrics)
 
   if (args.metrics) {

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -16,5 +16,7 @@ By default, it only listens on `localhost`/`127.0.0.1`.  To have your proxy list
 
 To make your proxy public facing, run `npm run start --nat extip` and the proxy will get its public IP address from a STUN server and route all traffic via the external IP address.
 
+### Simulated packet loss
 
+To test the portal network client under adverse network conditions, the `--packetLoss` parameter can be passed to the proxy to simulate a packet drop rate.  Any value between 0 and 100 can be passed so `--packetLoss=20` would indicate that approximately 20% of packets will be dropped.
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "debug": "^4.3.3",
+    "prom-client": "^14.0.1",
     "stun": "^2.1.0",
     "ws": "^8.2.2",
     "yargs": "^17.3.0"

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -2,6 +2,8 @@ import WS from 'ws'
 import * as dgram from 'dgram'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
+import http from 'http'
+import * as PromClient from 'prom-client'
 import debug from 'debug'
 const stun = require('stun')
 const log = debug('proxy')
@@ -30,10 +32,40 @@ const args: any = yargs(hideBin(process.argv))
     optional: true,
   }).argv
 
-console.log(args)
 if ((args.packetLoss && args.packetLoss < 0) || args.packetLoss >= 1) {
   log('packet loss parameter must be between 0 and 1. Exiting...')
   process.exit(0)
+}
+
+const register = new PromClient.Registry()
+
+const reportMetrics = async (req: http.IncomingMessage, res: http.ServerResponse) => {
+  res.writeHead(200)
+  res.end(await register.metrics())
+}
+
+const setupMetrics = () => {
+  return {
+    totalPacketsSent: new PromClient.Counter({
+      name: 'proxy_total_packets_sent',
+      help: 'how many packets have been sent',
+    }),
+    totalPacketsDropped: new PromClient.Counter({
+      name: 'proxy_total_packets_dropped',
+      help: 'how many packets have been dropped',
+    }),
+  }
+}
+
+const metricsServer = http.createServer(reportMetrics)
+let metrics: any
+
+if (args.packetLoss) {
+  metrics = setupMetrics()
+  Object.entries(metrics).forEach((entry: any) => {
+    register.registerMetric(entry[1])
+  })
+  metricsServer.listen(5051)
 }
 
 const startServer = async (ws: WS.Server, extip = false) => {
@@ -85,8 +117,10 @@ const startServer = async (ws: WS.Server, extip = false) => {
     log('UDP proxy listening on ', remoteAddr, udpsocket.address().port)
     websocket.on('message', (data) => {
       if (args.packetLoss) {
+        metrics.totalPacketsSent.inc()
         const num = Math.random()
         if (num <= args.packetLoss) {
+          metrics.totalPacketsDropped.inc()
           log('simulating packet loss')
           return
         }
@@ -115,6 +149,9 @@ function stop(): void {
     server.removeAllListeners()
     server.close()
   })
+  if (args.packetLoss) {
+    metricsServer.close()
+  }
   process.exit(0)
 }
 

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -32,8 +32,8 @@ const args: any = yargs(hideBin(process.argv))
     optional: true,
   }).argv
 
-if ((args.packetLoss && args.packetLoss < 0) || args.packetLoss >= 1) {
-  log('packet loss parameter must be between 0 and 1. Exiting...')
+if ((args.packetLoss && args.packetLoss < 0) || args.packetLoss >= 100) {
+  log('packet loss parameter must be between 0 and 100. Exiting...')
   process.exit(0)
 }
 
@@ -118,8 +118,7 @@ const startServer = async (ws: WS.Server, extip = false) => {
     websocket.on('message', (data) => {
       if (args.packetLoss) {
         metrics.totalPacketsSent.inc()
-        const num = Math.random()
-        if (num <= args.packetLoss) {
+        if (Math.random() * 100 <= args.packetLoss) {
           metrics.totalPacketsDropped.inc()
           log('simulating packet loss')
           return


### PR DESCRIPTION
Adds new `--packetLoss=X` parameter to proxy to simulate adverse network conditions where `X` percent of packets are dropped
Adds prometheus metrics reporting on total packets sent versus lost with metrics endpoint at localhost:5051