### PR TITLE
Loosen routing table eviction standards

### DIFF
--- a/packages/discv5/src/transport/websockets.ts
+++ b/packages/discv5/src/transport/websockets.ts
@@ -55,7 +55,6 @@ export class WebSocketTransportService
         const port = data.readUIntBE(4, 2);
         this.multiaddr = new Multiaddr(`/ip4/${address}/udp/${port}`);
         this.emit("multiaddrUpdate", this.multiaddr);
-        // eslint-disable-next-line no-empty
       } else {
         this.handleIncoming(data);
       }


### PR DESCRIPTION
Addresses a current issue where portal network nodes send NODES and FOUNDCONTENT messages that are too large based on discv5 packet size rules to allow routing table to stay populated.