### PR TITLE
Add header accumulator to History Protocol

### DIFF
--- a/packages/cli/scripts/buildAccumulator.ts
+++ b/packages/cli/scripts/buildAccumulator.ts
@@ -1,0 +1,15 @@
+import { Client } from 'jayson/promise'
+import { BlockHeader } from '@ethereumjs/block'
+import { fromHexString } from 'portalnetwork'
+const main = async () => {
+    const web3 = Client.http({ host: '127.0.0.1', port: 8546 })
+    const ultralight = Client.http({ host: '127.0.0.1', port: 8545 })
+    for (let x = 1; x < 5; x++) {
+        const web3res = await web3.request('debug_getHeaderRlp', [x])
+        const header = BlockHeader.fromRLPSerializedHeader(Buffer.from(fromHexString(web3res.result)))
+        const res2 = await ultralight.request('portal_addBlockHeaderToHistory', ['0x'+ header.hash().toString('hex'),web3res.result])
+        console.log(res2)
+    }
+}
+
+main()

--- a/packages/cli/scripts/seeder.ts
+++ b/packages/cli/scripts/seeder.ts
@@ -2,6 +2,7 @@ import { Client } from 'jayson/promise'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import fs from 'fs'
+import { ProtocolId } from 'portalnetwork'
 
 const args: any = yargs(hideBin(process.argv))
     .option('sourceFile', {
@@ -48,7 +49,7 @@ const main = async () => {
 
   for (let x = 1; x < args.numNodes; x++) {
     const _client = Client.http({ port: args.rpcPort + x })
-    const res = await _client.request('portal_ping', [bootNodeEnr.result])
+    const res = await _client.request('portal_ping', [bootNodeEnr.result, ProtocolId.HistoryNetwork])
     console.log(res)
     if (res.error) {
       throw new Error('should not error here')

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -14,7 +14,6 @@ import { HistoryNetworkContentTypes } from 'portalnetwork/dist/subprotocols/hist
 
 export class RPCManager {
   public _client: PortalNetwork
-  public protocol: HistoryProtocol
   private log: Debugger
   private _methods: { [key: string]: Function } = {
     discv5_nodeInfo: async () => {
@@ -27,25 +26,36 @@ export class RPCManager {
         `eth_getBlockByHash request received. blockHash: ${blockHash} includeTransactions: ${includeTransactions}`
       )
       try {
-        const block = await this.protocol.getBlockByHash(blockHash, includeTransactions)
+        const protocol = this._client.protocols.get(
+          ProtocolId.HistoryNetwork
+        ) as never as HistoryProtocol
+        const block = await protocol.getBlockByHash(blockHash, includeTransactions)
         return block ?? 'Block not found'
       } catch {
         return 'Block not found'
       }
     },
-    portal_addBootNode: async (params: [string]) => {
-      const [enr] = params
+    portal_addBootNode: async (params: [string, string]) => {
+      const [enr, protocolId] = params
       const encodedENR = ENR.decodeTxt(enr)
       this.log(
         `portal_addBootNode request received for NodeID: ${encodedENR.nodeId.slice(0, 15)}...`
       )
-      await this.protocol.addBootNode(enr)
-      return `Bootnode added for ${encodedENR.nodeId.slice(0, 15)}...`
+      const protocol = this._client.protocols.get(protocolId as ProtocolId)
+      if (protocol) {
+        await protocol.addBootNode(enr)
+        return `Bootnode added for ${encodedENR.nodeId.slice(0, 15)}...`
+      } else {
+        return `ProtocolID ${protocolId} not supported`
+      }
     },
     portal_addBlockToHistory: async (params: [string, string]) => {
       const [blockHash, rlpHex] = params
+      const protocol = this._client.protocols.get(
+        ProtocolId.HistoryNetwork
+      ) as never as HistoryProtocol
       try {
-        addRLPSerializedBlock(rlpHex, blockHash, this.protocol)
+        addRLPSerializedBlock(rlpHex, blockHash, protocol)
         return `blockheader for ${blockHash} added to content DB`
       } catch (err: any) {
         this.log(`Error trying to load block to DB. ${err.message.toString()}`)
@@ -77,27 +87,39 @@ export class RPCManager {
         return 'Unable to generate ENR'
       }
     },
-    portal_findNodes: async (params: [string, number[]]) => {
-      const [dstId, distances] = params
+    portal_findNodes: async (params: [string, number[], string]) => {
+      const [dstId, distances, protocolId] = params
       if (!isValidId(dstId)) {
         return 'invalid node id'
       }
+      const protocol = this._client.protocols.get(protocolId as ProtocolId)
+      if (!protocol) {
+        return `ProtocolID ${protocolId} not supported`
+      }
       this.log(`portal_findNodes request received with these distances ${distances.toString()}`)
-      const res = await this.protocol.sendFindNodes(dstId, distances)
+      const res = await protocol.sendFindNodes(dstId, distances)
       this.log(`response received to findNodes ${res?.toString()}`)
       return `${res?.total ?? 0} nodes returned`
     },
-    portal_ping: async (params: [string]) => {
-      const [enr] = params
+    portal_ping: async (params: [string, string]) => {
+      const [enr, protocolId] = params
+      const protocol = this._client.protocols.get(protocolId as ProtocolId)
+      if (!protocol) {
+        return `ProtocolID ${protocolId} not supported`
+      }
       const encodedENR = ENR.decodeTxt(enr)
       this.log(`portal_ping request received`)
-      await this.protocol.sendPing(enr)
-      this.log(`TEST PONG received from ${encodedENR.nodeId}`)
+      await protocol.sendPing(enr)
+      this.log(`PONG received from ${encodedENR.nodeId}`)
       return `PING/PONG successful with ${encodedENR.nodeId}`
     },
-    portal_history_findContent: async (params: [string, Uint8Array]) => {
-      const [enr, contentKey] = params
-      const res = await this.protocol.sendFindContent(enr, contentKey)
+    portal_history_findContent: async (params: [string, Uint8Array, string]) => {
+      const [enr, contentKey, protocolId] = params
+      const protocol = this._client.protocols.get(protocolId as ProtocolId)
+      if (!protocol) {
+        return `ProtocolID ${protocolId} not supported`
+      }
+      const res = await protocol.sendFindContent(enr, contentKey)
       return res
     },
     portal_history_offer: async (params: [string, string[], number[]]) => {
@@ -120,73 +142,19 @@ export class RPCManager {
           },
         })
       })
-      const res = await this.protocol.sendOffer(dstId, contentKeys)
+      const protocol = this._client.protocols.get(
+        ProtocolId.HistoryNetwork
+      ) as never as HistoryProtocol
+      const res = await protocol.sendOffer(dstId, contentKeys)
       return res
     },
-    portal_utp_find_content_test: async (params: [string]) => {
-      this.log(`portal_utp_get_test request received`)
-      const [enr] = params
-      const encodedENR = ENR.decodeTxt(enr)
-      await this.protocol.sendFindContent(
-        encodedENR.nodeId,
-        HistoryNetworkContentKeyUnionType.serialize({
-          selector: 0,
-          value: {
-            chainId: 1,
-            blockHash: Uint8Array.from(
-              fromHexString('0x46b332ceda6777098fe7943929e76a5fcea772a866c0fb1d170ec65c46c7e3ae')
-            ),
-          },
-        })
-      )
-      await this.protocol.sendFindContent(
-        encodedENR.nodeId,
-        HistoryNetworkContentKeyUnionType.serialize({
-          selector: 1,
-          value: {
-            chainId: 1,
-            blockHash: Uint8Array.from(
-              fromHexString('0x0c1cf9b3d4aa3e20e12b355416a4e3202da53f54eaaafc882a7644e3e68127ec')
-            ),
-          },
-        })
-      )
-      await this.protocol.sendFindContent(
-        encodedENR.nodeId,
-        HistoryNetworkContentKeyUnionType.serialize({
-          selector: 1,
-          value: {
-            chainId: 1,
-            blockHash: Uint8Array.from(
-              fromHexString('0xca6063e4d9b37c2777233b723d9b08cf248e34a5ebf7f5720d59323a93eec14f')
-            ),
-          },
-        })
-      )
-      return `Some uTP happened`
-    },
-    portal_utp_offer_test: async (params: [string, string[], number[]]) => {
-      this.log(`portal_utp_offer_test request received`)
-      const [enr, blockhashes, contentTypes] = params
-      const encodedENR = ENR.decodeTxt(enr)
-      const contentKeys = blockhashes.map((blockhash, idx) => {
-        return HistoryNetworkContentKeyUnionType.serialize({
-          selector: contentTypes[idx],
-          value: {
-            chainId: 1,
-            blockHash: Uint8Array.from(fromHexString(blockhash)),
-          },
-        })
-      })
-
-      await this.protocol.sendOffer(encodedENR.nodeId, contentKeys)
-      return `Some uTP happened`
+    portal_headerAccumulator: async () => {
+      return
     },
   }
 
   constructor(client: PortalNetwork) {
     this._client = client
-    this.protocol = client.protocols.get(ProtocolId.HistoryNetwork) as never as HistoryProtocol
     this.log = debug(this._client.discv5.enr.nodeId.slice(0, 5)).extend('ultralight:RPC')
   }
 

--- a/packages/cli/src/rpc.ts
+++ b/packages/cli/src/rpc.ts
@@ -9,7 +9,8 @@ import {
 } from 'portalnetwork'
 
 import { isValidId } from './util'
-import { HistoryProtocol } from 'portalnetwork/src/subprotocols/history/history'
+import { HistoryProtocol } from 'portalnetwork/dist/subprotocols/history/history'
+import { HistoryNetworkContentTypes } from 'portalnetwork/dist/subprotocols/history/types'
 
 export class RPCManager {
   public _client: PortalNetwork
@@ -45,6 +46,22 @@ export class RPCManager {
       const [blockHash, rlpHex] = params
       try {
         addRLPSerializedBlock(rlpHex, blockHash, this.protocol)
+        return `blockheader for ${blockHash} added to content DB`
+      } catch (err: any) {
+        this.log(`Error trying to load block to DB. ${err.message.toString()}`)
+        return `internal error`
+      }
+    },
+    portal_addBlockHeaderToHistory: async (params: [string, string]) => {
+      const [blockHash, rlpHex] = params
+      try {
+        const protocol = this._client.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
+        protocol.addContentToHistory(
+          1,
+          HistoryNetworkContentTypes.BlockHeader,
+          blockHash,
+          fromHexString(rlpHex)
+        )
         return `blockheader for ${blockHash} added to content DB`
       } catch (err: any) {
         this.log(`Error trying to load block to DB. ${err.message.toString()}`)

--- a/packages/portalnetwork/diagrams/HEADER_ACCUMULATOR.md
+++ b/packages/portalnetwork/diagrams/HEADER_ACCUMULATOR.md
@@ -1,0 +1,17 @@
+# Header Accumulator Update Strategy -- *UNDER CONSTRUCTION*
+
+The `Header Accumulator` is used to verify that block headers received from other nodes are part of the canonical chain following [the spec](https://github.com/ethereum/portal-network-specs/blob/header-gossip-test-vectors/header-gossip-network.md).
+
+## Header Accumulator Construction
+
+When we're first starting up, we should begin building the accumulator from genesis using the below sequence, starting at height x = 1 until we reach some preferred height Y (maybe at least height 8193 -- start of Epoch 2)
+
+```mermaid
+    sequenceDiagram
+        loop every block until height Y
+            ultralight->>fullnode: eth_getBlockByNumber x+1
+            fullnode->>ultralight: BlockHeader at x+1
+            Note left of ultralight: Add header to accumulator
+        end
+```
+

--- a/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
@@ -77,7 +77,11 @@ export class HeaderAccumulator {
     return false
   }
 
+  /**
+   * Returns the current height of the chain contained in the accumulator.  Assumes first block is genesis
+   * so subtracts one from chain height since genesis block height is technically 0.
+   */
   public currentHeight = () => {
-    return this.historicalEpochs.length * EPOCH_SIZE + this.currentEpoch.length
+    return this.historicalEpochs.length * EPOCH_SIZE + this.currentEpoch.length - 1
   }
 }

--- a/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
@@ -1,5 +1,5 @@
 import { Proof } from '@chainsafe/persistent-merkle-tree'
-import { toHexString } from '@chainsafe/ssz'
+import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { BlockHeader } from '@ethereumjs/block'
 import { EpochAccumulator, EPOCH_SIZE, HeaderAccumulatorType, HeaderRecordType } from './types'
 
@@ -7,9 +7,21 @@ export class HeaderAccumulator {
   private _currentEpoch: HeaderRecordType[]
   private _historicalEpochs: Uint8Array[]
 
-  constructor() {
+  /**
+   *
+   * @param initFromGenesis boolean indicating whether to initialize the accumulator with the mainnet genesis block
+   */
+  constructor(initFromGenesis = false) {
     this._currentEpoch = []
     this._historicalEpochs = []
+    if (initFromGenesis) {
+      const genesisHeaderRlp =
+        '0xf90214a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000850400000000808213888080a011bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82faa00000000000000000000000000000000000000000000000000000000000000000880000000000000042'
+      const genesisHeader = BlockHeader.fromRLPSerializedHeader(
+        Buffer.from(fromHexString(genesisHeaderRlp))
+      )
+      this.updateAccumulator(genesisHeader)
+    }
   }
 
   public get currentEpoch() {
@@ -63,5 +75,9 @@ export class HeaderAccumulator {
     } catch { }
 
     return false
+  }
+
+  public currentHeight = () => {
+    return this.historicalEpochs.length * EPOCH_SIZE + this.currentEpoch.length
   }
 }

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -203,6 +203,9 @@ export class HistoryProtocol extends BaseProtocol {
           ) {
             // Update the header accumulator if the block header is the next in the chain
             this.accumulator.updateAccumulator(header)
+            this.logger(
+              `Updated header accumulator.  Currently at height ${this.accumulator.currentHeight()}`
+            )
           }
           this.client.db.put(contentId, toHexString(value))
         } catch (err: any) {

--- a/packages/portalnetwork/src/util/discv5.ts
+++ b/packages/portalnetwork/src/util/discv5.ts
@@ -6,4 +6,4 @@ export {
   log2Distance,
   distance,
 } from '@chainsafe/discv5'
-export { fromHexString } from '@chainsafe/ssz'
+export { toHexString, fromHexString } from '@chainsafe/ssz'


### PR DESCRIPTION
Replaces #273 

- instantiates the accumulator as a private member of the `History` protocol (per the current discussion among Portal Network devs)
- Adds a new script to feed headers into the DB from a locally paired full node
- Updates the accumulator if the `parentHash` and block number match
- Exposes a new RPC endpoint to return the current accumulator root hash

This is part one of the work on #281 