### PR TITLE
Update peerId in CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "jayson": "^3.6.6",
     "level": "^7.0.1",
     "multiaddr": "^10.0.0",
-    "peer-id": "^0.15.2",
+    "peer-id": "^0.16.0",
     "portalnetwork": "^0.0.1",
     "prom-client": "^14.0.1",
     "rlp": "2.2.4",


### PR DESCRIPTION
Update `peer-id` dep to 0.16 to leverage non-deprecated versions of noble-secp256k1.  Similar PR is currently open on discv5 to remove these deprecated dependencies.