### PR TITLE
Add proof of concept for importing block headers from a full node

### DIFF
--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -5,11 +5,12 @@ import {
   HistoryNetworkContentKeyUnionType,
   ENR,
   fromHexString,
+  addRLPSerializedBlock,
 } from 'portalnetwork'
-import { addRLPSerializedBlock } from 'portalnetwork'
+
 import { isValidId } from './util'
 import { HistoryProtocol } from 'portalnetwork/src/subprotocols/history/history'
-
+import { Client as RpcClient } from 'jayson/promise'
 export class RPCManager {
   public _client: PortalNetwork
   public protocol: HistoryProtocol


### PR DESCRIPTION
Adds support for passing JSON RPC calls through to a web3 provider if not a supported method call within `portalnetwork`.