### PR TITLE
Use addrVotes instead of proxy reflection to update ENR

### DIFF
--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -198,11 +198,6 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
     this.sessionService.on("response", this.handleRpcResponse);
     this.sessionService.on("whoAreYouRequest", this.handleWhoAreYouRequest);
     this.sessionService.on("requestFailed", this.rpcFailure);
-    this.sessionService.transport.on("multiaddrUpdate", (addr) => {
-      this.enr.setLocationMultiaddr(addr);
-      this.emit("multiaddrUpdated", addr);
-      this.log("Updated ENR based on public multiaddr to", this.enr.encodeTxt(this.keypair.privateKey));
-    });
     await this.sessionService.start();
     this.started = true;
   }

--- a/packages/discv5/src/transport/types.ts
+++ b/packages/discv5/src/transport/types.ts
@@ -21,8 +21,6 @@ export interface IRemoteInfo {
 export interface ITransportEvents {
   packet: (src: Multiaddr, packet: IPacket) => void;
   decodeError: (err: Error, src: Multiaddr) => void;
-  newSocketConnection: (src: Multiaddr) => void;
-  multiaddrUpdate: (addr: Multiaddr) => void;
 }
 export type TransportEventEmitter = StrictEventEmitter<EventEmitter, ITransportEvents>;
 

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -76,6 +76,10 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
           enr.nodeId,
           proxyAddress
         ),
+        config: {
+          addrVotesToUpdateEnr: 5,
+          enrUpdate: true,
+        },
       },
       2n ** 256n
     )
@@ -93,6 +97,10 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         peerId: id,
         multiaddr: enr.getLocationMultiaddr('udp')!,
         transport: new CapacitorUDPTransportService(enr.getLocationMultiaddr('udp')!, enr.nodeId),
+        config: {
+          addrVotesToUpdateEnr: 5,
+          enrUpdate: true,
+        },
       },
       2n ** 256n
     )
@@ -130,6 +138,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     })
     this.client.on('talkReqReceived', this.onTalkReq)
     this.client.on('talkRespReceived', this.onTalkResp)
+    this.client.on('sessionEstablished', (nodeId) =>
+      (this.client as any).sendPing(this.client.getKadValue(nodeId))
+    )
     this.on('ContentAdded', this.gossipHistoryNetworkContent)
     /*  TODO: decide whether to add this code back in since some nodes are naughty and send UDP packets that
         are too big for discv5 and our discv5 implementation automatically evicts these nodes from the discv5

--- a/packages/portalnetwork/src/transports/capacitorUdp.ts
+++ b/packages/portalnetwork/src/transports/capacitorUdp.ts
@@ -39,11 +39,6 @@ export class CapacitorUDPTransportService
     const opts = this.multiaddr.toOptions()
     this.socket = await UDP.create()
     await UDP.bind({ socketId: this.socket.socketId, address: this.socket.ipv4, port: opts.port })
-    const socketInfo = await UDP.getInfo({ socketId: this.socket.socketId })
-    this.emit(
-      'multiaddrUpdate',
-      new Multiaddr(`/ip4/${this.socket.ipv4}/udp/${socketInfo.localPort?.toString()}`)
-    )
     UDP.addListener('receive', (ret: any) => {
       this.handleIncoming(Buffer.from(ret.buffer, 'base64'), {
         family: 'IPv4',

--- a/packages/portalnetwork/src/transports/websockets.ts
+++ b/packages/portalnetwork/src/transports/websockets.ts
@@ -49,15 +49,7 @@ export class WebSocketTransportService
     this.socket.ws.binaryType = 'arraybuffer'
     this.socket.onMessage.addListener((msg: MessageEvent | ArrayBuffer) => {
       const data = msg instanceof MessageEvent ? Buffer.from(msg.data) : Buffer.from(msg)
-
-      if (data.length === 6) {
-        const address = ip.decode(data.slice(0, 4))
-        const port = data.readUIntBE(4, 2)
-        this.multiaddr = new Multiaddr(`/ip4/${address}/udp/${port}`)
-        this.emit('multiaddrUpdate', this.multiaddr)
-      } else {
-        this.handleIncoming(data)
-      }
+      this.handleIncoming(data)
     })
     this.socket.onClose.addListener(() => log('socket to proxy closed'))
   }

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -4,16 +4,9 @@ A simple NodeJS websocket-to-UDP proxy to allow browser clients to connect to a 
 
 ## Protocol
 
-### Websocket Handshake/Connection
+### Initial connection
 
-When a client application first opens a web socket connection to the proxy, the proxy sends its public IPv4 address and an assigned port number to the client in a 6 byte message where the first 4 bytes represent the IPv4 address (XXX.XXX.XXX.XXX) where each byte corresponds to one byte of the IPv4 address and the last 2 bytes represent a port number between 1 and 65535 as a Uint16 (2 byte unsigned integer).
-
-In the context of the Discv5 protocol, the websocket client uses the proxy's public IP address and specified port number in its ENR in order to hook into the Discv5 network.
-### Proxy Service
-
-Once the initial websocket connection is established, the proxy acts as a message forwarding service between web socket clients and a UDP based network.
-
-It does so by maintaining a map of websocket connections to UDP port numbers.
+When a client application first opens a web socket connection to the proxy, the proxy assigns a UDP port to that connection and relays any packets received on the websocket connection to the mapped UDP port and vice versa.
 
 #### Websocket -> UDP forwarding
 All messages sent by the websocket client begin with the below prefix:

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -94,17 +94,6 @@ const startServer = async (ws: WS.Server, externalIp: string, wssPort = 5050, ud
         log(err)
       }
     }
-    // Send external IP address/port to websocket client to update ENR
-    const remoteAddrArray = externalIp.split('.')
-    const bAddress = Uint8Array.from([
-      parseInt(remoteAddrArray[0]),
-      parseInt(remoteAddrArray[1]),
-      parseInt(remoteAddrArray[2]),
-      parseInt(remoteAddrArray[3]),
-    ])
-    const bPort = Buffer.alloc(2)
-    bPort.writeUIntBE(udpsocket.address().port, 0, 2)
-    websocket.send(Buffer.concat([bAddress, bPort]))
     log('UDP proxy listening on ', externalIp, udpsocket.address().port)
     websocket.on('message', (data) => {
       try {


### PR DESCRIPTION
Removes public IP reflection from proxy and has `discv5` client use builtin `addrVotes` to update public IP instead
Also addresses point 3 of #205 by removing now unnecessary `ITransportEvents` in our `discv5` fork to make upstream merging easier. 