### PR TITLE
Peer Tools in Network Tab

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -49,9 +49,11 @@ export const BlockContext = React.createContext({
   block: Block.prototype,
   setBlock: (() => {}) as React.Dispatch<React.SetStateAction<Block>>,
 })
+export const HistoryProtocolContext = React.createContext(HistoryProtocol.prototype)
 
 export const App = () => {
   const [portal, setPortal] = React.useState<PortalNetwork>()
+  const [historyProtocol, setHistoryProtocol] = React.useState<HistoryProtocol>()
   const [peers, setPeers] = React.useState<ENR[]>([])
   const [sortedDistList, setSortedDistList] = React.useState<[number, string[]][]>([])
   const [enr, setENR] = React.useState<string>('')

--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -21,6 +21,8 @@ import {
   ModalContent,
   Divider,
   ChakraProvider,
+  HStack,
+  Input,
 } from '@chakra-ui/react'
 import {
   PortalNetwork,
@@ -72,27 +74,26 @@ export const App = () => {
   const LDB = new BrowserLevel('ultralight_history', { prefix: '', version: 1 })
 
   function updateAddressBook() {
-    const protocol = portal?.protocols.get(ProtocolId.HistoryNetwork)
-    if (!protocol) return
-    const known = protocol.routingTable.values()
-    const formattedKnown = known!.map((_enr: ENR) => {
-      const distToSelf = log2Distance(id, _enr.nodeId)
-      return [
-        distToSelf,
-        `${_enr.ip}`,
-        `${_enr.getLocationMultiaddr('udp')?.nodeAddress().port}`,
-        _enr.nodeId,
-        _enr.encodeTxt(),
-      ]
-    })
-    //@ts-ignore
-    const sorted = formattedKnown.sort((a, b) => a[0] - b[0]) //@ts-ignore
-    const table: [number, string[]][] = sorted.map((d) => {
-      return [d[0], [d[1], d[2], d[3], d[4]]]
-    })
-    setSortedDistList(table)
-    const peers = protocol.routingTable.values()
-    setPeers(peers)
+    try {
+      const known = historyProtocol!.routingTable.values()
+      const formattedKnown: [number, string, string, string, string][] = known.map((_enr: ENR) => {
+        const distToSelf = log2Distance(id, _enr.nodeId)
+        return [
+          distToSelf,
+          `${_enr.ip}`,
+          `${_enr.getLocationMultiaddr('udp')?.nodeAddress().port}`,
+          _enr.nodeId,
+          _enr.encodeTxt(),
+        ]
+      })
+      const sorted = formattedKnown.sort((a: any, b: any) => a[0] - b[0])
+      const table: [number, string[]][] = sorted.map((d) => {
+        return [d[0], [d[1], d[2], d[3], d[4]]]
+      })
+      setSortedDistList(table)
+      const peers = historyProtocol!.routingTable.values()
+      setPeers(peers)
+    } catch {}
   }
 
   async function handleClick() {
@@ -179,6 +180,9 @@ export const App = () => {
     }
 
     setPortal(node)
+    try {
+      setHistoryProtocol(node.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol)
+    } catch {}
     node.enableLog('*Portal*, -*uTP*, -*FINDNODES*')
     await node.start()
     node.storeNodeDetails()
@@ -282,29 +286,50 @@ export const App = () => {
               </DrawerFooter>
             </DrawerContent>
           </Drawer>
+          {historyProtocol && (
+            <HStack border={'1px'} width={'100%'} paddingY={1}>
+              <Button width={'25%'} bgColor={'blue.100'} size={'xs'} onClick={handleClick}>
+                Connect to new peer
+              </Button>
+              <Input
+                width={'75%'}
+                size={'xs'}
+                type="text"
+                placeholder={'enr:IS...'}
+                value={peerEnr}
+                onChange={(e) => {
+                  setPeerEnr(e.target.value)
+                }}
+              />
+            </HStack>
+          )}
+          <Divider />
+
           <Box>
-            {portal && (
-              <BlockContext.Provider value={blockValue}>
-                <Layout
-                  copy={copy}
-                  onOpen={onOpen}
-                  enr={enr}
-                  peerEnr={peerEnr}
-                  setPeerEnr={setPeerEnr}
-                  handleClick={handleClick}
-                  invalidHash={invalidHash}
-                  getBlockByHash={getBlockByHash}
-                  blockHash={blockHash}
-                  setBlockHash={setBlockHash}
-                  findParent={findParent}
-                  block={block}
-                  peers={peers}
-                  sortedDistList={sortedDistList}
-                  capacitor={Capacitor}
-                />
-              </BlockContext.Provider>
+            {historyProtocol && (
+              <HistoryProtocolContext.Provider value={historyProtocol}>
+                <BlockContext.Provider value={blockValue}>
+                  <Layout
+                    copy={copy}
+                    onOpen={onOpen}
+                    enr={enr}
+                    peerEnr={peerEnr}
+                    setPeerEnr={setPeerEnr}
+                    handleClick={handleClick}
+                    invalidHash={invalidHash}
+                    getBlockByHash={getBlockByHash}
+                    blockHash={blockHash}
+                    setBlockHash={setBlockHash}
+                    findParent={findParent}
+                    block={block}
+                    peers={peers}
+                    sortedDistList={sortedDistList}
+                    capacitor={Capacitor}
+                    refresh={updateAddressBook}
+                  />
+                </BlockContext.Provider>
+              </HistoryProtocolContext.Provider>
             )}
-            <Button onClick={() => updateAddressBook()}>Update Address Book</Button>
           </Box>
           <Box width={'100%'} pos={'fixed'} bottom={'0'}>
             <Center>

--- a/packages/browser-client/src/Components/ContentManager.tsx
+++ b/packages/browser-client/src/Components/ContentManager.tsx
@@ -1,44 +1,58 @@
 import { Button } from '@chakra-ui/react'
+import { Block } from '@ethereumjs/block'
 import {
   PortalNetwork,
   addRLPSerializedBlock,
   getHistoryNetworkContentId,
   distance,
   ProtocolId,
+  fromHexString,
 } from 'portalnetwork'
 import { HistoryProtocol } from 'portalnetwork/dist/subprotocols/history/history'
-import React from 'react'
+import React, { useContext, useState } from 'react'
+import { BlockContext, HistoryProtocolContext, PortalContext } from '../App'
 
-interface ContentManagerProps {
-  portal: PortalNetwork | undefined
-}
-export const ContentManager: React.FC<ContentManagerProps> = ({ portal }) => {
+export default function ContentManager() {
+  // Add list of blocks to db from json file
+  // json:
+  // [
+  //   {
+  //     hash: "0xa7b7524f..."
+  //     rlp: "0x8ab3614cd62fe..."
+  //   },
+  //   {
+  //     hash: "0x725fac22..."
+  //     rlp: "0x3cd5ab36..."
+  //   }
+  // ]
+  const [newest, setNewest] = useState('')
+  const protocol = useContext(HistoryProtocolContext)
+  const portal = useContext(PortalContext)
+  const { setBlock } = useContext(BlockContext)
+  interface jsonblock {
+    hash: string
+    rlp: string
+  }
+
   const handleUpload = async (evt: React.ChangeEvent<HTMLInputElement>) => {
-    const protocol = portal?.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
     const files = evt.target.files
     const reader = new FileReader()
     if (files && files.length > 0) {
       reader.onload = async function () {
         if (reader.result) {
-          const data = JSON.parse(reader.result as string)
-          const arrayData = Object.entries(data)
+          const arrayData = JSON.parse(reader.result as string) as jsonblock[]
           arrayData
             .sort((a, b) => {
               const diff =
-                distance(
-                  BigInt('0x' + portal!.discv5.enr.nodeId),
-                  BigInt(getHistoryNetworkContentId(1, a[0], 0))
-                ) -
-                distance(
-                  BigInt('0x' + portal!.discv5.enr.nodeId),
-                  BigInt(getHistoryNetworkContentId(1, b[0], 0))
-                )
+                distance(BigInt('0x' + portal.discv5.enr.nodeId), BigInt(a.hash)) -
+                distance(BigInt('0x' + portal!.discv5.enr.nodeId), BigInt(b.hash))
               const res = diff < 0n ? -1 : 1
               return res
             })
             .slice(0, 10)
-            .forEach(async (block) => {
-              addRLPSerializedBlock((block[1] as any).rlp, block[0], protocol!)
+            .forEach(async (block, idx) => {
+              setNewest(block.rlp)
+              addRLPSerializedBlock(block.rlp, block.hash, protocol)
             })
         }
       }
@@ -52,8 +66,13 @@ export const ContentManager: React.FC<ContentManagerProps> = ({ portal }) => {
     fileInputEl.accept = 'application/json'
     fileInputEl.style.display = 'none'
     document.body.appendChild(fileInputEl)
-    fileInputEl.addEventListener('input', function (e) {
-      handleUpload(e as any)
+    fileInputEl.addEventListener('input', async (e) => {
+      await handleUpload(e as any)
+      setBlock(
+        Block.fromRLPSerializedBlock(Buffer.from(fromHexString(newest)), {
+          hardforkByBlockNumber: true,
+        })
+      )
       document.body.removeChild(fileInputEl)
     })
     fileInputEl.click()

--- a/packages/browser-client/src/Components/DevTools.tsx
+++ b/packages/browser-client/src/Components/DevTools.tsx
@@ -49,10 +49,6 @@ export default function DevTools(props: DevToolsProps) {
     sharing()
   }, [])
 
-  const addBootNode = () => {
-    portal.protocols.get(ProtocolId.HistoryNetwork)!.addBootNode(props.peerEnr)
-  }
-
   return (
     <VStack>
       {canShare ? (
@@ -65,41 +61,6 @@ export default function DevTools(props: DevToolsProps) {
         </Button>
       )}
       <ContentManager />
-
-      {props.native ? (
-        <Center>
-          <VStack>
-            <Button
-              isDisabled={!props.peerEnr.startsWith('enr:')}
-              width={'100%'}
-              onClick={addBootNode}
-            >
-              Connect To Node
-            </Button>
-            <Input
-              width={'100%'}
-              bg="whiteAlpha.800"
-              value={props.peerEnr}
-              placeholder={'Node ENR'}
-              onChange={(evt) => props.setPeerEnr(evt.target.value)}
-            />
-          </VStack>
-        </Center>
-      ) : (
-        <VStack width={'100%'} spacing={0} border="1px" borderRadius={'0.375rem'}>
-          <Input
-            size="sm"
-            bg="whiteAlpha.800"
-            value={props.peerEnr}
-            placeholder="Node ENR"
-            onChange={(evt) => props.setPeerEnr(evt.target.value)}
-            mb={2}
-          />
-          <Button width={'100%'} onClick={props.handleClick}>
-            Connect To Node
-          </Button>
-        </VStack>
-      )}
     </VStack>
   )
 }

--- a/packages/browser-client/src/Components/DevTools.tsx
+++ b/packages/browser-client/src/Components/DevTools.tsx
@@ -1,20 +1,9 @@
-import {
-  Input,
-  Heading,
-  Button,
-  Box,
-  VStack,
-  Divider,
-  Center,
-  useToast,
-  Select,
-} from '@chakra-ui/react'
-import { ProtocolId, ENR, fromHexString, HistoryNetworkContentKeyUnionType } from 'portalnetwork'
-import React, { Dispatch, SetStateAction, useContext, useState } from 'react'
-import ContentManager from './ContentManager'
 import { Share } from '@capacitor/share'
+import { Button, Center, Input, useToast, VStack } from '@chakra-ui/react'
+import { ENR, ProtocolId } from 'portalnetwork'
+import React, { Dispatch, SetStateAction, useContext, useState } from 'react'
 import { PortalContext } from '../App'
-import { HistoryProtocol } from 'portalnetwork/dist/subprotocols/history/history'
+import ContentManager from './ContentManager'
 
 interface DevToolsProps {
   peers: ENR[]
@@ -29,44 +18,14 @@ interface DevToolsProps {
 export default function DevTools(props: DevToolsProps) {
   const portal = useContext(PortalContext)
   const [canShare, setCanShare] = useState(false)
-  const peers = props.peers.map((p) => {
-    return p.nodeId
-  })
-  const [peer, _setPeer] = useState(peers[0])
-  const [targetNodeId, setTarget] = useState('')
-  const [distance, setDistance] = useState('')
-  const [blockHash, setBlockHash] = useState('')
   const toast = useToast()
-  const handlePing = () => {
-    const protocol = portal.protocols.get(ProtocolId.HistoryNetwork)!
-    const enr = protocol.routingTable.getValue(peer)
-    protocol.sendPing(enr!)
-  }
+
   async function share() {
     await Share.share({
       title: `Ultralight ENR`,
       text: props.enr,
       dialogTitle: `Share ENR`,
     })
-  }
-
-  const handleFindNodes = (nodeId: string) => {
-    const protocol = portal.protocols.get(ProtocolId.HistoryNetwork)
-    protocol!.sendFindNodes(nodeId, [parseInt(distance)])
-  }
-
-  const handleOffer = (nodeId: string) => {
-    if (blockHash.slice(0, 2) !== '0x') {
-      setBlockHash('')
-      toast({
-        title: 'Invalid content key',
-        description: 'Key must be hex prefixed',
-        status: 'warning',
-      })
-      return
-    }
-    const protocol = portal.protocols.get(ProtocolId.HistoryNetwork)
-    protocol!.sendOffer(nodeId, [fromHexString(blockHash)])
   }
 
   async function handleCopy() {
@@ -92,18 +51,6 @@ export default function DevTools(props: DevToolsProps) {
 
   const addBootNode = () => {
     portal.protocols.get(ProtocolId.HistoryNetwork)!.addBootNode(props.peerEnr)
-  }
-
-  const handleRequestSnapshot = () => {
-    const protocol: HistoryProtocol = portal.protocols.get(
-      ProtocolId.HistoryNetwork
-    ) as HistoryProtocol
-    protocol.logger('Requesting Accumulator Snapshot')
-    const accumulatorKey = HistoryNetworkContentKeyUnionType.serialize({
-      selector: 4,
-      value: { selector: 0, value: null },
-    })
-    protocol.sendFindContent(peer, accumulatorKey)
   }
 
   return (
@@ -153,55 +100,6 @@ export default function DevTools(props: DevToolsProps) {
           </Button>
         </VStack>
       )}
-      <Divider />
-      <Heading size="sm">Peer Tools</Heading>
-      <Box w="100%">
-        <Center>
-          <Heading size="xs">
-            Select Peer ({peers.indexOf(peer) + 1}/{peers.length})
-          </Heading>
-        </Center>
-        <Divider />
-        <Select value={peer} onChange={(evt) => _setPeer(evt.target.value)}>
-          {peers.map((_peer) => (
-            <option key={_peer} value={_peer}>
-              {_peer.slice(0, 25)}...
-            </option>
-          ))}
-        </Select>
-      </Box>
-      <Divider />
-      <Button isDisabled={!portal} size="sm" width="100%" onClick={() => handlePing()}>
-        Send Ping
-      </Button>
-      <Button isDisabled={!portal} size="sm" width="100%" onClick={() => handleRequestSnapshot()}>
-        Request Accumulator Snapshot
-      </Button>
-      <Divider />
-      <Input
-        placeholder={'Distance'}
-        onChange={(evt) => {
-          setDistance(evt.target.value)
-        }}
-      />
-      <Button isDisabled={!portal} size="sm" width="100%" onClick={() => handleFindNodes(peer)}>
-        Request Nodes from Peer
-      </Button>
-      <Divider />
-      <Input
-        value={blockHash}
-        placeholder="Content Key"
-        onChange={(evt) => setBlockHash(evt.target.value)}
-      />
-      <Button isDisabled={!portal} width={'100%'} size="sm" onClick={() => handleOffer(peer)}>
-        Send Offer
-      </Button>
-      <Divider />
-      <Input
-        placeholder="Target Node ID"
-        value={targetNodeId}
-        onChange={(evt) => setTarget(evt.target.value)}
-      />
     </VStack>
   )
 }

--- a/packages/browser-client/src/Components/DevTools.tsx
+++ b/packages/browser-client/src/Components/DevTools.tsx
@@ -1,6 +1,6 @@
 import { Share } from '@capacitor/share'
-import { Button, Center, Input, useToast, VStack } from '@chakra-ui/react'
-import { ENR, ProtocolId } from 'portalnetwork'
+import { Button, useToast, VStack } from '@chakra-ui/react'
+import { ENR } from 'portalnetwork'
 import React, { Dispatch, SetStateAction, useContext, useState } from 'react'
 import { PortalContext } from '../App'
 import ContentManager from './ContentManager'

--- a/packages/browser-client/src/Components/DevTools.tsx
+++ b/packages/browser-client/src/Components/DevTools.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react'
 import { ProtocolId, ENR, fromHexString, HistoryNetworkContentKeyUnionType } from 'portalnetwork'
 import React, { Dispatch, SetStateAction, useContext, useState } from 'react'
-import { ContentManager } from './ContentManager'
+import ContentManager from './ContentManager'
 import { Share } from '@capacitor/share'
 import { PortalContext } from '../App'
 import { HistoryProtocol } from 'portalnetwork/dist/subprotocols/history/history'
@@ -117,7 +117,7 @@ export default function DevTools(props: DevToolsProps) {
           COPY ENR
         </Button>
       )}
-      <ContentManager portal={portal} />
+      <ContentManager />
 
       {props.native ? (
         <Center>

--- a/packages/browser-client/src/Components/GetBlockByNumber.tsx
+++ b/packages/browser-client/src/Components/GetBlockByNumber.tsx
@@ -2,7 +2,7 @@ import { Button, FormControl, HStack, Input } from '@chakra-ui/react'
 import { ProtocolId } from 'portalnetwork'
 import { HistoryProtocol } from 'portalnetwork/dist/subprotocols/history/history'
 import React, { Dispatch, SetStateAction, useContext, useState } from 'react'
-import { BlockContext, PortalContext } from '../App'
+import { BlockContext, HistoryProtocolContext } from '../App'
 
 interface IGetBlockByNumberProps {
   setBlockHash: Dispatch<SetStateAction<string>>
@@ -10,14 +10,12 @@ interface IGetBlockByNumberProps {
 }
 
 export default function GetBlockByNumber(props: IGetBlockByNumberProps) {
-  const [searchNumber, setSearchNumber] = useState('0')
+  const history = useContext(HistoryProtocolContext)
+  const [searchNumber, setSearchNumber] = useState(history.accumulator.currentHeight().toString())
   const { setBlock } = useContext(BlockContext)
-
-  const portal = useContext(PortalContext)
 
   async function eth_getBlockByNumber(blockNumber: string, includeTransactions: boolean) {
     try {
-      const history = portal.protocols.get(ProtocolId.HistoryNetwork) as never as HistoryProtocol
       const block = await history.getBlockByNumber(parseInt(blockNumber), includeTransactions)
       setBlock(block!)
     } catch {
@@ -33,15 +31,18 @@ export default function GetBlockByNumber(props: IGetBlockByNumberProps) {
 
   return (
     <HStack marginY={1}>
-      <Button width={'100%'} onClick={handleClick}>
+      <Button
+        disabled={history.accumulator.currentHeight() < 1}
+        width={'100%'}
+        onClick={handleClick}
+      >
         Get Block by Number
       </Button>
       <FormControl isInvalid={parseInt(searchNumber) < 0}>
         <Input
           bg="whiteAlpha.800"
-          placeholder={'209999'}
+          placeholder={`BlockNumber (Max: ${history.accumulator.currentHeight()})`}
           type={'number'}
-          value={searchNumber}
           onChange={(e) => setSearchNumber(e.target.value)}
         />
       </FormControl>

--- a/packages/browser-client/src/Components/HistoryNetwork.tsx
+++ b/packages/browser-client/src/Components/HistoryNetwork.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   FormControl,
   HStack,
+  IconButton,
   Input,
   Tab,
   TabList,
@@ -15,6 +16,7 @@ import DisplayBlock from './DisplayBlock'
 import RoutingTableView from './RoutingTableView'
 import { ENR } from 'portalnetwork'
 import GetBlockByNumber from './GetBlockByNumber'
+import { RepeatIcon } from '@chakra-ui/icons'
 
 interface HistoryNetworkProps {
   findParent: (hash: string) => Promise<void>
@@ -25,6 +27,7 @@ interface HistoryNetworkProps {
   setBlockHash: Dispatch<SetStateAction<string>>
   peers: ENR[] | undefined
   sortedDistList: [number, string[]][]
+  refresh: () => void
 }
 
 export default function HistoryNetwork(props: HistoryNetworkProps) {
@@ -60,7 +63,7 @@ export default function HistoryNetwork(props: HistoryNetworkProps) {
           disabled={props.invalidHash}
           onClick={async () => handleClick()}
         >
-          Get Block by Blockhash
+          Get Block by Hash
         </Button>
         <FormControl isInvalid={props.invalidHash}>
           <Input
@@ -76,12 +79,21 @@ export default function HistoryNetwork(props: HistoryNetworkProps) {
       <GetBlockByNumber setIsLoading={setIsLoading} setBlockHash={props.setBlockHash} />
       <Tabs index={tabIndex} onChange={handleTabsChange}>
         <TabList>
-          <Tab>Network</Tab>
+          <Tab>
+            {`Network`}{' '}
+            <IconButton
+              onClick={props.refresh}
+              aria-label="refresh routing table"
+              icon={<RepeatIcon />}
+            />
+          </Tab>
           <Tab>Block Explorer</Tab>
         </TabList>
         <TabPanels>
           <TabPanel>
-            <RoutingTableView peers={props.peers} sortedDistList={props.sortedDistList} />
+            {props.peers && (
+              <RoutingTableView peers={props.peers} sortedDistList={props.sortedDistList} />
+            )}
           </TabPanel>
           <TabPanel>
             {props.block?.header && <DisplayBlock isLoading={isLoading} findParent={findParent} />}

--- a/packages/browser-client/src/Components/Layout.tsx
+++ b/packages/browser-client/src/Components/Layout.tsx
@@ -21,6 +21,7 @@ interface LayoutProps {
   peers: ENR[] | undefined
   sortedDistList: [number, string[]][]
   capacitor: CapacitorGlobal
+  refresh: () => void
 }
 
 export default function Layout(props: LayoutProps) {
@@ -64,6 +65,7 @@ export default function Layout(props: LayoutProps) {
                 block={props.block}
                 peers={props.peers}
                 sortedDistList={props.sortedDistList}
+                refresh={props.refresh}
               />
             </TabPanel>
             <TabPanel>State Network</TabPanel>

--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -1,0 +1,395 @@
+import { ArrowLeftIcon, ArrowRightIcon, CopyIcon } from '@chakra-ui/icons'
+import {
+  Box,
+  Button,
+  Divider,
+  GridItem,
+  Heading,
+  HStack,
+  IconButton,
+  Input,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Tooltip,
+  Tr,
+  VStack,
+} from '@chakra-ui/react'
+import {
+  ENR,
+  fromHexString,
+  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentTypes,
+  reassembleBlock,
+  shortId,
+} from 'portalnetwork'
+import React, { Dispatch, SetStateAction, useContext, useState } from 'react'
+import { BlockContext, HistoryProtocolContext } from '../App'
+
+export interface PeerButtonsProps {
+  peerIdx: number
+  setPeerIdx: Dispatch<SetStateAction<number>>
+  sortedDistList: any
+  peer: ENR
+  peers: ENR[]
+}
+
+export default function PeerButtons(props: PeerButtonsProps) {
+  const { block, setBlock } = useContext(BlockContext)
+  const [epoch, setEpoch] = useState(0)
+  const { peerIdx, setPeerIdx, sortedDistList, peer } = props
+  const [offer, setOffer] = useState<Uint8Array[]>([])
+  const [pinging, setPinging] = useState(false)
+  const [ponged, setPonged] = useState<boolean | undefined>()
+  const [distance, setDistance] = useState('')
+  const [blockHash, setBlockHash] = useState('')
+  const historyProtocol = useContext(HistoryProtocolContext)
+  const addToOffer = (type: string) => {
+    const contentKeys: Uint8Array[] = []
+    switch (type) {
+      case 'header':
+        contentKeys.push(
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockHeader,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(blockHash),
+            },
+          })
+        )
+        break
+      case 'body':
+        contentKeys.push(
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockBody,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(blockHash),
+            },
+          })
+        )
+        break
+      case 'block':
+        contentKeys.push(
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockHeader,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(blockHash),
+            },
+          })
+        )
+        contentKeys.push(
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockBody,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(blockHash),
+            },
+          })
+        )
+
+        break
+    }
+    setOffer([...offer, ...contentKeys])
+  }
+  const handlePing = async () => {
+    setPinging(true)
+    setTimeout(async () => {
+      const pong = await historyProtocol.sendPing(peer)
+      if (pong) {
+        setPonged(true)
+        setTimeout(() => {
+          setPinging(false)
+          setPonged(undefined)
+        }, 1500)
+      } else {
+        setPonged(false)
+        setTimeout(() => {
+          setPinging(false)
+          setPonged(undefined)
+        }, 1000)
+      }
+    }, 500)
+  }
+  const handleFindNodes = (peer: ENR) => {
+    historyProtocol.sendFindNodes(peer.nodeId, [parseInt(distance)])
+  }
+  const handleRequestSnapshot = () => {
+    const accumulatorKey = HistoryNetworkContentKeyUnionType.serialize({
+      selector: 4,
+      value: { selector: 0, value: null },
+    })
+    historyProtocol.sendFindContent(peer.nodeId, accumulatorKey)
+  }
+
+  const handleOffer = (peer: ENR) => {
+    historyProtocol.sendOffer(peer.nodeId, offer)
+  }
+  const sendFindContent = async (type: string) => {
+    if (type === 'header') {
+      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 0,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(blockHash),
+        },
+      })
+      historyProtocol.sendFindContent(peer.nodeId, headerKey)
+    } else if (type === 'body') {
+      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 0,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(blockHash),
+        },
+      })
+      historyProtocol.sendFindContent(peer.nodeId, headerKey)
+      const bodyKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 1,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(blockHash),
+        },
+      })
+      historyProtocol.sendFindContent(peer.nodeId, bodyKey)
+    } else if (type === 'block') {
+      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 0,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(blockHash),
+        },
+      })
+      const bodyKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 1,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(blockHash),
+        },
+      })
+      try {
+        const header = (await historyProtocol.sendFindContent(peer.nodeId, headerKey))
+          ?.value as Uint8Array
+        const _body = await historyProtocol.sendFindContent(peer.nodeId, bodyKey)
+        const body: Uint8Array | undefined =
+          _body !== undefined ? (_body.value as Uint8Array) : undefined
+        const block = reassembleBlock(header, body)
+        setBlock(block)
+      } catch {}
+    } else if (type === 'epoch') {
+      const epochKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 3,
+        value: {
+          chainId: 1,
+          blockHash: historyProtocol.accumulator.historicalEpochs[epoch],
+        },
+      })
+    }
+  }
+  return (
+    <GridItem>
+      <Box border={'1px'}>
+        <VStack>
+          <HStack>
+            <VStack>
+              <HStack>
+                <IconButton
+                  disabled={peerIdx < 1}
+                  onClick={() => setPeerIdx(peerIdx - 1)}
+                  aria-label="prev peer"
+                  icon={<ArrowLeftIcon />}
+                />
+                <Heading size={'md'}>
+                  Peer {peerIdx + 1} / {props.peers.length}
+                </Heading>
+                <IconButton
+                  onClick={() => setPeerIdx(peerIdx + 1)}
+                  disabled={peerIdx === props.peers.length - 1}
+                  aria-label="prev peer"
+                  icon={<ArrowRightIcon />}
+                />
+              </HStack>
+              <Table size="xs">
+                <Tbody>
+                  <Tr>
+                    <Td>ENR:</Td>
+                    <Th>
+                      <Tooltip label={props.sortedDistList[peerIdx][1][3]}>
+                        <CopyIcon
+                          cursor={'pointer'}
+                          onClick={() =>
+                            navigator.clipboard.writeText(sortedDistList[peerIdx][1][3])
+                          }
+                        />
+                      </Tooltip>
+                    </Th>
+                  </Tr>
+                  <Tr>
+                    <Td>Addr: </Td>
+                    <Td>
+                      {props.sortedDistList[peerIdx][1][0]}: {sortedDistList[peerIdx][1][1]}
+                    </Td>
+                  </Tr>
+                  <Tr>
+                    <Td>NodeId: </Td>
+                    <Td>{shortId(peer.nodeId)}</Td>
+                  </Tr>
+                </Tbody>
+              </Table>
+            </VStack>
+            <Button
+              size="lg"
+              onClick={() => handlePing()}
+              bgColor={
+                ponged === true
+                  ? 'green.100'
+                  : ponged === false
+                  ? 'red.100'
+                  : pinging
+                  ? 'yellow.100'
+                  : 'blue.100'
+              }
+            >
+              {ponged === true
+                ? 'PONG RECEIVED!'
+                : ponged === false
+                ? 'PING/PONG FAILED'
+                : pinging
+                ? 'PINGING'
+                : 'Send PING'}{' '}
+            </Button>
+          </HStack>
+          <Button width="100%" onClick={() => handleRequestSnapshot()}>
+            Request Accumulator Snapshot
+          </Button>
+          <Divider />
+          <HStack width={'100%'}>
+            <Button
+              isDisabled={historyProtocol.accumulator.historicalEpochs.length < 1}
+              width="70%"
+              onClick={() => sendFindContent('epoch')}
+            >
+              Request Epoch Accumulator by Epoch
+            </Button>
+            <Input
+              type={'number'}
+              min={1}
+              max={historyProtocol.accumulator.historicalEpochs.length}
+              width={'30%'}
+              placeholder={'Epoch'}
+              onChange={(evt) => {
+                setEpoch(parseInt(evt.target.value))
+              }}
+            />
+          </HStack>
+          <Divider />
+          <HStack width={'100%'}>
+            <Button
+              isDisabled={historyProtocol.accumulator.historicalEpochs.length < 1}
+              width="70%"
+              onClick={() => sendFindContent('epoch')}
+            >
+              Request Epoch Accumulator by BlockNumber
+            </Button>
+            <Input
+              type={'number'}
+              min={1}
+              max={historyProtocol.accumulator.currentHeight()}
+              width={'30%'}
+              placeholder={`BlockNumber (Max: ${historyProtocol.accumulator.currentHeight()})`}
+              onChange={(evt) => {
+                setEpoch(Math.floor(parseInt(evt.target.value) / 8192))
+              }}
+            />
+          </HStack>
+          <Divider />
+          <HStack width={'100%'}>
+            <Button width="70%" onClick={() => handleFindNodes(peer)}>
+              FindNodes
+            </Button>
+            <Input
+              width={'30%'}
+              placeholder={'Distance'}
+              onChange={(evt) => {
+                setDistance(evt.target.value)
+              }}
+            />
+          </HStack>
+          <Divider />
+          <Input
+            value={blockHash}
+            placeholder="BlockHash"
+            onChange={(evt) => setBlockHash(evt.target.value)}
+          />
+          <HStack width={'100%'}>
+            <Button
+              width={'33%'}
+              title="Add content to offer"
+              onClick={() => {
+                sendFindContent('header')
+              }}
+            >
+              Find Header
+            </Button>
+            <Button
+              width={'33%'}
+              title="Add content to offer"
+              onClick={() => {
+                sendFindContent('body')
+              }}
+            >
+              Find Body
+            </Button>
+            <Button
+              width={'33%'}
+              title="Add content to offer"
+              onClick={() => {
+                sendFindContent('block')
+              }}
+            >
+              Find Block
+            </Button>
+          </HStack>
+          <HStack width={'100%'}>
+            <Button
+              width={'33%'}
+              title="Add content to offer"
+              onClick={() => {
+                addToOffer('header')
+              }}
+            >
+              Offer Header
+            </Button>
+            <Button
+              width={'33%'}
+              title="Add content to offer"
+              onClick={() => {
+                addToOffer('body')
+              }}
+            >
+              Offer Body
+            </Button>
+            <Button
+              width={'33%'}
+              title="Add content to offer"
+              onClick={() => {
+                addToOffer('block')
+              }}
+            >
+              Offer Block
+            </Button>
+          </HStack>
+          <Box width={'90%'} border={'1px'}>
+            <Text textAlign={'center'}>OFFER: {offer.length} / 26</Text>
+          </Box>
+          <Button width={'100%'} onClick={() => handleOffer(peer)}>
+            Send Offer
+          </Button>
+        </VStack>
+      </Box>
+    </GridItem>
+  )
+}

--- a/packages/browser-client/src/Components/RoutingTableView.tsx
+++ b/packages/browser-client/src/Components/RoutingTableView.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { ENR } from 'portalnetwork'
-import { CopyIcon } from '@chakra-ui/icons'
+import React, { useContext, useState } from 'react'
+import { ENR, fromHexString, HistoryNetworkContentKeyUnionType, shortId } from 'portalnetwork'
+import { ArrowLeftIcon, ArrowRightIcon, CopyIcon } from '@chakra-ui/icons'
 import {
   Table,
   Box,
@@ -12,52 +12,144 @@ import {
   Tr,
   Td,
   Tooltip,
+  VStack,
+  HStack,
+  Button,
+  Divider,
+  Input,
+  useToast,
+  Text,
+  GridItem,
+  SimpleGrid,
+  IconButton,
+  Heading,
 } from '@chakra-ui/react'
+import { HistoryProtocolContext } from '../App'
+import PeerButtons from './PeerButtons'
 
 interface RoutingTableViewProps {
-  peers: ENR[] | undefined
+  peers: ENR[]
   sortedDistList: [number, string[]][]
 }
 
 export default function RoutingTableView(props: RoutingTableViewProps) {
+  const [peerIdx, setPeerIdx] = useState(0)
+  const [hover, setHover] = useState<number>()
+  const [peer, _setPeer] = useState(props.peers[peerIdx])
+  const [distance, setDistance] = useState('')
+  const [blockHash, setBlockHash] = useState('')
+  const [offer, setOffer] = useState<string[]>([])
+  const [pinging, setPinging] = useState(false)
+  const [ponged, setPonged] = useState<boolean | undefined>()
+  const toast = useToast()
+
+  const protocol = useContext(HistoryProtocolContext)
+
+  const handlePing = async () => {
+    setPinging(true)
+    setTimeout(async () => {
+      const pong = await protocol.sendPing(peer)
+      if (pong) {
+        setPonged(true)
+        setTimeout(() => {
+          setPinging(false)
+          setPonged(undefined)
+        }, 1500)
+      } else {
+        setPonged(false)
+        setTimeout(() => {
+          setPinging(false)
+          setPonged(undefined)
+        }, 1000)
+      }
+    }, 500)
+  }
+  const handleFindNodes = (peer: ENR) => {
+    protocol.sendFindNodes(peer.nodeId, [parseInt(distance)])
+  }
+  const handleRequestSnapshot = () => {
+    const accumulatorKey = HistoryNetworkContentKeyUnionType.serialize({
+      selector: 4,
+      value: { selector: 0, value: null },
+    })
+    protocol.sendFindContent(peer.nodeId, accumulatorKey)
+  }
+
+  const handleOffer = (peer: ENR) => {
+    if (blockHash.slice(0, 2) !== '0x') {
+      setBlockHash('')
+      toast({
+        title: 'Invalid content key',
+        description: 'Key must be hex prefixed',
+        status: 'warning',
+      })
+      return
+    }
+    protocol.sendOffer(peer.nodeId, [fromHexString(blockHash)])
+  }
+
+  const addToOffer = () => {
+    setOffer([...offer, blockHash])
+  }
+
   return (
     <Center>
-      <Box width={'90%'} maxHeight="40%">
-        <Center>
-          <Table size="xs">
-            <TableCaption>Peers: {props.peers?.length}</TableCaption>
-            <Thead>
-              <Tr>
-                <Th>ENR</Th>
-                <Th>DIST</Th>
-                <Th>IP</Th>
-                <Th>PORT</Th>
-                <Th>NodeId</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {props.sortedDistList.map((peer) => {
-                return (
-                  <Tr key={peer[1][2]}>
-                    <Td key={peer[1][2] + 'abc'}>
-                      <Tooltip label={peer[1][3]}>
-                        <CopyIcon
-                          cursor={'pointer'}
-                          onClick={() => navigator.clipboard.writeText(peer[1][3])}
-                        />
-                      </Tooltip>
-                    </Td>
-                    <Th>{peer[0]}</Th>
-                    <Td>{peer[1][0]}</Td>
-                    <Td>{peer[1][1]}</Td>
-                    <Td>{peer[1][2].slice(0, 15) + '...'}</Td>
-                  </Tr>
-                )
-              })}
-            </Tbody>
-          </Table>
-        </Center>
-      </Box>
+      {/* <Box width={'90%'} maxHeight="10%"> */}
+      <SimpleGrid width={'100%'} columns={[1, 1, 1, 2]}>
+        <PeerButtons
+          peers={props.peers}
+          peer={peer}
+          setPeerIdx={setPeerIdx}
+          peerIdx={peerIdx}
+          sortedDistList={props.sortedDistList}
+        />
+        <GridItem>
+          <Center>
+            <Table size="xs">
+              <TableCaption>Peers: {props.peers?.length}</TableCaption>
+              <Thead>
+                <Tr>
+                  <Th>ENR</Th>
+                  <Th>DIST</Th>
+                  <Th>IP</Th>
+                  <Th>PORT</Th>
+                  <Th>NodeId</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {props.sortedDistList.map((peer, idx) => {
+                  return (
+                    <Tr
+                      key={peer[1][2]}
+                      onMouseEnter={() => setHover(idx)}
+                      onMouseLeave={() => {
+                        setHover(undefined)
+                      }}
+                      onClick={() => setPeerIdx(idx)}
+                      backgroundColor={
+                        idx === hover ? 'blue.100' : peerIdx === idx ? 'red.100' : 'whiteAlpha.100'
+                      }
+                    >
+                      <Td key={peer[1][2] + 'abc'}>
+                        <Tooltip label={peer[1][3]}>
+                          <CopyIcon
+                            cursor={'pointer'}
+                            onClick={() => navigator.clipboard.writeText(peer[1][3])}
+                          />
+                        </Tooltip>
+                      </Td>
+                      <Th>{peer[0]}</Th>
+                      <Td>{peer[1][0]}</Td>
+                      <Td>{peer[1][1]}</Td>
+                      <Td>{peer[1][2].slice(0, 15) + '...'}</Td>
+                    </Tr>
+                  )
+                })}
+              </Tbody>
+            </Table>
+          </Center>
+        </GridItem>
+      </SimpleGrid>
     </Center>
   )
 }


### PR DESCRIPTION
Updates the `netowrk` tab in browser client to include tools to interact with individual peers.

Address book view is unchanged, but has become a select menu to choose a peer to interact with.

PeerTools will appear over (small screen) or beside (large screen) the address book.

PeerTools expands on DevTools with an improved interface to test Ping/Pong, FindContent, and Offer.

Also extracts the `add peer` function to the main page of the app.