### PR TITLE
Recreate-mobile

### DIFF
--- a/packages/browser-client/package.json
+++ b/packages/browser-client/package.json
@@ -23,7 +23,7 @@
     "@capacitor/cli": "^3.4.3",
     "@capacitor/share": "1.1.2",
     "@types/node": "^17.0.23",
-    "@types/react": "^17.0.43",
+    "@types/react": "^18.0.9",
     "@types/react-dom": "^17.0.14",
     "assert": "^2.0.0",
     "babel-loader": "^8.2.4",
@@ -44,13 +44,13 @@
     "webpack-dev-server": "^4.8.0"
   },
   "dependencies": {
-    "@capacitor/android": "^3.4.3",
+    "@capacitor/android": "3.5.1",
     "@capacitor/core": "^3.4.3",
     "@capacitor/ios": "^3.4.3",
-    "@chakra-ui/icons": "^1.1.5",
-    "@chakra-ui/react": "^1.8.8",
-    "@emotion/react": "^11.0.0",
-    "@emotion/styled": "^11.0.0",
+    "@chakra-ui/icons": "2.0.0",
+    "@chakra-ui/react": "2.0.0",
+    "@emotion/react": "11.9.0",
+    "@emotion/styled": "^11.8.1",
     "@ethereumjs/block": "^3.6.0",
     "@ethereumjs/common": "^2.6.0",
     "@ethereumjs/tx": "^3.5.0",
@@ -61,8 +61,8 @@
     "multiaddr": "^10.0.1",
     "peer-id": "^0.16.0",
     "portalnetwork": "^0.0.1",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.1.0",
+    "react-dom": "18.1.0",
     "react-icons": "^3.0.0",
     "rlp": "2.2.4"
   }

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -105,16 +105,20 @@ export const App = () => {
 
   async function createNodeFromScratch(): Promise<PortalNetwork> {
     const node = Capacitor.isNativePlatform()
-      ? await PortalNetwork.createMobilePortalNetwork(bns)
+      ? // @ts-ignore
+        await PortalNetwork.createMobilePortalNetwork(bns, LDB)
       : // @ts-ignore
         await PortalNetwork.createPortalNetwork(proxy, bns, LDB)
     return node
   }
 
   async function createNodeFromStorage(): Promise<PortalNetwork> {
-    // @ts-ignore
-    const prev_node = await PortalNetwork.recreatePortalNetwork(proxy, LDB)
-    return prev_node
+    const node = Capacitor.isNativePlatform()
+      ? // @ts-ignore
+        await PortalNetwork.recreateMobilePortalNetwork(bns, LDB)
+      : // @ts-ignore
+        await PortalNetwork.recreatePortalNetwork(proxy, LDB)
+    return node
   }
 
   const init = async () => {
@@ -127,6 +131,7 @@ export const App = () => {
     } catch {
       node = await createNodeFromScratch()
     }
+
     setPortal(node)
     node.enableLog('*discv5*, *portalnetwork*, *uTP*')
     await node.start()


### PR DESCRIPTION
Initial testing shows that the same browser-level API works on android, and will recreate an ENR , routing table, database.
1. Client: Added `recreateMobilePortalNetwork` modeled after `recreatePortalNetwork`
2. App: Update init() methods to look for stored mobile node
3. Unrelated Dependency Update
  -  `npm i` produced errors related to upstream dependency issues.  
  -  issues were related to `chakra-ui` releasing v2, and `react` releasign `v18`
  -  updating these did not cause any problems that i have seen.



- Not committed here are experiments with `Backgournd Mode`  which allows an app to perform tasks while running but not in the foreground.  
  - Success: 
    - App will stay active in background and continue to perform `liveness check` every 30s
  - Problems:
    - `Background Mode` requires an additional capacitor plugin (`@ionic-native/background-mode`)
    - While the app does remain active, network calls are not actually made.  