### PR TITLE
Switch accumulator to multiproofs

### DIFF
--- a/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
@@ -86,6 +86,11 @@ export class HeaderAccumulator {
     return false
   }
 
+  /**
+   *
+   * @param blockHash blockhash of header used in proof
+   * @returns a merkle multiproof representing the header at the last position in the current epoch
+   */
   public generateInclusionProof = (blockHash: string) => {
     const position = this._currentEpoch.findIndex(
       (record) => toHexString(record.blockHash) === blockHash

--- a/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/headerGossip/headerAccumulator.ts
@@ -61,6 +61,7 @@ export class HeaderAccumulator {
    * @returns true if proof is valid, false otherwise
    */
   public verifyInclusionProof = (proof: Proof, header: BlockHeader, blockPosition: number) => {
+    // Rewind current epoch to point where block header is last header in `currentEpoch`
     const historicalAccumulator = HeaderAccumulatorType.toView({
       historicalEpochs: this._historicalEpochs,
       currentEpoch: this._currentEpoch.slice(0, blockPosition + 1),
@@ -85,6 +86,7 @@ export class HeaderAccumulator {
     return false
   }
 
+  public generateHeaderProof = block
   /**
    * Returns the current height of the chain contained in the accumulator.  Assumes first block is genesis
    * so subtracts one from chain height since genesis block height is technically 0.

--- a/packages/portalnetwork/test/subprotocols/headerGossip/headerAccumulator.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/headerGossip/headerAccumulator.spec.ts
@@ -2,12 +2,7 @@ import tape from 'tape'
 import { HeaderAccumulator, HeaderAccumulatorType } from '../../../src/subprotocols/headerGossip'
 import { BlockHeader } from '@ethereumjs/block'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import {
-  deserializeProof,
-  serializeProof,
-  createProof,
-  ProofType,
-} from '@chainsafe/persistent-merkle-tree'
+import { createProof, ProofType } from '@chainsafe/persistent-merkle-tree'
 
 tape('Validate accumulator updates', (t) => {
   const accumulator = new HeaderAccumulator()

--- a/packages/portalnetwork/test/subprotocols/headerGossip/headerAccumulator.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/headerGossip/headerAccumulator.spec.ts
@@ -37,15 +37,7 @@ tape('Validate accumulator updates', (t) => {
     'roots match after Block 2'
   )
 
-  const tree = HeaderAccumulatorType.toView(accumulator)
-
-  const multiProof = createProof(tree.node, {
-    type: ProofType.multi,
-    gindices: HeaderAccumulatorType.tree_createProofGindexes(tree.node, [
-      ['currentEpoch', 2, 'blockHash'],
-      ['currentEpoch', 2, 'totalDifficulty'],
-    ]),
-  })
+  const multiProof = accumulator.generateInclusionProof(toHexString(block2Header.hash()))
 
   t.ok(
     accumulator.verifyInclusionProof(multiProof, block2Header, 2),


### PR DESCRIPTION
- Use multiproofs instead of tree-offset proofs in header accumulator
- Add new `generateInclusionProof` to generate header proofs from current epoch