### PR TITLE
Add standalone history network content gossip handling

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -71,7 +71,7 @@ export const App = () => {
       {
         enr: enr,
         peerId: id,
-        multiaddr: new Multiaddr('/ip4/104.248.102.101/udp/0'),
+        multiaddr: enr.getLocationMultiaddr('udp')!,
         transport: Capacitor.isNativePlatform() ? 'cap' : 'wss',
         proxyAddress: `ws://${proxy}`,
       },

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -947,8 +947,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     const nodeId = typeof srcId === 'string' ? srcId : srcId.nodeId
     let enr = typeof srcId === 'string' ? routingTable.getValue(srcId) : srcId
     if (!add) {
-      routingTable!.removeById(nodeId)
-      routingTable!.removeFromRadiusMap(nodeId)
+      routingTable!.evictNode(nodeId)
       this.logger(
         `removed ${nodeId} from ${
           Object.keys(SubNetworkIds)[Object.values(SubNetworkIds).indexOf(networkId)]

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -2,9 +2,11 @@ import { KademliaRoutingTable, NodeId } from '@chainsafe/discv5'
 
 export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   private radiusMap: Map<NodeId, bigint>
+  private gossipMap: Map<NodeId, Set<string>>
   constructor(nodeId: NodeId) {
     super(nodeId)
     this.radiusMap = new Map()
+    this.gossipMap = new Map()
   }
 
   /**
@@ -18,20 +20,46 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   }
 
   /**
-   *
-   * Delete a node from the `radiusMap`
-   * @param nodeId node to be deleted from radius map
-   */
-  public removeFromRadiusMap = (nodeId: NodeId) => {
-    this.radiusMap.delete(nodeId)
-  }
-
-  /**
    * Returns the last recorded radius of a peer with the corresponding `nodeId`
    * @param nodeId nodeId of peer for whom radius is sought
    * @returns radius of the peer corresponding to `nodeId`
    */
   public getRadius = (nodeId: NodeId) => {
     return this.radiusMap.get(nodeId)
+  }
+
+  /**
+   * Checks to see if a contentKey is known by a peer already
+   * @param nodeId `nodeId` of peer content was OFFERed to
+   * @param contentKey hex prefixed string representation of content key
+   * @returns boolean indicating if node has already been OFFERed `contentKey` already
+   */
+  public contentKeyKnownToPeer = (nodeId: NodeId, contentKey: string) => {
+    let gossipList = this.gossipMap.get(nodeId)
+    if (!gossipList) {
+      // If no gossipList exists, create new one for `nodeId` and add contentKey to it
+      gossipList = new Set<string>()
+      gossipList.add(contentKey)
+      this.gossipMap.set(nodeId, gossipList)
+      return false
+    }
+    const alreadyKnownToPeer = gossipList.has(contentKey)
+    if (alreadyKnownToPeer) return true
+    else {
+      // If contentKey has not been shared with peer, add contentKey to gossipList
+      gossipList.add(contentKey)
+      this.gossipMap.set(nodeId, gossipList)
+      return false
+    }
+  }
+
+  /**
+   * Remove a node from the routing table
+   * @param nodeId nodeId of peer to be evicted
+   */
+  public evictNode = (nodeId: NodeId) => {
+    this.radiusMap.delete(nodeId)
+    this.gossipMap.delete(nodeId)
+    this.removeById(nodeId)
   }
 }

--- a/packages/portalnetwork/src/wire/contentLookup.ts
+++ b/packages/portalnetwork/src/wire/contentLookup.ts
@@ -92,7 +92,11 @@ export class ContentLookup {
           // Offer content to neighbors who should have had content but don't if we receive content directly
           this.contacted.forEach((peer) => {
             if (!peer.hasContent) {
-              this.client.sendOffer(peer.nodeId, [this.contentKey], this.networkId)
+              const routingTable = this.client.routingTables.get(this.networkId)!
+              if (!routingTable.contentKeyKnownToPeer(peer.nodeId, toHexString(this.contentKey))) {
+                // Only offer content if not already offered to this peer
+                this.client.sendOffer(peer.nodeId, [this.contentKey], this.networkId)
+              }
             }
           })
           return res.value


### PR DESCRIPTION
Fixes #199.

This adds a new mapping to the Routing Table class to track which contentKeys have been previously OFFERed to which node and also a standalone `gossipHistoryNetworkContent` method that listens for ContentAdded events and gossips that content out to the network.