### PR TITLE
Move handle find content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9751,12 +9751,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
-    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -13281,37 +13275,6 @@
         "tape": "bin/tape"
       }
     },
-    "node_modules/tape-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tape-promise/-/tape-promise-4.0.0.tgz",
-      "integrity": "sha512-mNi5yhWAKDuNgZCfFKeZbsXvraVOf+I8UZG+lf+aoRrzX4+jd4mpNBjYh16/VcpEMUtS0iFndBgnfxxZbtyLFw==",
-      "dev": true,
-      "dependencies": {
-        "is-promise": "^2.1.0",
-        "onetime": "^2.0.0"
-      }
-    },
-    "node_modules/tape-promise/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tape-promise/node_modules/onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/tape/node_modules/resolve": {
       "version": "2.0.0-next.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -14964,7 +14927,6 @@
         "eslint": "^8.6.0",
         "prettier": "^2.5.1",
         "tape": "^5.5.3",
-        "tape-promise": "^4.0.0",
         "testdouble": "^3.16.3",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
@@ -22339,12 +22301,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -23703,7 +23659,6 @@
         "rlp": "^4.0.0-beta.2",
         "strict-event-emitter-types": "^2.0.0",
         "tape": "^5.5.3",
-        "tape-promise": "^4.0.0",
         "testdouble": "^3.16.3",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
@@ -25076,33 +25031,6 @@
             "is-core-module": "^2.9.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
-          }
-        }
-      }
-    },
-    "tape-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tape-promise/-/tape-promise-4.0.0.tgz",
-      "integrity": "sha512-mNi5yhWAKDuNgZCfFKeZbsXvraVOf+I8UZG+lf+aoRrzX4+jd4mpNBjYh16/VcpEMUtS0iFndBgnfxxZbtyLFw==",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0",
-        "onetime": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
           }
         }
       }

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -1,11 +1,12 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { ENR } from '@chainsafe/discv5/index.js'
+import { distance, ENR } from '@chainsafe/discv5/index.js'
+import { INodeAddress } from '@chainsafe/discv5/lib/session/nodeInfo.js'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { Debugger } from 'debug'
 import { ProtocolId } from '../types.js'
 import { PortalNetwork } from '../../client/client.js'
 import { PortalNetworkMetrics } from '../../client/types.js'
-import { shortId } from '../../util/index.js'
+import { serializedContentKeyToContentId, shortId } from '../../util/index.js'
 import { HeaderAccumulator } from './headerAccumulator.js'
 import {
   connectionIdType,
@@ -28,6 +29,7 @@ import {
 import { getHistoryNetworkContentId, reassembleBlock } from './util.js'
 import * as rlp from 'rlp'
 import { ReceiptsManager } from '../receipt.js'
+import { MAX_PACKET_SIZE, randUint16 } from '../../wire/utp/index.js'
 
 export class HistoryProtocol extends BaseProtocol {
   protocolId: ProtocolId
@@ -156,6 +158,103 @@ export class HistoryProtocol extends BaseProtocol {
       }
     } catch (err: any) {
       this.logger(`Error sending FINDCONTENT to ${shortId(dstId)} - ${err.message}`)
+    }
+  }
+
+  public handleFindContent = async (
+    src: INodeAddress,
+    requestId: bigint,
+    protocol: Buffer,
+    decodedContentMessage: FindContentMessage
+  ) => {
+    this.metrics?.contentMessagesSent.inc()
+    //Check to see if value in content db
+    const lookupKey = serializedContentKeyToContentId(decodedContentMessage.contentKey)
+    this.logger(`handleFindContent lookupKey ${toHexString(decodedContentMessage.contentKey)}`)
+
+    let value = Uint8Array.from([])
+    try {
+      value = Buffer.from(fromHexString(await this.client.db.get(lookupKey)))
+    } catch {}
+    if (value.length === 0) {
+      if (toHexString(protocol) === this.protocolId) {
+        // Discv5 calls for maximum of 16 nodes per NODES message
+        const ENRs = this.routingTable.nearest(lookupKey, 16)
+        const encodedEnrs = ENRs.map((enr) => {
+          // Only include ENR if not the ENR of the requesting node and the ENR is closer to the
+          // contentId than this node
+          return enr.nodeId !== src.nodeId &&
+            distance(enr.nodeId, lookupKey) < distance(this.client.discv5.enr.nodeId, lookupKey)
+            ? enr.encode()
+            : undefined
+        }).filter((enr) => enr !== undefined)
+        if (encodedEnrs.length > 0) {
+          this.logger(`Found ${encodedEnrs.length} closer to content than us`)
+          // TODO: Add capability to send multiple TALKRESP messages if # ENRs exceeds packet size
+          while (encodedEnrs.flat().length > 1200) {
+            // Remove ENRs until total ENRs less than 1200 bytes
+            encodedEnrs.pop()
+          }
+          const payload = ContentMessageType.serialize({
+            selector: 2,
+            value: encodedEnrs as Buffer[],
+          })
+          this.client.sendPortalNetworkResponse(
+            src,
+            requestId,
+            Buffer.concat([Buffer.from([MessageCodes.CONTENT]), payload])
+          )
+        } else {
+          this.logger(`Found no ENRs closer to content than us`)
+          this.client.sendPortalNetworkResponse(src, requestId, Uint8Array.from([]))
+        }
+      } else {
+        this.client.sendPortalNetworkResponse(src, requestId, Uint8Array.from([]))
+      }
+    } else if (value && value.length < MAX_PACKET_SIZE) {
+      this.logger(
+        'Found value for requested content ' +
+          Buffer.from(decodedContentMessage.contentKey).toString('hex') +
+          value.slice(0, 10) +
+          `...`
+      )
+      const payload = ContentMessageType.serialize({
+        selector: 1,
+        value: value,
+      })
+      this.logger.extend('CONTENT')(`Sending requested content to ${src.nodeId}`)
+      this.logger(Uint8Array.from(value))
+      this.client.sendPortalNetworkResponse(
+        src,
+        requestId,
+        Buffer.concat([Buffer.from([MessageCodes.CONTENT]), Buffer.from(payload)])
+      )
+    } else {
+      this.logger.extend('FOUNDCONTENT')(
+        'Found value for requested content.  Larger than 1 packet.  uTP stream needed.' +
+          Buffer.from(decodedContentMessage.contentKey).toString('hex') +
+          value.slice(0, 10) +
+          `...`
+      )
+      const _id = randUint16()
+      this.client.uTP.logger(`Generating Random Connection Id...`, _id)
+      await this.client.uTP.handleNewRequest({
+        contentKeys: [decodedContentMessage.contentKey],
+        peerId: src.nodeId,
+        connectionId: _id,
+        requestCode: RequestCode.FOUNDCONTENT_WRITE,
+        contents: [value],
+      })
+
+      const id = connectionIdType.serialize(_id)
+      this.logger.extend('FOUNDCONTENT')(`Sent message with CONNECTION ID: ${_id}.`)
+      this.client.uTP.logger('Waiting for SYN Packet')
+      const payload = ContentMessageType.serialize({ selector: 0, value: id })
+      this.client.sendPortalNetworkResponse(
+        src,
+        requestId,
+        Buffer.concat([Buffer.from([MessageCodes.CONTENT]), Buffer.from(payload)])
+      )
     }
   }
 

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -1,5 +1,5 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { distance, ENR } from '@chainsafe/discv5/index.js'
+import { distance, ENR } from '@chainsafe/discv5'
 import { INodeAddress } from '@chainsafe/discv5/lib/session/nodeInfo.js'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { Debugger } from 'debug'

--- a/packages/portalnetwork/src/subprotocols/rendezvous/rendezvous.ts
+++ b/packages/portalnetwork/src/subprotocols/rendezvous/rendezvous.ts
@@ -23,6 +23,10 @@ export class Rendezvous extends BaseProtocol {
     return Promise.resolve()
   }
 
+  //@ts-ignore
+  public handleFindContent(): any {
+    return Promise.resolve()
+  }
   public sendFindContent = (_dstId: string, _key: Uint8Array) => {
     return Promise.resolve(undefined)
   }

--- a/packages/portalnetwork/test/subprotocols/protocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/protocol.spec.ts
@@ -35,6 +35,7 @@ class FakeProtocol extends BaseProtocol {
   }
   sendFindContent = td.func<any>()
   init = td.func<any>()
+  handleFindContent = td.func<any>()
 }
 
 tape('protocol wire message tests', async (t) => {


### PR DESCRIPTION
We had some history protocol specific stuff seep into `handleFindContent` so I think it makes sense to make this a subprotocol specific method so we can do more specific handling within each subprotocol.  I'm motivated mainly by the fact that we want to start validating headers against our accumulator and this should be done in handleFindContent if possible.