### PR TITLE
Web-storage

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -44,6 +44,7 @@ export const mediumblue = theme.colors.blue[200]
 
 export const App = () => {
   const [portal, setPortal] = React.useState<PortalNetwork>()
+  const [IDB, setIDB] = React.useState<IDBDatabase>()
   const [peers, setPeers] = React.useState<ENR[] | undefined>([])
   const [sortedDistList, setSortedDistList] = React.useState<[number, string[]][]>([])
   const [enr, setENR] = React.useState<string>('')
@@ -92,6 +93,23 @@ export const App = () => {
   }, [portal])
 
   const init = async () => {
+    const _IDB = window.indexedDB.open('UltralightIndexedDB', 1)
+    _IDB.onupgradeneeded = () => {
+      const db = _IDB.result
+      if (!db.objectStoreNames.contains('peers')) {
+        db.createObjectStore('peers')
+      }
+      if (!db.objectStoreNames.contains('headers')) {
+        db.createObjectStore('headers')
+      }
+      if (!db.objectStoreNames.contains('blocks')) {
+        db.createObjectStore('blocks')
+      }
+    }
+    _IDB.onsuccess = () => {
+      setIDB(_IDB.result)
+      ;(window as any).IDB = _IDB.result
+    }
     if (portal?.client.isStarted()) {
       await portal.stop()
     }

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -38,6 +38,7 @@ import { Capacitor } from '@capacitor/core'
 import { HamburgerIcon } from '@chakra-ui/icons'
 import Footer from './Components/Footer'
 import InfoMenu from './Components/InfoMenu'
+import { addToIndexedDB, saveToLocalStorage } from './Components/localStorage'
 // export const lightblue = '#bee3f8'
 export const lightblue = theme.colors.blue[100]
 export const mediumblue = theme.colors.blue[200]
@@ -58,7 +59,7 @@ export const App = () => {
   const { onCopy } = useClipboard(enr)
   const { onOpen } = useDisclosure()
   const disclosure = useDisclosure()
-  const toast = useToast()
+  // const toast = useToast()
   const [modalStatus, setModal] = React.useState(false)
 
   function updateAddressBook() {
@@ -153,12 +154,12 @@ export const App = () => {
     if (!errMessage) {
       errMessage = 'Node did not respond'
     }
-    toast({
-      title: errMessage,
-      status: 'error',
-      duration: 3000,
-      isClosable: true,
-    })
+    // toast({
+    //   title: errMessage,
+    //   status: 'error',
+    //   duration: 3000,
+    //   isClosable: true,
+    // })
   }
 
   async function handleFindContent(blockHash: string): Promise<Block | void> {
@@ -271,24 +272,24 @@ export const App = () => {
       </Drawer>
       <Box>
         {IDB && (
-        <Layout
-          copy={copy}
-          onOpen={onOpen}
-          enr={enr}
-          peerEnr={peerEnr}
-          setPeerEnr={setPeerEnr}
-          handleClick={handleClick}
-          invalidHash={invalidHash}
-          handleFindContent={handleFindContent}
-          contentKey={contentKey}
-          setContentKey={setContentKey}
-          findParent={findParent}
-          block={block}
-          peers={peers}
+          <Layout
+            copy={copy}
+            onOpen={onOpen}
+            enr={enr}
+            peerEnr={peerEnr}
+            setPeerEnr={setPeerEnr}
+            handleClick={handleClick}
+            invalidHash={invalidHash}
+            handleFindContent={handleFindContent}
+            contentKey={contentKey}
+            setContentKey={setContentKey}
+            findParent={findParent}
+            block={block}
+            peers={peers}
             IDB={IDB}
-          sortedDistList={sortedDistList}
-          capacitor={Capacitor}
-        />
+            sortedDistList={sortedDistList}
+            capacitor={Capacitor}
+          />
         )}
         <Button onClick={() => updateAddressBook()}>Update Address Book</Button>
       </Box>

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -270,6 +270,7 @@ export const App = () => {
         </DrawerContent>
       </Drawer>
       <Box>
+        {IDB && (
         <Layout
           copy={copy}
           onOpen={onOpen}
@@ -284,9 +285,11 @@ export const App = () => {
           findParent={findParent}
           block={block}
           peers={peers}
+            IDB={IDB}
           sortedDistList={sortedDistList}
           capacitor={Capacitor}
         />
+        )}
         <Button onClick={() => updateAddressBook()}>Update Address Book</Button>
       </Box>
       <Box width={'100%'} pos={'fixed'} bottom={'0'}>

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -208,6 +208,16 @@ export const App = () => {
   }
   const invalidHash = /([^0-z])+/.test(contentKey)
 
+  React.useEffect(() => {
+    if (peers && peers.length > 0) {
+      try {
+        peers?.forEach(async (peer) => {
+          addToIndexedDB('peers', peer.encodeTxt(), peer, IDB!)
+        })
+      } catch {}
+    }
+  }, [peers])
+
   return (
     <>
       <Center bg={'gray.200'}>

--- a/packages/browser-client/src/Components/Bootnodes.tsx
+++ b/packages/browser-client/src/Components/Bootnodes.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Progress, Text, useInterval, VStack } from '@chakra-ui/react'
-import React, { Dispatch, SetStateAction, useState } from 'react'
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
 interface BootnodesProps {
   IDB: IDBDatabase | undefined
@@ -77,10 +77,15 @@ export default function Bootnodes(props: BootnodesProps) {
       setType(bns[index][0])
       setIdx(bns[index][1])
       props.setPeerEnr(bns[index][2])
-      setIndex(index + 1)
       setProgress(progress + 10)
+    } else if (index - bns.length < oldPeers.length) {
+      await props.handleClick()
+      props.setPeerEnr(oldPeers[index - bns.length])
     }
+    setIndex(index + 1)
   }, 500)
+  }, 150)
+
   return index < bns.length ? (
     <VStack>
       <Heading size="sm">Connecting to Bootnodes...</Heading>

--- a/packages/browser-client/src/Components/Bootnodes.tsx
+++ b/packages/browser-client/src/Components/Bootnodes.tsx
@@ -2,6 +2,7 @@ import { Box, Heading, Progress, Text, useInterval, VStack } from '@chakra-ui/re
 import React, { Dispatch, SetStateAction, useState } from 'react'
 
 interface BootnodesProps {
+  IDB: IDBDatabase | undefined
   setPeerEnr: Dispatch<SetStateAction<string>>
   handleClick: () => Promise<void>
 }

--- a/packages/browser-client/src/Components/Bootnodes.tsx
+++ b/packages/browser-client/src/Components/Bootnodes.tsx
@@ -8,9 +8,16 @@ interface BootnodesProps {
 }
 export default function Bootnodes(props: BootnodesProps) {
   const [type, setType] = useState<string>()
+  const [oldPeers, setOldPeers] = useState<string[]>([])
   const [index, setIndex] = useState<number>(0)
   const [idx, setIdx] = useState<string>()
   const [progress, setProgress] = useState(0)
+  useEffect(() => {
+    const request = props.IDB!.transaction('peers', 'readonly').objectStore('peers').getAllKeys()
+    request.onsuccess = () => {
+      setOldPeers(request.result as string[])
+    }
+  }, [])
   const bns: string[][] = [
     [
       'Ultralight',

--- a/packages/browser-client/src/Components/Bootnodes.tsx
+++ b/packages/browser-client/src/Components/Bootnodes.tsx
@@ -83,7 +83,18 @@ export default function Bootnodes(props: BootnodesProps) {
       props.setPeerEnr(oldPeers[index - bns.length])
     }
     setIndex(index + 1)
-  }, 500)
+    // LOCAL_STORAGE SOLUTION (ALSO WORKS)
+    // if (index < Object.keys(localStorage).length) {
+    //   index !== 0 && (await props.handleClick())
+    //   if (localStorage.getItem(`peer${index}`)) {
+    //     if (localStorage.getItem(`peer${index}`)?.substring(0, 3) === 'ENR') {
+    //     }
+    //     try {
+    //       props.setPeerEnr(localStorage.getItem(`peer${index}`) as string)
+    //     } catch {}
+    //   }
+    //   setIndex(index + 1)
+    // }
   }, 150)
 
   return index < bns.length ? (

--- a/packages/browser-client/src/Components/Layout.tsx
+++ b/packages/browser-client/src/Components/Layout.tsx
@@ -19,6 +19,7 @@ import Bootnodes from './Bootnodes'
 interface LayoutProps {
   copy: () => Promise<void>
   onOpen: () => void
+  IDB: IDBDatabase | undefined
   enr: string
   peerEnr: string
   setPeerEnr: Dispatch<SetStateAction<string>>
@@ -60,7 +61,11 @@ export default function Layout(props: LayoutProps) {
         <VStack paddingTop={2} spacing={1} align="stretch">
           <Divider />
           <Divider />
-          <Bootnodes setPeerEnr={props.setPeerEnr} handleClick={props.handleClick} />
+          <Bootnodes
+            IDB={props.IDB}
+            setPeerEnr={props.setPeerEnr}
+            handleClick={props.handleClick}
+          />
         </VStack>
         {props.peers && props.peers.length > 0 && (
           <TabPanels>

--- a/packages/browser-client/src/Components/localStorage.ts
+++ b/packages/browser-client/src/Components/localStorage.ts
@@ -6,3 +6,24 @@ export function saveToLocalStorage(key: string, value: string) {
   }
 }
 
+export async function addToIndexedDB(type: string, key: string, value: any, db: IDBDatabase) {
+  const request = db.transaction(type, 'readwrite').objectStore(type).add(value, key)
+  request.onsuccess = () => {
+    console.log('added to indexeddb')
+    return request.result
+  }
+  request.onerror = () => {
+    return
+  }
+}
+
+export async function removeFromIndexedDB(type: string, key: string, db: IDBDatabase) {
+  const request = db.transaction(type, 'readwrite').objectStore(type).delete(key)
+  request.onsuccess = () => {
+    console.log('removed from indexeddb')
+    return request.result
+  }
+  request.onerror = () => {
+    return
+  }
+}

--- a/packages/browser-client/src/Components/localStorage.ts
+++ b/packages/browser-client/src/Components/localStorage.ts
@@ -1,0 +1,8 @@
+export function saveToLocalStorage(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    console.log('something went wrong with local storage')
+  }
+}
+


### PR DESCRIPTION
WIP

Proof of Concept 

Use webstorage to persist node data.

Testing 2 methods:
- local storage 
- indexeddb

For storing a list of ENR's, both methods work.

List of unique ENR's will persist in the browser's indexxeddb database.

Upon reopening the page, the bootnodes sequence will also attempt to resume contact with other nodes by sending ping to each ENR.

TODO: prevent infinite growth