### PR TITLE
client: set bucketRefresh interval on start

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -198,9 +198,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
    */
   public start = async () => {
     await this.discv5.start()
-    // Start kbucket refresh on 30 second interval
-    //this.refreshListener = setInterval(() => this.bucketRefresh(), 30000)
     this.protocols.forEach((protocol) => {
+      // Start kbucket refresh on 30 second interval
+      setInterval(() => protocol.bucketRefresh(), 30000)
       this.bootnodes.forEach(async (peer: string) => {
         await protocol.addBootNode(peer)
       })

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -580,7 +580,7 @@ export abstract class BaseProtocol {
    * 3: Randomly generate a NodeID that falls within this bucket.
    * Do the random lookup on this node-id.
    */
-  private bucketRefresh = async () => {
+  public bucketRefresh = async () => {
     const notFullBuckets = this.routingTable.buckets
       .map((bucket, idx) => {
         return { bucket: bucket, distance: idx }


### PR DESCRIPTION
bucket refresh was disabled in recent refactor

This PR brings back `setInterval()` for bucket refresh as part of `client.start()`

`protocol.bucketRefresh()` was set to `private`, and was unaccessable from client.  making this method `public` solved the issue.  

If we prefer this method to remain private we will have to move the setInterval() call into `protocol` itself 