### PR TITLE
Set node radius within maximum bound

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -108,7 +108,7 @@ const main = async () => {
         allowUnverifiedSessions: true,
       },
     },
-    radius: 2n ** 256n,
+    radius: 2n ** 256n - 1n,
     //@ts-ignore Because level doesn't know how to get along with itself
     db,
     metrics,

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -36,7 +36,7 @@ export abstract class BaseProtocol {
   public client: PortalNetwork
   constructor(client: PortalNetwork, nodeRadius?: bigint, metrics?: PortalNetworkMetrics) {
     this.client = client
-    this.nodeRadius = nodeRadius ?? 2n ** 256n
+    this.nodeRadius = nodeRadius ?? 2n ** 256n - 1n
     this.routingTable = new PortalNetworkRoutingTable(client.discv5.enr.nodeId)
     this.metrics = metrics
     if (this.metrics) {
@@ -152,7 +152,7 @@ export abstract class BaseProtocol {
   private sendPong = async (src: INodeAddress, requestId: bigint) => {
     const payload = {
       enrSeq: this.client.discv5.enr.seq,
-      customPayload: PingPongCustomDataType.serialize({ radius: BigInt(this.nodeRadius) }),
+      customPayload: PingPongCustomDataType.serialize({ radius: this.nodeRadius }),
     }
     const pongMsg = PortalWireMessageType.serialize({
       selector: MessageCodes.PONG,


### PR DESCRIPTION
Our node radius was being set to 2^256 which is actually outside the bounds of what a node's radius should be so was being coded as 0 in the outbound PONG messages.  This sets our default node radius to 2^256 - 1 so node radius comes back as a reasonable number.