### PR TITLE
fix: set correct max within the `randUint16` function and remove unused `randUint32` function

### DIFF
--- a/packages/portalnetwork/src/wire/utp/Utils/math.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/math.ts
@@ -15,9 +15,6 @@ export function Bytes32TimeStamp(): number {
 export function randUint16(): Uint16 {
   return Math.floor(Math.random() * (2 ** 16 - 1))
 }
-export function randUint32(): Uint16 {
-  return Math.floor(Math.random() * 2 ** 32)
-}
 
 export function bitLength(n: number): number {
   const bitstring = n.toString(2)

--- a/packages/portalnetwork/src/wire/utp/Utils/math.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/math.ts
@@ -13,7 +13,7 @@ export function Bytes32TimeStamp(): number {
 }
 
 export function randUint16(): Uint16 {
-  return Math.floor(Math.random() * 2 ** 16)
+  return Math.floor(Math.random() * (2 ** 16 - 1))
 }
 export function randUint32(): Uint16 {
   return Math.floor(Math.random() * 2 ** 32)


### PR DESCRIPTION
Fixes #274 