### PR TITLE
Miscellaneous fixes

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -145,13 +145,8 @@ export const App = () => {
   }
 
   React.useEffect(() => {
-    init().then(() => {
-      window.onbeforeunload = async (evt) => {
-        evt.preventDefault()
-        portal?.storeNodeDetails()
-        evt.stopImmediatePropagation()
-      }
-    })
+    init()
+    portal?.storeNodeDetails()
   }, [])
 
   async function handleFindContent(blockHash: string): Promise<Block | void> {

--- a/packages/browser-client/src/Components/BlocksToExplore.tsx
+++ b/packages/browser-client/src/Components/BlocksToExplore.tsx
@@ -1,16 +1,11 @@
 import { Box, Menu, MenuItemOption, MenuOptionGroup } from '@chakra-ui/react'
 import { Block } from '@ethereumjs/block'
 import { rlp } from 'ethereumjs-util'
-import {
-  fromHexString,
-  getHistoryNetworkContentId,
-  PortalNetwork,
-  reassembleBlock,
-} from 'portalnetwork'
+import { fromHexString, getHistoryNetworkContentId, reassembleBlock } from 'portalnetwork'
 import React, { Dispatch, ReactElement, SetStateAction, useEffect, useState } from 'react'
+import { PortalContext } from '../App'
 
 interface BlocksToExploreProps {
-  portal: PortalNetwork
   findContent: any
   setBlock: Dispatch<SetStateAction<Block | undefined>>
 }
@@ -21,7 +16,7 @@ export default function BlocksToExplore(props: BlocksToExploreProps) {
   const [_display, _setDisplay] = useState<ReactElement>()
   const [menu, setMenu] = useState<ReactElement>(<></>)
 
-  const portal = props.portal
+  const portal = React.useContext(PortalContext)
 
   function addKey(key: string) {
     const k = keys


### PR DESCRIPTION
3 small fixes:
1. Removes the `window.onbeforeunload` event listener as it didn't seem to actually work and replacing it with a straight call to `storeNodeDetails` in the init function.
2. Moves the `peerId` to a private property of the `portalnetwork` class so we can access it later for storing in the db.
3. Move one react component to use the new `PortalContext` object.