### PR TITLE
Canonical Block Index and getBlockByNumber

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -112,7 +112,7 @@ const main = async () => {
     radius: 2n ** 256n,
     db,
     metrics,
-    supportedProtocols: [ProtocolId.HistoryNetwork],
+    supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.CanonicalIndicesNetwork],
     dataDir: args.datadir,
   })
   portal.discv5.enableLogs()

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -28,6 +28,7 @@ import { CapacitorUDPTransportService, WebSocketTransportService } from '../tran
 import LRU from 'lru-cache'
 import { dirSize, MEGABYTE } from '../util'
 import { DBManager } from './dbManager'
+import { CanonicalIndicesProtocol } from '../subprotocols/canonicalIndices/canonicalIndices'
 
 export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEventEmitter }) {
   discv5: Discv5
@@ -153,6 +154,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
           break
         case ProtocolId.Rendezvous:
           this.supportsRendezvous = true
+          break
+        case ProtocolId.CanonicalIndicesNetwork:
+          this.protocols.set(protocol, new CanonicalIndicesProtocol(this))
           break
       }
     }

--- a/packages/portalnetwork/src/subprotocols/canonicalIndices/canonicalIndices.ts
+++ b/packages/portalnetwork/src/subprotocols/canonicalIndices/canonicalIndices.ts
@@ -1,0 +1,65 @@
+import { BlockHeader } from '@ethereumjs/block'
+import { Debugger } from 'debug'
+import { ProtocolId } from '..'
+import { PortalNetwork } from '../../client'
+import { toHexString } from '../../util/discv5'
+import { BaseProtocol } from '../protocol'
+
+export class CanonicalIndicesProtocol extends BaseProtocol {
+  logger: Debugger
+  readonly protocolId: ProtocolId
+  readonly protocolName: string
+  sendFindContent: undefined
+  private _blockIndex: string[]
+  constructor(client: PortalNetwork) {
+    super(client, 2n ** 256n)
+    this.logger = client.logger.extend('canonicalIndices')
+    this.protocolId = ProtocolId.CanonicalIndicesNetwork
+    this.protocolName = 'Canonical Indices'
+    this._blockIndex = []
+  }
+
+  /**
+   *
+   * @param blockNumber block number to retrieve hash for
+   * @returns blockhash or else undefined
+   */
+  public blockHash = (blockNumber: number) => {
+    if (blockNumber >= this._blockIndex.length || blockNumber < 0) {
+      return
+    }
+    return this._blockIndex[blockNumber - 1]
+  }
+
+  /**
+   *
+   * @param header header to be added to canonical index
+   * @returns true if header was next valid header, false otherwise
+   */
+  public incrementBlockIndex = (header: BlockHeader) => {
+    const blockHash = toHexString(Uint8Array.from(header.hash()))
+    let updated = false
+    if (
+      header.number.toNumber() === 1 &&
+      toHexString(Uint8Array.from(header.parentHash)) ===
+        '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
+    ) {
+      // Check for genesis block hash
+      this._blockIndex.push(blockHash)
+      updated = true
+    } else if (
+      header.number.toNumber() === this._blockIndex.length + 1 &&
+      toHexString(Uint8Array.from(header.parentHash)) ===
+        this._blockIndex[this._blockIndex.length - 1]
+    ) {
+      this._blockIndex.push(blockHash)
+      updated = true
+    }
+    if (updated) {
+      this.logger(
+        `Incremented block index to height: ${this._blockIndex.length} - Block Hash ${blockHash}`
+      )
+    }
+    return updated
+  }
+}

--- a/packages/portalnetwork/src/subprotocols/contentLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/contentLookup.ts
@@ -32,6 +32,8 @@ export class ContentLookup {
    * requests peers closer to the content until either the content is found or there are no more peers to query
    */
   public startLookup = async () => {
+    // Don't support content lookups for protocols that don't implement it (i.e. Canonical Indices)
+    if (!this.protocol.sendFindContent) return
     this.protocol.client.metrics?.totalContentLookups.inc()
     try {
       const res = await this.protocol.client.db.get(this.contentId)

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -30,15 +30,11 @@ export abstract class BaseProtocol {
   public routingTable: PortalNetworkRoutingTable | StateNetworkRoutingTable
   protected metrics: PortalNetworkMetrics | undefined
   private nodeRadius: bigint
-  abstract logger: Debugger
+  protected abstract logger: Debugger
   abstract protocolId: ProtocolId
   abstract protocolName: string
   public client: PortalNetwork
-  constructor(
-    client: PortalNetwork,
-    nodeRadius: bigint | undefined,
-    metrics?: PortalNetworkMetrics
-  ) {
+  constructor(client: PortalNetwork, nodeRadius?: bigint, metrics?: PortalNetworkMetrics) {
     this.client = client
     this.nodeRadius = nodeRadius ?? 2n ** 256n
     this.routingTable = new PortalNetworkRoutingTable(client.discv5.enr.nodeId)
@@ -545,7 +541,7 @@ export abstract class BaseProtocol {
     return
   }
 
-  abstract sendFindContent: (
+  abstract sendFindContent?: (
     dstId: string,
     key: Uint8Array
   ) => Promise<Union<Uint8Array | Uint8Array[]> | undefined>

--- a/packages/portalnetwork/test/subprotocols/protocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/protocol.spec.ts
@@ -4,7 +4,6 @@ import tape from 'tape'
 import td from 'testdouble'
 import {
   ENR,
-  FindNodesMessage,
   generateRandomNodeIdAtDistance,
   MessageCodes,
   NodesMessage,
@@ -18,7 +17,6 @@ import { HistoryProtocol } from '../../src/subprotocols/history/history'
 import { BaseProtocol } from '../../src/subprotocols/protocol'
 import { Debugger } from 'debug'
 import PeerId from 'peer-id'
-import { toHexString } from '@chainsafe/ssz'
 import { INodeAddress } from '@chainsafe/discv5/lib/session/nodeInfo'
 
 // Fake Protocol class for testing Protocol class


### PR DESCRIPTION
- Introduces a first version of the Canonical Indices protocol
- Builds canonical block index along side building header accumulator
- Exposes `eth_getBlockByNumber` via rpc in `cli` (though does not support `latest` or `earliest` parameter types