### PR TITLE
Fix message length computation

### DIFF
--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -241,12 +241,8 @@ export abstract class BaseProtocol {
             if (enr.nodeId === src.nodeId) return true
             // Break from loop if total size of NODES payload would exceed 1200 bytes
             // TODO: Decide what to do about case where we have more ENRs we could send
-            this.logger(
-              `# ENRs in message ${
-                nodesPayload.enrs.length
-              } and length of payload ${arrayByteLength(nodesPayload.enrs)}`
-            )
-            if (arrayByteLength(nodesPayload.enrs) + enr.size > 1200) return false
+
+            if (arrayByteLength(nodesPayload.enrs) + enr.encode().length > 1200) return false
             nodesPayload.total++
             nodesPayload.enrs.push(enr.encode())
             return true

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -11,6 +11,7 @@ import {
   shortId,
   serializedContentKeyToContentId,
   generateRandomNodeIdAtDistance,
+  arrayByteLength,
 } from '../util/index.js'
 import {
   AcceptMessage,
@@ -230,7 +231,7 @@ export abstract class BaseProtocol {
         enrs: [],
       }
       payload.distances.every((distance) => {
-        if (distance === 0 && nodesPayload.enrs.flat().length < 1200) {
+        if (distance === 0 && arrayByteLength(nodesPayload.enrs) < 1200) {
           // Send the client's ENR if a node at distance 0 is requested
           nodesPayload.total++
           nodesPayload.enrs.push(this.client.discv5.enr.encode())
@@ -240,7 +241,12 @@ export abstract class BaseProtocol {
             if (enr.nodeId === src.nodeId) return true
             // Break from loop if total size of NODES payload would exceed 1200 bytes
             // TODO: Decide what to do about case where we have more ENRs we could send
-            if (nodesPayload.enrs.flat().length + enr.size > 1200) return false
+            this.logger(
+              `# ENRs in message ${
+                nodesPayload.enrs.length
+              } and length of payload ${arrayByteLength(nodesPayload.enrs)}`
+            )
+            if (arrayByteLength(nodesPayload.enrs) + enr.size > 1200) return false
             nodesPayload.total++
             nodesPayload.enrs.push(enr.encode())
             return true
@@ -461,7 +467,7 @@ export abstract class BaseProtocol {
         if (encodedEnrs.length > 0) {
           this.logger(`Found ${encodedEnrs.length} closer to content than us`)
           // TODO: Add capability to send multiple TALKRESP messages if # ENRs exceeds packet size
-          while (encodedEnrs.flat().length > 1200) {
+          while (encodedEnrs.length > 0 && arrayByteLength(encodedEnrs) > 1200) {
             // Remove ENRs until total ENRs less than 1200 bytes
             encodedEnrs.pop()
           }

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -49,3 +49,8 @@ export const dirSize = async (directory: string) => {
   )
   return bytesSize / MEGABYTE
 }
+
+export const arrayByteLength = (byteArray: Uint8Array[]) => {
+  const length = byteArray.reduce((prev, curr) => prev + curr.byteLength, 0)
+  return length
+}

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -50,7 +50,7 @@ export const dirSize = async (directory: string) => {
   return bytesSize / MEGABYTE
 }
 
-export const arrayByteLength = (byteArray: Uint8Array[]) => {
-  const length = byteArray.reduce((prev, curr) => prev + curr.byteLength, 0)
+export function arrayByteLength(byteArray: any[]): number {
+  const length = byteArray.reduce((prev, curr) => prev + curr.length, 0)
   return length
 }

--- a/packages/portalnetwork/test/subprotocols/protocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/protocol.spec.ts
@@ -280,4 +280,22 @@ tape('handleFindNodes message handler tests', async (t) => {
     )
   )
   t.pass('Nodes response contained 3 ENRs since one more ENR added to bucket 256')
+
+  await (protocol as any).handleFindNodes({ socketAddr: new Multiaddr(), nodeId: newNode }, 1n, {
+    distances: [239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 255, 256],
+  })
+
+  td.verify(
+    node.sendPortalNetworkResponse(
+      { socketAddr: new Multiaddr(), nodeId: newNode },
+      1n,
+      td.matchers.argThat((arg: Uint8Array) => {
+        const msg = PortalWireMessageType.deserialize(arg).value as NodesMessage
+        return msg.enrs.length === 10
+      })
+    )
+  )
+  t.pass(
+    'Nodes response contained 10 ENRs even though requested nodes in 12 buckets since nodes max payload size met'
+  )
 })

--- a/packages/portalnetwork/test/util/util.spec.ts
+++ b/packages/portalnetwork/test/util/util.spec.ts
@@ -12,7 +12,9 @@ tape('utility method tests', (t) => {
   randomNodeId = generateRandomNodeIdAtDistance(nodeId, 25)
   t.ok(log2Distance(nodeId, randomNodeId) === 25, 'calculated random node id at distance 25')
 
-  const arrayOfByteArrays = [Uint8Array.from([1, 2, 3]), Uint8Array.from([1, 2])]
-  t.equal(arrayByteLength(arrayOfByteArrays), 5, 'computed correct length of nested Uint8Array')
+  const arrayOfUint8Arrays = [Uint8Array.from([1, 2, 3]), Uint8Array.from([1, 2])]
+  const arrayOfBuffers = [Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3, 4, 5])]
+  t.equal(arrayByteLength(arrayOfUint8Arrays), 5, 'computed correct length of nested Uint8Arrays')
+  t.equal(arrayByteLength(arrayOfBuffers), 8, 'computed correct length of nested Buffers')
   t.end()
 })

--- a/packages/portalnetwork/test/util/util.spec.ts
+++ b/packages/portalnetwork/test/util/util.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { shortId, generateRandomNodeIdAtDistance } from '../../src/util/index.js'
+import { shortId, generateRandomNodeIdAtDistance, arrayByteLength } from '../../src/util/index.js'
 import { log2Distance } from '@chainsafe/discv5'
 tape('utility method tests', (t) => {
   const nodeId = '82418605a77ea8c8f47802d71661d3812ff64e70fd2fc5f0ff57a113185b2c41'
@@ -11,5 +11,8 @@ tape('utility method tests', (t) => {
   t.ok(log2Distance(nodeId, randomNodeId) === 255, 'calculated random node ID at distance 255')
   randomNodeId = generateRandomNodeIdAtDistance(nodeId, 25)
   t.ok(log2Distance(nodeId, randomNodeId) === 25, 'calculated random node id at distance 25')
+
+  const arrayOfByteArrays = [Uint8Array.from([1, 2, 3]), Uint8Array.from([1, 2])]
+  t.equal(arrayByteLength(arrayOfByteArrays), 5, 'computed correct length of nested Uint8Array')
   t.end()
 })


### PR DESCRIPTION
This fixes the logic for computing the length of the ENRs messages sent in the `handleFindNodes` and `handleFindContent` message handlers.