### PR TITLE
Convert history content lookup to `getBlockByHash`

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -45,7 +45,7 @@ export const App = () => {
   const [enr, setENR] = React.useState<string>('')
   const [id, _setId] = React.useState<string>('')
   const [peerEnr, setPeerEnr] = React.useState('')
-  const [contentKey, setContentKey] = React.useState<string>(
+  const [blockHash, setBlockHash] = React.useState<string>(
     '0xf37c632d361e0a93f08ba29b1a2c708d9caa3ee19d1ee8d2a02612bffe49f0a9'
   )
   const [proxy, setProxy] = React.useState('ws://127.0.0.1:5050')
@@ -175,7 +175,7 @@ export const App = () => {
   async function getBlockByHash(blockHash: string) {
     if (portal) {
       if (blockHash.slice(0, 2) !== '0x') {
-        setContentKey('')
+        setBlockHash('')
       } else {
         const protocol = portal.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
         if (!protocol) return
@@ -186,7 +186,7 @@ export const App = () => {
   }
 
   async function findParent(hash: string) {
-    setContentKey(hash)
+    setBlockHash(hash)
     getBlockByHash(hash)
     portal?.logger('Showing Block')
   }
@@ -195,7 +195,7 @@ export const App = () => {
     setModal(true)
     disclosure.onClose()
   }
-  const invalidHash = /([^0-z])+/.test(contentKey)
+  const invalidHash = /([^0-z])+/.test(blockHash)
 
   return (
     <ChakraProvider theme={theme}>
@@ -260,8 +260,8 @@ export const App = () => {
                 handleClick={handleClick}
                 invalidHash={invalidHash}
                 getBlockByHash={getBlockByHash}
-                contentKey={contentKey}
-                setContentKey={setContentKey}
+                blockHash={blockHash}
+                setBlockHash={setBlockHash}
                 findParent={findParent}
                 block={block}
                 peers={peers}

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -134,6 +134,13 @@ export const App = () => {
         proxyAddress: proxy,
         db: LDB as any,
         transport: TransportLayer.WEB,
+        //@ts-ignore
+        config: {
+          config: {
+            enrUpdate: true,
+            addrVotesToUpdateEnr: 1,
+          },
+        },
       })
     } else {
       try {

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -172,7 +172,7 @@ export const App = () => {
     portal?.storeNodeDetails()
   }, [])
 
-  async function handleFindContent(blockHash: string) {
+  async function getBlockByHash(blockHash: string) {
     if (portal) {
       if (blockHash.slice(0, 2) !== '0x') {
         setContentKey('')
@@ -187,7 +187,7 @@ export const App = () => {
 
   async function findParent(hash: string) {
     setContentKey(hash)
-    handleFindContent(hash)
+    getBlockByHash(hash)
     portal?.logger('Showing Block')
   }
 
@@ -259,7 +259,7 @@ export const App = () => {
                 setPeerEnr={setPeerEnr}
                 handleClick={handleClick}
                 invalidHash={invalidHash}
-                handleFindContent={handleFindContent}
+                getBlockByHash={getBlockByHash}
                 contentKey={contentKey}
                 setContentKey={setContentKey}
                 findParent={findParent}

--- a/packages/browser-client/src/Components/DevTools.tsx
+++ b/packages/browser-client/src/Components/DevTools.tsx
@@ -34,7 +34,7 @@ export default function DevTools(props: DevToolsProps) {
   const [peer, _setPeer] = useState(peers[0])
   const [targetNodeId, setTarget] = useState('')
   const [distance, setDistance] = useState('')
-  const [contentKey, setContentKey] = useState('')
+  const [blockHash, setBlockHash] = useState('')
   const toast = useToast()
   const handlePing = () => {
     const protocol = portal.protocols.get(ProtocolId.HistoryNetwork)!
@@ -55,8 +55,8 @@ export default function DevTools(props: DevToolsProps) {
   }
 
   const handleOffer = (nodeId: string) => {
-    if (contentKey.slice(0, 2) !== '0x') {
-      setContentKey('')
+    if (blockHash.slice(0, 2) !== '0x') {
+      setBlockHash('')
       toast({
         title: 'Invalid content key',
         description: 'Key must be hex prefixed',
@@ -65,7 +65,7 @@ export default function DevTools(props: DevToolsProps) {
       return
     }
     const protocol = portal.protocols.get(ProtocolId.HistoryNetwork)
-    protocol!.sendOffer(nodeId, [fromHexString(contentKey)])
+    protocol!.sendOffer(nodeId, [fromHexString(blockHash)])
   }
 
   const sendRendezvous = async (peer: string) => {
@@ -175,9 +175,9 @@ export default function DevTools(props: DevToolsProps) {
       </Button>
       <Divider />
       <Input
-        value={contentKey}
+        value={blockHash}
         placeholder="Content Key"
-        onChange={(evt) => setContentKey(evt.target.value)}
+        onChange={(evt) => setBlockHash(evt.target.value)}
       />
       <Button isDisabled={!portal} width={'100%'} size="sm" onClick={() => handleOffer(peer)}>
         Send Offer

--- a/packages/browser-client/src/Components/HistoryNetwork.tsx
+++ b/packages/browser-client/src/Components/HistoryNetwork.tsx
@@ -19,7 +19,7 @@ interface HistoryNetworkProps {
   findParent: (hash: string) => Promise<void>
   block: Block | undefined
   invalidHash: boolean
-  handleFindContent: (blockHash: string) => Promise<void | Block>
+  getBlockByHash: (blockHash: string) => Promise<void | Block>
   contentKey: string
   setContentKey: Dispatch<SetStateAction<string>>
   peers: ENR[] | undefined
@@ -36,7 +36,7 @@ export default function HistoryNetwork(props: HistoryNetworkProps) {
 
   async function handleClick() {
     setIsLoading(true)
-    await props.handleFindContent(props.contentKey)
+    await props.getBlockByHash(props.contentKey)
     setTabIndex(1)
     setIsLoading(false)
   }

--- a/packages/browser-client/src/Components/HistoryNetwork.tsx
+++ b/packages/browser-client/src/Components/HistoryNetwork.tsx
@@ -20,8 +20,8 @@ interface HistoryNetworkProps {
   block: Block | undefined
   invalidHash: boolean
   getBlockByHash: (blockHash: string) => Promise<void | Block>
-  contentKey: string
-  setContentKey: Dispatch<SetStateAction<string>>
+  blockHash: string
+  setBlockHash: Dispatch<SetStateAction<string>>
   peers: ENR[] | undefined
   sortedDistList: [number, string[]][]
 }
@@ -36,7 +36,7 @@ export default function HistoryNetwork(props: HistoryNetworkProps) {
 
   async function handleClick() {
     setIsLoading(true)
-    await props.getBlockByHash(props.contentKey)
+    await props.getBlockByHash(props.blockHash)
     setTabIndex(1)
     setIsLoading(false)
   }
@@ -65,9 +65,9 @@ export default function HistoryNetwork(props: HistoryNetworkProps) {
           <Input
             bg="whiteAlpha.800"
             placeholder={'Block Hash'}
-            value={props.contentKey}
+            value={props.blockHash}
             onChange={(evt) => {
-              props.setContentKey(evt.target.value)
+              props.setBlockHash(evt.target.value)
             }}
           />
         </FormControl>

--- a/packages/browser-client/src/Components/Layout.tsx
+++ b/packages/browser-client/src/Components/Layout.tsx
@@ -14,8 +14,8 @@ interface LayoutProps {
   handleClick: () => Promise<void>
   invalidHash: boolean
   getBlockByHash: (blockHash: string) => Promise<void | Block>
-  contentKey: string
-  setContentKey: Dispatch<SetStateAction<string>>
+  blockHash: string
+  setBlockHash: Dispatch<SetStateAction<string>>
   findParent: (hash: string) => Promise<void>
   block: Block | undefined
   peers: ENR[] | undefined
@@ -58,8 +58,8 @@ export default function Layout(props: LayoutProps) {
               <HistoryNetwork
                 invalidHash={props.invalidHash}
                 getBlockByHash={props.getBlockByHash}
-                contentKey={props.contentKey}
-                setContentKey={props.setContentKey}
+                blockHash={props.blockHash}
+                setBlockHash={props.setBlockHash}
                 findParent={props.findParent}
                 block={props.block}
                 peers={props.peers}

--- a/packages/browser-client/src/Components/Layout.tsx
+++ b/packages/browser-client/src/Components/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
   setPeerEnr: Dispatch<SetStateAction<string>>
   handleClick: () => Promise<void>
   invalidHash: boolean
-  handleFindContent: (blockHash: string) => Promise<void | Block>
+  getBlockByHash: (blockHash: string) => Promise<void | Block>
   contentKey: string
   setContentKey: Dispatch<SetStateAction<string>>
   findParent: (hash: string) => Promise<void>
@@ -57,7 +57,7 @@ export default function Layout(props: LayoutProps) {
             <TabPanel>
               <HistoryNetwork
                 invalidHash={props.invalidHash}
-                handleFindContent={props.handleFindContent}
+                getBlockByHash={props.getBlockByHash}
                 contentKey={props.contentKey}
                 setContentKey={props.setContentKey}
                 findParent={props.findParent}

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -25,7 +25,8 @@ export class RPCManager {
         `eth_getBlockByHash request received. blockHash: ${blockHash} includeTransactions: ${includeTransactions}`
       )
       try {
-        return this.protocol.getBlockByHash(blockHash, includeTransactions)
+        const block = await this.protocol.getBlockByHash(blockHash, includeTransactions)
+        return block ?? 'Block not found'
       } catch {
         return 'Block not found'
       }

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -1,14 +1,11 @@
 import debug, { Debugger } from 'debug'
 import {
   PortalNetwork,
-  getHistoryNetworkContentId,
   ProtocolId,
-  reassembleBlock,
   HistoryNetworkContentKeyUnionType,
   ENR,
   fromHexString,
 } from 'portalnetwork'
-import * as rlp from 'rlp'
 import { addRLPSerializedBlock } from 'portalnetwork'
 import { isValidId } from './util'
 import { HistoryProtocol } from 'portalnetwork/src/subprotocols/history/history'
@@ -27,37 +24,8 @@ export class RPCManager {
       this.log(
         `eth_getBlockByHash request received. blockHash: ${blockHash} includeTransactions: ${includeTransactions}`
       )
-      // lookup block header in DB and return if found
-      const headerlookupKey = getHistoryNetworkContentId(1, blockHash, 0)
-      const bodylookupKey = includeTransactions && getHistoryNetworkContentId(1, blockHash, 1)
-      let header
-      let body
-      let block
       try {
-        header = await this._client.db.get(headerlookupKey)
-        body = includeTransactions ? await this._client.db.get(bodylookupKey) : rlp.encode([[], []])
-        block = reassembleBlock(
-          fromHexString(header),
-          typeof body === 'string' ? fromHexString(body) : body
-        )
-        this._client.metrics?.successfulContentLookups.inc()
-        return block
-      } catch (err: any) {
-        this.log(err.message)
-      }
-      // If block isn't in local DB, request block from network
-      try {
-        header = await this.protocol.historyNetworkContentLookup(0, blockHash)
-        if (!header) {
-          return 'Block not found'
-        }
-        body = includeTransactions
-          ? (await this.protocol.historyNetworkContentLookup(1, blockHash)) ?? rlp.encode([[], []])
-          : rlp.encode([[], []])
-        // TODO: Figure out why block body isn't coming back as Uint8Array
-        //@ts-ignore
-        block = reassembleBlock(header as Uint8Array, body)
-        return block
+        return this.protocol.getBlockByHash(blockHash, includeTransactions)
       } catch {
         return 'Block not found'
       }

--- a/packages/portalnetwork/src/subprotocols/contentLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/contentLookup.ts
@@ -1,5 +1,5 @@
 import { ENR, distance, NodeId, EntryStatus } from '@chainsafe/discv5'
-import { toHexString } from '@chainsafe/ssz'
+import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Debugger } from 'debug'
 import { serializedContentKeyToContentId, shortId } from '../util'
 import { BaseProtocol } from './protocol'
@@ -35,8 +35,10 @@ export class ContentLookup {
     this.protocol.client.metrics?.totalContentLookups.inc()
     try {
       const res = await this.protocol.client.db.get(this.contentId)
-      return res
-    } catch {}
+      return fromHexString(res)
+    } catch (err) {
+      this.logger(err)
+    }
     this.protocol.routingTable.nearest(this.contentId, 5).forEach((peer) => {
       try {
         const dist = distance(peer.nodeId, this.contentId)

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -108,7 +108,10 @@ export class HistoryProtocol extends BaseProtocol {
     }
   }
 
-  public getBlockByHash = async (blockHash: string, includeTransactions: boolean) => {
+  public getBlockByHash = async (
+    blockHash: string,
+    includeTransactions: boolean
+  ): Promise<Block | undefined> => {
     const headerContentKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: 0,
       value: { chainId: 1, blockHash: fromHexString(blockHash) },
@@ -127,7 +130,7 @@ export class HistoryProtocol extends BaseProtocol {
       let lookup = new ContentLookup(this, headerContentKey)
       header = await lookup.startLookup()
       if (!header) {
-        return 'block not found'
+        undefined
       }
       if (!includeTransactions) {
         body = rlp.encode([[], []])

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -145,6 +145,12 @@ export class HistoryProtocol extends BaseProtocol {
                 resolve(block)
               }
             })
+          } else if (body) {
+            block = reassembleBlock(header, fromHexString(body))
+            resolve(block)
+          } else {
+            block = reassembleBlock(header, rlp.encode([[], []]))
+            resolve(block)
           }
         })
       }

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -152,6 +152,12 @@ export class HistoryProtocol extends BaseProtocol {
                 resolve(block)
               }
             })
+            setTimeout(() => {
+              // Body lookup didn't return within 2 seconds so timeout and return header
+              this.client.removeAllListeners('ContentAdded')
+              block = reassembleBlock(header, rlp.encode([[], []]))
+              resolve(block)
+            }, 2000)
           } else {
             // Assume we weren't able to find the block body and just return the header
             block = reassembleBlock(header, rlp.encode([[], []]))

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -34,8 +34,7 @@ export const getHistoryNetworkContentId = (
  */
 export const reassembleBlock = (rawHeader: Uint8Array, rawBody: Uint8Array) => {
   const decodedBody = rlp.decode(rawBody)
-  //@ts-ignore
-  return Block.fromValuesArray(
+  const block = Block.fromValuesArray(
     //@ts-ignore
     [
       rlp.decode(Buffer.from(rawHeader)),
@@ -43,6 +42,8 @@ export const reassembleBlock = (rawHeader: Uint8Array, rawBody: Uint8Array) => {
       (decodedBody as Buffer[])[1],
     ] as BlockBuffer
   )
+
+  return block
 }
 
 /**

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/HistoryNetworkContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/HistoryNetworkContentRequest.ts
@@ -1,5 +1,4 @@
 import { UtpSocket } from '..'
-import { HistoryNetworkContentKey, HistoryNetworkContentKeyUnionType } from '../../..'
 import ContentReader from '../Protocol/read/ContentReader'
 import ContentWriter from '../Protocol/write/ContentWriter'
 import { sendSynPacket } from '../Packets/PacketSenders'
@@ -10,8 +9,8 @@ export type ContentRequest = HistoryNetworkContentRequest // , StateNetwork..., 
 
 export class HistoryNetworkContentRequest {
   requestCode: RequestCode
-  contentKey: HistoryNetworkContentKey
-  contentKeys: HistoryNetworkContentKey[]
+  contentKey: Uint8Array
+  contentKeys: Uint8Array[]
   socket: UtpSocket
   sockets: UtpSocket[]
   socketKey: string
@@ -28,9 +27,7 @@ export class HistoryNetworkContentRequest {
   ) {
     this.sockets = socket
     //@ts-ignore
-    this.contentKeys = contentKey.map((k) => {
-      return HistoryNetworkContentKeyUnionType.deserialize(Uint8Array.from(k)).value
-    })
+    this.contentKeys = contentKey
     this.requestCode = requestCode
     this.contentKey = this.contentKeys[0]
     this.content = content[0]

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/PortalNetworkUTP.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/PortalNetworkUTP.ts
@@ -4,6 +4,7 @@ import { Debugger } from 'debug'
 import { bufferToPacket, ConnectionState, Packet, PacketType, randUint16, UtpSocket } from '..'
 import { ProtocolId } from '../../..'
 import { PortalNetwork } from '../../..'
+import { HistoryNetworkContentKeyUnionType } from '../../../subprotocols/history'
 import { HistoryProtocol } from '../../../subprotocols/history/history'
 import { sendFinPacket } from '../Packets/PacketSenders'
 import { BasicUtp } from '../Protocol/BasicUtp'
@@ -468,13 +469,13 @@ export class PortalNetworkUTP {
   async handleFinPacket(request: HistoryNetworkContentRequest, packet: Packet) {
     const requestCode = request.requestCode
     const streamer = async (content: Uint8Array) => {
+      const contentKey = HistoryNetworkContentKeyUnionType.deserialize(request.contentKey)
       await (
         this.portal.protocols.get(ProtocolId.HistoryNetwork)! as HistoryProtocol
       ).addContentToHistory(
-        request.contentKey.chainId,
-        // TODO: Fix contentKey so it's not deserialized so we can infer the content type instead of hardcoding it
-        1,
-        toHexString(request.contentKey.blockHash),
+        contentKey.value.chainId,
+        contentKey.selector,
+        toHexString(contentKey.value.blockHash),
         content
       )
     }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/PortalNetworkUTP.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/PortalNetworkUTP.ts
@@ -472,7 +472,8 @@ export class PortalNetworkUTP {
         this.portal.protocols.get(ProtocolId.HistoryNetwork)! as HistoryProtocol
       ).addContentToHistory(
         request.contentKey.chainId,
-        0,
+        // TODO: Fix contentKey so it's not deserialized so we can infer the content type instead of hardcoding it
+        1,
         toHexString(request.contentKey.blockHash),
         content
       )


### PR DESCRIPTION
- Converts `HistoryContentLookup` to `getBlockByHash` within `HistoryProtocol`
- Adjusts `cli` and `browser-client` to use `historyProtocol.getBlockByHash`
- Resolves issue in uTP where contentType was hardcoded to `BlockHeader` instead of following the content type defined in the `contentKey` used when creating the uTP socket.
- Adds better support for local testing with browser clients.  
 
To validate:
1) Start up some local `cli` clients using the `devnet` script
2) Run `npx ts-node scripts/seeder.ts --rpcPort=8546 --blockHash=0xc628e74fda3d533428e2954d27f3d5a7bcefc34fe27c7bf09446bf5e86e6d1cb --sourceFile="./blocks200000-210000.json" --numNodes=1` and adjust the file location to one of your choosing (block hash as well though this one is known to be very large and will initiate uTP)
3) Run `npx ts-node scripts/seeder.ts --rpcPort=8546  --sourceFile="./blocks200000-210000.json" --numNodes=2 ` to connect the two nodes
4) Run `curlie 127.0.0.1:8547 jsonrpc=2.0 id=1 method=eth_getBlockByHash params:='["0xc628e74fda3d533428e2954d27f3d5a7bcefc34fe27c7bf09446bf5e86e6d1cb",true]'` to validate that it works between CLI clients
5) Get the ENR for one of the `cli` clients - `curlie 127.0.0.1:8547 jsonrpc=2.0 id=1 method=portal_nodeEnr`
6) Start up the browser client using the `npm run start-local` script and connect to this client using the browser client
7) The `browser-client` should update it's ENR to reflect its observed IP address.  You can then start another browser client and connect to it using this client's ENR
8) Search for the above block hash using the browser client and you should retrieve it's header and display in the block explorer

There is another bug related to uTP that I haven't fully triaged yet that prevents uTP from working consistently for nodes with invalid IP/Ports that is unrelated to this PR and shouldn't hold up merging it.