### PR TITLE
Node lookup and Table Management improvements

### DIFF
--- a/DEVNET.md
+++ b/DEVNET.md
@@ -5,7 +5,7 @@ There are a collection of scripts in the `cli` package's `scripts` directory to 
 ## Starting the devnet
 
 1. Build all packages -- `npm i`
-2. From `packages/cli`, run the devnet script -- `bash scripts/devnet.sh -n [Number of nodes to start] -l [Amount of packet loss to simuliate (i.e. 1-100)]`
+2. From `packages/cli`, run the devnet script -- `bash scripts/devnet.sh -n [Number of nodes to start] -l [Amount of packet loss to simuliate (i.e. 0-100)]`
 3. Observe logs to confirm nodes are running
 4. Press `Ctrl+c` to shutdown the devnet at any time
 
@@ -37,11 +37,15 @@ The first million blocks from Ethereum mainnet can be acquired [here](https://ga
 
 ## Monitoring the devnet
 
-The devnet script starts each node up with a Prometheus metrics server running at the port number of the RPC + 10000.  The metrics can be scraped by Prometheus by adding the below configuration option to your `prometheus.yml` config file.  Update the `targets` based on how many nodes you have started.  Note that `localhost:5051` points to the proxy and reports how many packets have been sent and how many dropped, assuming you provided a value on packet loss.  
+The devnet script starts each node up with a Prometheus metrics server running at the RPC port number + 10000.  The `seeder` script outputs a file called `targets.json` with a list of targets to the current directory that can be provided to Prometheus for metric scraping.  Add the below to your `prometheus.yml` config file.   Note that `localhost:5051` points to the proxy and reports how many packets have been sent and how many dropped, assuming you provided a value on packet loss.  
 ```yaml
 scrape_configs:
   - job_name: "ultralight_devnet"
 
+    file_sd_configs:
+      - files:
+        - '/path/to/targets.json'
+    
     static_configs:
-      - targets: ["localhost:18546", "localhost:18547"...,"localhost:5051"]
+      - targets: ["localhost:5051"]
 ```

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -64,8 +64,8 @@ export class RPCManager {
       this.log(
         `portal_addBootNode request received for NodeID: ${encodedENR.nodeId.slice(0, 15)}...`
       )
-      const res = await this._client.sendPing(enr, SubNetworkIds.HistoryNetwork)
-      return res?.enrSeq ? `ENR added for ${encodedENR.nodeId.slice(0, 15)}...` : 'Node not found'
+      await this._client.addBootNode(enr, SubNetworkIds.HistoryNetwork)
+      return `Bootnode added for ${encodedENR.nodeId.slice(0, 15)}...`
     },
     portal_addBlockToHistory: async (params: [string, string]) => {
       const [blockHash, rlpHex] = params

--- a/packages/cli/targets.json
+++ b/packages/cli/targets.json
@@ -1,0 +1,19 @@
+[
+  {
+    "targets": [
+      "localhost:18546",
+      "localhost:18547",
+      "localhost:18548",
+      "localhost:18549",
+      "localhost:18550",
+      "localhost:18551",
+      "localhost:18552",
+      "localhost:18553",
+      "localhost:18554",
+      "localhost:18555"
+    ],
+    "labels": {
+      "env": "devnet"
+    }
+  }
+]


### PR DESCRIPTION
- Adds new `addBootNode` method to `portalnetwork` moduel which will try to populate routing table with nodes from bootnode when called
- Adjusts `cli` RPC call to `portal_addBootNode` to use new `addBootNode` method
- Tweaks to `seeder` script and devnet docs to easy prometheus metrics reporting