### PR TITLE
Add total bytes sent/received metrics

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -134,6 +134,14 @@ const setupMetrics = () => {
       name: 'ultralight_nodes_messages_received',
       help: 'how many nodes messages have been received',
     }),
+    totalBytesReceived: new PromClient.Counter({
+      name: 'ultralight_total_bytes_received',
+      help: 'how many bytes have been received in Portal Network message payloads',
+    }),
+    totalBytesSent: new PromClient.Counter({
+      name: 'ultralight_total_bytes_sent',
+      help: 'how many bytes have been sent in Portal Network message payloads',
+    }),
   }
 }
 

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -523,6 +523,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   }
 
   private onTalkReq = async (src: INodeAddress, sourceId: ENR | null, message: ITalkReqMessage) => {
+    this.metrics?.totalBytesReceived.inc(message.request.length)
     const srcId = src.nodeId
     switch (toHexString(message.protocol)) {
       // TODO: Add handling for other subnetworks as functionality is added
@@ -576,6 +577,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   }
 
   private onTalkResp = (src: INodeAddress, sourceId: ENR | null, message: ITalkRespMessage) => {
+    this.metrics?.totalBytesReceived.inc(message.response.length)
     const srcId = src.nodeId
     this.logger(`TALKRESPONSE message received from ${srcId}, ${message.response.toString()}`)
   }
@@ -869,6 +871,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     }
     const messageProtocol = utpMessage ? SubNetworkIds.UTPNetwork : networkId
     try {
+      this.metrics?.totalBytesSent.inc(payload.length)
       const res = await this.client.sendTalkReq(dstId, payload, fromHexString(messageProtocol), enr)
       return res
     } catch (err: any) {

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -41,4 +41,6 @@ export interface PortalNetworkMetrics {
   findNodesMessagesReceived: ICounter
   nodesMessagesSent: ICounter
   nodesMessagesReceived: ICounter
+  totalBytesReceived: ICounter
+  totalBytesSent: ICounter
 }


### PR DESCRIPTION
Adds two new metrics that show total bytes sent and received in portal network message payloads.