### PR TITLE
Fix get block no body

### DIFF
--- a/packages/browser-client/src/Components/GetBlockByNumber.tsx
+++ b/packages/browser-client/src/Components/GetBlockByNumber.tsx
@@ -15,8 +15,6 @@ export default function GetBlockByNumber(props: IGetBlockByNumberProps) {
 
   const portal = useContext(PortalContext)
 
-  // Adapted from rpc method in cli.
-
   async function eth_getBlockByNumber(blockNumber: string, includeTransactions: boolean) {
     try {
       const history = portal.protocols.get(ProtocolId.HistoryNetwork) as never as HistoryProtocol

--- a/packages/portalnetwork/src/subprotocols/contentLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/contentLookup.ts
@@ -39,7 +39,7 @@ export class ContentLookup {
       const res = await this.protocol.client.db.get(this.contentId)
       return fromHexString(res)
     } catch (err) {
-      // this.logger(err)
+      this.logger(err)
     }
     this.protocol.routingTable.nearest(this.contentId, 5).forEach((peer: any) => {
       try {

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -239,7 +239,7 @@ export class HistoryProtocol extends BaseProtocol {
       let lookup = new ContentLookup(this, headerContentKey)
       header = await lookup.startLookup()
       if (!header) {
-        undefined
+        return undefined
       }
       if (!includeTransactions) {
         block = reassembleBlock(header, rlp.encode([[], []]))
@@ -272,7 +272,7 @@ export class HistoryProtocol extends BaseProtocol {
             }, 2000)
           } else {
             // Assume we weren't able to find the block body and just return the header
-            block = reassembleBlock(header, rlp.encode([[], []]))
+            block = reassembleBlock(header)
             resolve(block)
           }
         })
@@ -322,7 +322,6 @@ export class HistoryProtocol extends BaseProtocol {
               `Found EpochAccumulator with blockHash for block ${blockNumber}`
             )
             const epoch = EpochAccumulator.deserialize(fromHexString(content))
-            this.logger.extend(`ETH_GETBLOCKBYNUMBER`)
             blockHash = toHexString(epoch[blockIndex].blockHash)
             try {
               const block = await this.getBlockByHash(blockHash, includeTransactions)

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -86,19 +86,27 @@ export const sszEncodeBlockBody = (block: Block) => {
  * @param rawBody RLP encoded block body consisting of transactions and uncles as nested Uint8Arrays
  * @returns a `Block` object assembled from the header and body provided
  */
-export const reassembleBlock = (rawHeader: Uint8Array, rawBody: Uint8Array) => {
-  const decodedBody = decodeSszBlockBody(rawBody)
-  const block = Block.fromValuesArray(
-    //@ts-ignore
-    [
+export const reassembleBlock = (rawHeader: Uint8Array, rawBody?: Uint8Array) => {
+  if (rawBody) {
+    const decodedBody = decodeSszBlockBody(rawBody)
+    const block = Block.fromValuesArray(
+      [
+        rlp.decode(Buffer.from(rawHeader)),
+        decodedBody.txsRlp,
+        rlp.decode(decodedBody.unclesRlp),
+      ] as BlockBuffer,
+      { hardforkByBlockNumber: true }
+    )
+    return block
+  } else {
+    const blockBuffer: BlockBuffer = [
       rlp.decode(Buffer.from(rawHeader)),
-      decodedBody.txsRlp,
-      rlp.decode(decodedBody.unclesRlp),
-    ] as BlockBuffer,
-    { hardforkByBlockNumber: true }
-  )
-
-  return block
+      rlp.decode(Buffer.from(Uint8Array.from([]))),
+      rlp.decode(Buffer.from(Uint8Array.from([]))),
+    ] as BlockBuffer
+    const block = Block.fromValuesArray(blockBuffer, { hardforkByBlockNumber: true })
+    return block
+  }
 }
 
 /**

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -113,7 +113,7 @@ function connectAndTest(
   })
 }
 
-tape('Portal Network Wire Spec Integration Tests', (t) => {
+tape('Integration Tests -- PING/PONG', (t) => {
   t.test('clients start and connect to each other', (st) => {
     const ping = async (portal1: PortalNetwork, portal2: PortalNetwork) => {
       const protocol = portal2.protocols.get(ProtocolId.HistoryNetwork)
@@ -123,7 +123,9 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
     }
     connectAndTest(t, st, ping)
   })
+})
 
+tape('Integration -- FINDCONTENT/FOUNDCONTENT', (t) => {
   t.test('Nodes should stream content with FINDCONTENT / FOUNDCONTENT', (st) => {
     const findBlocks = async (
       portal1: PortalNetwork,
@@ -222,7 +224,9 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
     }
     connectAndTest(t, st, findBlocks, true)
   })
+})
 
+tape('FINDCONTENT/FOUNDCONTENT -- Accumulator Snapshots', (t) => {
   t.test('Nodes should share accumulator snapshot with FINDCONTENT / FOUNDCONTENT', (st) => {
     const findAccumulator = async (
       portal1: PortalNetwork,
@@ -280,7 +284,9 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
     }
     connectAndTest(t, st, findAccumulator, true)
   })
+})
 
+tape('OFFER/ACCEPT', (t) => {
   t.test('Nodes should stream multiple blocks OFFER / ACCEPT', (st) => {
     const offerBlocks = async (
       portal1: PortalNetwork,
@@ -455,7 +461,9 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
     }
     connectAndTest(t, st, gossip, true)
   })
+})
 
+tape('getBlockByHash', (t) => {
   t.test('eth_getBlockByHash test', (st) => {
     const gossip = async (
       portal1: PortalNetwork,
@@ -525,11 +533,7 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
     connectAndTest(t, st, gossip, true)
   })
   t.test('eth_getBlockByHash test -- no body available', (st) => {
-    const getBlock = async (
-      portal1: PortalNetwork,
-      portal2: PortalNetwork,
-      child: ChildProcessWithoutNullStreams
-    ) => {
+    const getBlock = async (portal1: PortalNetwork, portal2: PortalNetwork) => {
       const protocol1 = portal1.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       const protocol2 = portal2.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       const testBlockData = require('./testBlock.json')
@@ -554,8 +558,7 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
       st.equal(_h, toHexString(testHeader), 'eth_getBlockByHash returned a Block Header')
 
       try {
-        const body = await portal2.db.get(getHistoryNetworkContentId(1, 1, testHash))
-        console.log(body)
+        await portal2.db.get(getHistoryNetworkContentId(1, 1, testHash))
         st.fail('should not find block body')
       } catch (e: any) {
         st.equal(
@@ -567,7 +570,9 @@ tape('Portal Network Wire Spec Integration Tests', (t) => {
     }
     connectAndTest(t, st, getBlock)
   })
+})
 
+tape('getBlockByNumber', (t) => {
   t.test('eth_getBlockByNumber test', (st) => {
     const findAccumulator = async (
       portal1: PortalNetwork,


### PR DESCRIPTION
Fix for eth_getBlockByHash

When header is returned but no block body is found -- eth_getBlockByHash should still return a block with an empty body.

We had this coded into the protocol, but we where throwing an error instead of returning the block.

This happened because we call `reassembleBlock` once both the header lookup and the body lookup have finished.  Within `reassembleBlock`, we would call `decodeSszBlockBody`, even on a failed lookup.  By making the `rawBody` parameter of `reassembleBlock` optional, we can bypass the call to decode a non-existent block body.  The return value will be a `Block` object with header info, but no info in the block body.
