### PR TITLE
Portal Network wire message metrics

### DIFF
--- a/packages/browser-client/src/Components/AddressBookManager.tsx
+++ b/packages/browser-client/src/Components/AddressBookManager.tsx
@@ -10,7 +10,7 @@ import {
   Menu,
   MenuItemOption,
 } from '@chakra-ui/react'
-import { PortalNetwork, SubNetworkIds } from 'portalnetwork'
+import { PortalNetwork, SubNetworkIds, NodeLookup } from 'portalnetwork'
 import { generateRandomNodeIdAtDistance } from 'portalnetwork/dist/util'
 import { HistoryNetworkContentKeyUnionType } from 'portalnetwork/dist/historySubnetwork/types'
 import React, { useEffect, useState } from 'react'
@@ -77,7 +77,8 @@ const AddressBookManager: React.FC<NodeManagerProps> = ({ portal, network, findi
 
   const handleFindRandom = () => {
     const lookupNode = generateRandomNodeIdAtDistance(portal.client.enr.nodeId, 240)
-    portal.nodeLookup(lookupNode, SubNetworkIds.HistoryNetwork)
+    const nodeLookup = new NodeLookup(portal, lookupNode, SubNetworkIds.HistoryNetwork)
+    nodeLookup.startLookup()
   }
   const handlePing = (nodeId: string) => {
     portal.sendPing(nodeId, network)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -86,6 +86,54 @@ const setupMetrics = () => {
       name: 'ultralight_failed_content_lookups',
       help: 'how many content lookups failed to return content',
     }),
+    offerMessagesSent: new PromClient.Counter({
+      name: 'ultralight_offer_messages_sent',
+      help: 'how many offer messages have been sent',
+    }),
+    offerMessagesReceived: new PromClient.Counter({
+      name: 'ultralight_offer_messages_received',
+      help: 'how many offer messages have been received',
+    }),
+    acceptMessagesSent: new PromClient.Counter({
+      name: 'ultralight_accept_messages_sent',
+      help: 'how many accept messages have been sent',
+    }),
+    acceptMessagesReceived: new PromClient.Counter({
+      name: 'ultralight_accept_messages_received',
+      help: 'how many accept messages have been received',
+    }),
+    findContentMessagesSent: new PromClient.Counter({
+      name: 'ultralight_findContent_messages_sent',
+      help: 'how many findContent messages have been sent',
+    }),
+    findContentMessagesReceived: new PromClient.Counter({
+      name: 'ultralight_findContent_messages_received',
+      help: 'how many findContent messages have been received',
+    }),
+    contentMessagesSent: new PromClient.Counter({
+      name: 'ultralight_content_messages_sent',
+      help: 'how many content messages have been sent',
+    }),
+    contentMessagesReceived: new PromClient.Counter({
+      name: 'ultralight_content_messages_received',
+      help: 'how many content messages have been received',
+    }),
+    findNodesMessagesSent: new PromClient.Counter({
+      name: 'ultralight_findNodes_messages_sent',
+      help: 'how many findNodes messages have been sent',
+    }),
+    findNodesMessagesReceived: new PromClient.Counter({
+      name: 'ultralight_findNodes_messages_received',
+      help: 'how many findNodes messages have been received',
+    }),
+    nodesMessagesSent: new PromClient.Counter({
+      name: 'ultralight_nodes_messages_sent',
+      help: 'how many nodes messages have been sent',
+    }),
+    nodesMessagesReceived: new PromClient.Counter({
+      name: 'ultralight_nodes_messages_received',
+      help: 'how many nodes messages have been received',
+    }),
   }
 }
 

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -29,4 +29,16 @@ export interface PortalNetworkMetrics {
   knownDiscv5Nodes: IGauge
   successfulContentLookups: ICounter
   failedContentLookups: ICounter
+  offerMessagesSent: ICounter
+  offerMessagesReceived: ICounter
+  acceptMessagesSent: ICounter
+  acceptMessagesReceived: ICounter
+  findContentMessagesSent: ICounter
+  findContentMessagesReceived: ICounter
+  contentMessagesSent: ICounter
+  contentMessagesReceived: ICounter
+  findNodesMessagesSent: ICounter
+  findNodesMessagesReceived: ICounter
+  nodesMessagesSent: ICounter
+  nodesMessagesReceived: ICounter
 }

--- a/packages/portalnetwork/src/index.ts
+++ b/packages/portalnetwork/src/index.ts
@@ -1,6 +1,6 @@
 export { PortalNetwork } from './client/index'
 export { StateNetworkRoutingTable, distance } from './stateSubnetwork/index'
-export * from './historySubnetwork/index'
-export * from './wire/types'
+export * from './historySubnetwork'
+export * from './wire'
 export * from './util'
 export * from './historySubnetwork'


### PR DESCRIPTION
- Adds metrics to track total # of each type of wire message sent and received
- Fixes node lookup in `browser-client`