### PR TITLE
Upgrade level to modern versions everywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4651,27 +4651,52 @@
       }
     },
     "node_modules/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
       "dependencies": {
-        "buffer": "^6.0.3",
-        "catering": "^2.0.0",
-        "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
+      }
+    },
+    "node_modules/abstract-leveldown/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/abstract-leveldown/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/accepts": {
@@ -5498,9 +5523,9 @@
       ]
     },
     "node_modules/browserslist": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
-      "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+      "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5512,11 +5537,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001349",
-        "electron-to-chromium": "^1.4.147",
-        "escalade": "^3.1.1",
+        "caniuse-lite": "^1.0.30001358",
+        "electron-to-chromium": "^1.4.164",
         "node-releases": "^2.0.5",
-        "picocolors": "^1.0.0"
+        "update-browserslist-db": "^1.0.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5853,6 +5877,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
+    },
+    "node_modules/classic-level": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
+      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/clean-css": {
       "version": "5.3.0",
@@ -6511,15 +6551,64 @@
       "dev": true
     },
     "node_modules/deferred-leveldown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "dependencies": {
-        "abstract-leveldown": "^7.2.0",
+        "abstract-leveldown": "~6.2.1",
         "inherits": "^2.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
+      }
+    },
+    "node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deferred-leveldown/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/deferred-leveldown/node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -6786,9 +6875,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.5.tgz",
-      "integrity": "sha512-gC4kPr/Mf7QbeE5NAo1AC4Zg/SXLnW0ttlyzhVdyB2aErBspWh231UhHLJUlOdaVNqitdbnppdaXjoZHsR5QzQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
+      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6804,9 +6893,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.164",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.164.tgz",
-      "integrity": "sha512-K7iy5y6XyP9Pzh3uaDti0KC4JUNT6T1tLG5RTOmesqq2YgAJpYYYJ32m+anvZYjCV35llPTEh87kvEV/uSsiyQ=="
+      "version": "1.4.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.165.tgz",
+      "integrity": "sha512-DKQW1lqUSAYQvn9dnpK7mWaDpWbNOXQLXhfCi7Iwx0BKxdZOxkKcCyKw1l3ihWWW5iWSxKKbhEUoNRoHvl/hbA=="
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "16.11.41",
@@ -6869,17 +6958,17 @@
       }
     },
     "node_modules/encoding-down": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
-      "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
       "dependencies": {
-        "abstract-leveldown": "^7.2.0",
+        "abstract-leveldown": "^6.2.1",
         "inherits": "^2.0.3",
-        "level-codec": "^10.0.0",
-        "level-errors": "^3.0.0"
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/end-of-stream": {
@@ -8815,6 +8904,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -9823,16 +9917,15 @@
       }
     },
     "node_modules/level": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level/-/level-7.0.1.tgz",
-      "integrity": "sha512-w3E64+ALx2eZf8RV5JL4kIcE0BFAvQscRYd1yU4YVqZN9RGTQxXSvH202xvK15yZwFFxRXe60f13LJjcJ//I4Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
       "dependencies": {
-        "level-js": "^6.1.0",
-        "level-packager": "^6.0.1",
-        "leveldown": "^6.1.0"
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=12"
       },
       "funding": {
         "type": "opencollective",
@@ -9840,81 +9933,93 @@
       }
     },
     "node_modules/level-codec": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
-      "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "dependencies": {
-        "buffer": "^6.0.3"
+        "buffer": "^5.6.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-codec/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/level-concat-iterator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-      "dependencies": {
-        "catering": "^2.1.0"
-      },
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/level-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dependencies": {
+        "errno": "~0.1.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/level-iterator-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
       "dependencies": {
         "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/level-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
-      "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.3",
-        "ltgt": "^2.1.2",
-        "run-parallel-limit": "^1.1.0"
+        "node": ">=6"
       }
     },
     "node_modules/level-mem": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-6.0.1.tgz",
-      "integrity": "sha512-IBliILfS59qDUibuGs/jCD0loih0oI0+5pmvsZ0Yxa/SWBEEgVT70dKnArEo7UdOciUHEcyD07LEx5Ox5QHIMg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
       "dependencies": {
-        "level-packager": "^6.0.1",
-        "memdown": "^6.1.1"
+        "level-packager": "^5.0.3",
+        "memdown": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/level-packager": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-6.0.1.tgz",
-      "integrity": "sha512-8Ezr0XM6hmAwqX9uu8IGzGNkWz/9doyPA8Oo9/D7qcMI6meJC+XhIbNYHukJhIn8OGdlzQs/JPcL9B8lA2F6EQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
       "dependencies": {
-        "encoding-down": "^7.1.0",
-        "levelup": "^5.1.1"
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/level-supports": {
@@ -9950,42 +10055,30 @@
         "node": ">=6"
       }
     },
-    "node_modules/leveldown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
-      "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/levelup": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
       "dependencies": {
-        "catering": "^2.0.0",
-        "deferred-leveldown": "^7.0.0",
-        "level-errors": "^3.0.1",
-        "level-iterator-stream": "^5.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/levelup/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -10228,19 +10321,93 @@
       }
     },
     "node_modules/memdown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-6.1.1.tgz",
-      "integrity": "sha512-vh2RiuVrn6Vv73088C1KzLwy9+hhRwoZsgddYqIoVuFFrcoc2Rt+lq/KrmkFn6ulko7AtQ0AvqtYid35exb38A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
       "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
-        "functional-red-black-tree": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ltgt": "^2.2.0"
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       }
+    },
+    "node_modules/memdown/node_modules/abstract-leveldown": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/memdown/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/memdown/node_modules/immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg=="
+    },
+    "node_modules/memdown/node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/memdown/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/memfs": {
       "version": "3.4.6",
@@ -10252,6 +10419,19 @@
       },
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
+      "dependencies": {
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/merge-descriptors": {
@@ -10287,233 +10467,6 @@
         "readable-stream": "^3.6.0",
         "semaphore-async-await": "^1.5.1"
       }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/abstract-leveldown": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
-      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "dependencies": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/encoding-down": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-      "dependencies": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg=="
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-codec": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-      "dependencies": {
-        "errno": "~0.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-mem": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
-      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
-      "dependencies": {
-        "level-packager": "^5.0.3",
-        "memdown": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-packager": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-      "dependencies": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/level-supports": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-      "dependencies": {
-        "xtend": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/levelup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-      "dependencies": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/memdown": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
-      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
-      "dependencies": {
-        "abstract-leveldown": "~6.2.1",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/memdown/node_modules/abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/merkle-patricia-tree/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -13795,9 +13748,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.0.tgz",
-      "integrity": "sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
+      "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -14131,6 +14084,31 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+      "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -15061,7 +15039,7 @@
         "@ethereumjs/block": "^3.6.0",
         "debug": "^4.3.3",
         "jayson": "^3.6.6",
-        "level": "^7.0.1",
+        "level": "^8.0.0",
         "multiaddr": "^10.0.0",
         "peer-id": "^0.16.0",
         "portalnetwork": "^0.0.1",
@@ -15140,8 +15118,8 @@
         "bigint-buffer": "^1.1.5",
         "debug": "^4.3.2",
         "isomorphic-ws": "^4.0.1",
-        "level-mem": "^6.0.1",
         "lru-cache": "^7.10.1",
+        "memory-level": "^1.0.0",
         "multiaddr": "^10.0.1",
         "peer-id": "^0.16.0",
         "prom-client": "^14.0.1",
@@ -18783,22 +18761,33 @@
       }
     },
     "abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
       "requires": {
-        "buffer": "^6.0.3",
-        "catering": "^2.0.0",
-        "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
         "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA=="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "requires": {
+            "xtend": "^4.0.2"
+          }
         }
       }
     },
@@ -19508,15 +19497,14 @@
       }
     },
     "browserslist": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
-      "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+      "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001349",
-        "electron-to-chromium": "^1.4.147",
-        "escalade": "^3.1.1",
+        "caniuse-lite": "^1.0.30001358",
+        "electron-to-chromium": "^1.4.164",
         "node-releases": "^2.0.5",
-        "picocolors": "^1.0.0"
+        "update-browserslist-db": "^1.0.0"
       }
     },
     "bs58": {
@@ -19753,6 +19741,18 @@
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
+    "classic-level": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
+      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -19786,7 +19786,7 @@
         "debug": "^4.3.3",
         "eslint": "^8.6.0",
         "jayson": "^3.6.6",
-        "level": "^7.0.1",
+        "level": "^8.0.0",
         "multiaddr": "^10.0.0",
         "peer-id": "^0.16.0",
         "portalnetwork": "^0.0.1",
@@ -20342,12 +20342,43 @@
       "dev": true
     },
     "deferred-leveldown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-      "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "requires": {
-        "abstract-leveldown": "^7.2.0",
+        "abstract-leveldown": "~6.2.1",
         "inherits": "^2.0.3"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        }
       }
     },
     "define-lazy-prop": {
@@ -20560,9 +20591,9 @@
       "dev": true
     },
     "electron": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.5.tgz",
-      "integrity": "sha512-gC4kPr/Mf7QbeE5NAo1AC4Zg/SXLnW0ttlyzhVdyB2aErBspWh231UhHLJUlOdaVNqitdbnppdaXjoZHsR5QzQ==",
+      "version": "19.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
+      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",
@@ -20579,9 +20610,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.164",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.164.tgz",
-      "integrity": "sha512-K7iy5y6XyP9Pzh3uaDti0KC4JUNT6T1tLG5RTOmesqq2YgAJpYYYJ32m+anvZYjCV35llPTEh87kvEV/uSsiyQ=="
+      "version": "1.4.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.165.tgz",
+      "integrity": "sha512-DKQW1lqUSAYQvn9dnpK7mWaDpWbNOXQLXhfCi7Iwx0BKxdZOxkKcCyKw1l3ihWWW5iWSxKKbhEUoNRoHvl/hbA=="
     },
     "elementtree": {
       "version": "0.1.7",
@@ -20631,14 +20662,14 @@
       "dev": true
     },
     "encoding-down": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
-      "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
       "requires": {
-        "abstract-leveldown": "^7.2.0",
+        "abstract-leveldown": "^6.2.1",
         "inherits": "^2.0.3",
-        "level-codec": "^10.0.0",
-        "level-errors": "^3.0.0"
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
       }
     },
     "end-of-stream": {
@@ -22099,6 +22130,11 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -22810,73 +22846,72 @@
       "dev": true
     },
     "level": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level/-/level-7.0.1.tgz",
-      "integrity": "sha512-w3E64+ALx2eZf8RV5JL4kIcE0BFAvQscRYd1yU4YVqZN9RGTQxXSvH202xvK15yZwFFxRXe60f13LJjcJ//I4Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
       "requires": {
-        "level-js": "^6.1.0",
-        "level-packager": "^6.0.1",
-        "leveldown": "^6.1.0"
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
       }
     },
     "level-codec": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
-      "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "requires": {
-        "buffer": "^6.0.3"
+        "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "level-concat-iterator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-      "requires": {
-        "catering": "^2.1.0"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
     },
     "level-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-      "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ=="
-    },
-    "level-iterator-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-      "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "errno": "~0.1.1"
       }
     },
-    "level-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
-      "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
+    "level-iterator-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
       "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.3",
-        "ltgt": "^2.1.2",
-        "run-parallel-limit": "^1.1.0"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
       }
     },
     "level-mem": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-6.0.1.tgz",
-      "integrity": "sha512-IBliILfS59qDUibuGs/jCD0loih0oI0+5pmvsZ0Yxa/SWBEEgVT70dKnArEo7UdOciUHEcyD07LEx5Ox5QHIMg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
       "requires": {
-        "level-packager": "^6.0.1",
-        "memdown": "^6.1.1"
+        "level-packager": "^5.0.3",
+        "memdown": "^5.0.0"
       }
     },
     "level-packager": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-6.0.1.tgz",
-      "integrity": "sha512-8Ezr0XM6hmAwqX9uu8IGzGNkWz/9doyPA8Oo9/D7qcMI6meJC+XhIbNYHukJhIn8OGdlzQs/JPcL9B8lA2F6EQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
       "requires": {
-        "encoding-down": "^7.1.0",
-        "levelup": "^5.1.1"
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
       }
     },
     "level-supports": {
@@ -22903,33 +22938,25 @@
         "xtend": "^4.0.1"
       }
     },
-    "leveldown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
-      "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
-      "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      }
-    },
     "levelup": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-      "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
       "requires": {
-        "catering": "^2.0.0",
-        "deferred-leveldown": "^7.0.0",
-        "level-errors": "^3.0.1",
-        "level-iterator-stream": "^5.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA=="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "requires": {
+            "xtend": "^4.0.2"
+          }
         }
       }
     },
@@ -23130,15 +23157,57 @@
       "dev": true
     },
     "memdown": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-6.1.1.tgz",
-      "integrity": "sha512-vh2RiuVrn6Vv73088C1KzLwy9+hhRwoZsgddYqIoVuFFrcoc2Rt+lq/KrmkFn6ulko7AtQ0AvqtYid35exb38A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
       "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "buffer": "^6.0.3",
-        "functional-red-black-tree": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ltgt": "^2.2.0"
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg=="
+        },
+        "level-supports": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+          "requires": {
+            "xtend": "^4.0.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "memfs": {
@@ -23148,6 +23217,16 @@
       "dev": true,
       "requires": {
         "fs-monkey": "^1.0.3"
+      }
+    },
+    "memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
+      "requires": {
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
       }
     },
     "merge-descriptors": {
@@ -23179,169 +23258,6 @@
         "level-ws": "^2.0.0",
         "readable-stream": "^3.6.0",
         "semaphore-async-await": "^1.5.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
-          "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "immediate": "^3.2.3",
-            "level-concat-iterator": "~2.0.0",
-            "level-supports": "~1.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-          "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-          "requires": {
-            "abstract-leveldown": "~6.2.1",
-            "inherits": "^2.0.3"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "6.2.3",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-              "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-              "requires": {
-                "buffer": "^5.5.0",
-                "immediate": "^3.2.3",
-                "level-concat-iterator": "~2.0.0",
-                "level-supports": "~1.0.0",
-                "xtend": "~4.0.0"
-              }
-            }
-          }
-        },
-        "encoding-down": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-          "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-          "requires": {
-            "abstract-leveldown": "^6.2.1",
-            "inherits": "^2.0.3",
-            "level-codec": "^9.0.0",
-            "level-errors": "^2.0.0"
-          }
-        },
-        "immediate": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg=="
-        },
-        "level-codec": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-          "requires": {
-            "buffer": "^5.6.0"
-          }
-        },
-        "level-concat-iterator": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-          "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
-        },
-        "level-errors": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-          "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-          "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0",
-            "xtend": "^4.0.2"
-          }
-        },
-        "level-mem": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
-          "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
-          "requires": {
-            "level-packager": "^5.0.3",
-            "memdown": "^5.0.0"
-          }
-        },
-        "level-packager": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-          "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-          "requires": {
-            "encoding-down": "^6.3.0",
-            "levelup": "^4.3.2"
-          }
-        },
-        "level-supports": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-          "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-          "requires": {
-            "xtend": "^4.0.2"
-          }
-        },
-        "levelup": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-          "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-          "requires": {
-            "deferred-leveldown": "~5.3.0",
-            "level-errors": "~2.0.0",
-            "level-iterator-stream": "~4.0.0",
-            "level-supports": "~1.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
-        "memdown": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
-          "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
-          "requires": {
-            "abstract-leveldown": "~6.2.1",
-            "functional-red-black-tree": "~1.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.2.0"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "6.2.3",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-              "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-              "requires": {
-                "buffer": "^5.5.0",
-                "immediate": "^3.2.3",
-                "level-concat-iterator": "~2.0.0",
-                "level-supports": "~1.0.0",
-                "xtend": "~4.0.0"
-              }
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
       }
     },
     "methods": {
@@ -24251,8 +24167,8 @@
         "debug": "^4.3.2",
         "eslint": "^8.6.0",
         "isomorphic-ws": "^4.0.1",
-        "level-mem": "^6.0.1",
         "lru-cache": "^7.10.1",
+        "memory-level": "^1.0.0",
         "multiaddr": "^10.0.1",
         "nyc": "^15.1.0",
         "peer-id": "^0.16.0",
@@ -25912,9 +25828,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.0.tgz",
-      "integrity": "sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
+      "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -26145,6 +26061,15 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+      "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "@ethereumjs/block": "^3.6.0",
     "debug": "^4.3.3",
     "jayson": "^3.6.6",
-    "level": "^7.0.1",
+    "level": "^8.0.0",
     "multiaddr": "^10.0.0",
     "peer-id": "^0.16.0",
     "portalnetwork": "^0.0.1",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,8 +10,7 @@ import * as PromClient from 'prom-client'
 import debug from 'debug'
 import { RPCManager } from './rpc'
 import { setupMetrics } from './metrics'
-
-const level = require('level')
+import { Level } from 'level'
 
 const args: any = yargs(hideBin(process.argv))
   .option('pk', {
@@ -94,8 +93,8 @@ const main = async () => {
   const log = debug(enr.nodeId.slice(0, 5)).extend('ultralight')
   const metrics = setupMetrics()
   let db
-  if (args.datadir) {
-    db = level(args.datadir)
+  if (args.dataDir) {
+    db = new Level<string, string>(args.dataDir)
   }
 
   const portal = await PortalNetwork.create({
@@ -110,6 +109,7 @@ const main = async () => {
       },
     },
     radius: 2n ** 256n,
+    //@ts-ignore Because level doesn't know how to get along with itself
     db,
     metrics,
     supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.CanonicalIndicesNetwork],

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -28,7 +28,7 @@
     "bigint-buffer": "^1.1.5",
     "debug": "^4.3.2",
     "isomorphic-ws": "^4.0.1",
-    "level-mem": "^6.0.1",
+    "memory-level": "^1.0.0",
     "lru-cache": "^7.10.1",
     "multiaddr": "^10.0.1",
     "peer-id": "^0.16.0",

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -1,15 +1,15 @@
-//eslint-disable-next-line implicit-dependencies/no-implicit
 import { AbstractBatchOperation, AbstractLevel } from 'abstract-level'
 import { Debugger } from 'debug'
-const level = require('level-mem')
+import { MemoryLevel } from 'memory-level'
 
 export class DBManager {
-  db: AbstractLevel<string>
+  db: AbstractLevel<string, string>
   logger: Debugger
   currentSize: () => Promise<number>
 
   constructor(logger: Debugger, currentSize: () => Promise<number>, db?: AbstractLevel<string>) {
-    this.db = db ?? level()
+    //@ts-ignore Because level doesn't know how to get along with itself
+    this.db = db ?? new MemoryLevel()
     this.logger = logger.extend('DB')
     this.currentSize = currentSize
   }
@@ -25,7 +25,7 @@ export class DBManager {
   }
 
   batch(ops: AbstractBatchOperation<string, string, string>[]) {
-    //@ts-ignore
+    //@ts-ignore Because level doesn't know how to get along with itself
     return this.db.batch(ops)
   }
 

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -21,7 +21,7 @@ export interface PortalNetworkOpts {
   supportedProtocols: ProtocolId[]
   radius?: bigint
   bootnodes?: string[]
-  db?: AbstractLevel<string>
+  db?: AbstractLevel<string, string> | undefined
   metrics?: PortalNetworkMetrics
   bindAddress?: string
   transport?: TransportLayer


### PR DESCRIPTION
Upgrades `level` in both `cli` and `portalnetwork` to use theoretically `Abstractlevel` compliant versions though Typescript still doesn't agree.