### PR TITLE
Fix invalid ENR management

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -137,6 +137,7 @@ export const App = () => {
     let node: PortalNetwork
     if (process.env.BINDADDRESS) {
       node = await PortalNetwork.create({
+        supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.CanonicalIndicesNetwork],
         proxyAddress: proxy,
         db: LDB as any,
         transport: TransportLayer.WEB,


### PR DESCRIPTION
Fixes a bug in our routing table management where an ENR that had no reachable UDP socket was incorrectly added to the routing table instead of the unverified sessions cache.