### PR TITLE
Point discv5 back to master branch

### DIFF
--- a/packages/browser-client/webpack.config.js
+++ b/packages/browser-client/webpack.config.js
@@ -58,6 +58,6 @@ module.exports = {
         new webpack.ProvidePlugin({
             process: 'process/browser',
         }),
-        new webpack.EnvironmentPlugin({ BINDADDRESS : '' })
+        new webpack.EnvironmentPlugin({ BINDADDRESS : '' , NODE_BACKEND : 'js'})
     ],
 };

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.3.1",
-    "@chainsafe/discv5": "acolytec3/discv5#c5f9026abbfe73b915659055fb3d2afca8e341de",
+    "@chainsafe/discv5": "^1.1.1",
     "@chainsafe/persistent-merkle-tree": "^0.4.1",
     "@chainsafe/ssz": "^0.9.1",
     "@ethereumjs/block": "^4.0.0-beta.2",


### PR DESCRIPTION
I finally found a setting within `bcrypto` to help webpack know which bindings to use so have updated this and the browser client will now compile and work with the `discv5` master branch again.  Will remove our fork of discv5 from `package.json` and allow us to build off master again.