### PR TITLE
browser-client: move PeerReducer into separate utility file

### DIFF
--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -26,61 +26,11 @@ import {
 } from 'portalnetwork'
 import React, { useContext, useEffect, useReducer } from 'react'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
-
-interface PeerButtonsState {
-  epoch: number
-  offer: Uint8Array[]
-  ping: [string, string]
-  distance: string
-  blockHash: string
-}
-
-const peerButtonsInitialState = {
-  epoch: 0,
-  offer: [],
-  ping: ['blue.100', 'PING'] as [string, string],
-  distance: '',
-  blockHash: '',
-}
-
-enum PeerButtonsStateChange {
-  SETEPOCH = 'SETEPOCH',
-  ADDTOOFFER = 'ADDTOOFFER',
-  PING = 'PING',
-  SETDISTANCE = 'SETDISTANCE',
-  SETBLOCKHASH = 'SETBLOCKHASH',
-  SETPEERIDX = 'SETPEERIDX',
-}
-
-interface AppStateAction {
-  type: PeerButtonsStateChange
-  payload?: any
-}
-
-const reducer = (state: PeerButtonsState, action: AppStateAction) => {
-  const { type, payload } = action
-  switch (type) {
-    case PeerButtonsStateChange.SETEPOCH:
-      return state
-    case PeerButtonsStateChange.ADDTOOFFER:
-      return {
-        ...state,
-        offer: [...state.offer, payload],
-      }
-    case PeerButtonsStateChange.PING:
-      return { ...state, ping: payload }
-    case PeerButtonsStateChange.SETDISTANCE:
-      return state
-    case PeerButtonsStateChange.SETBLOCKHASH:
-      return { ...state, blockHash: payload }
-    default:
-      throw new Error()
-  }
-}
+import { peerInitialState, peerReducer, PeerStateChange } from '../peerReducer'
 
 export default function PeerButtons() {
   const { state, dispatch } = useContext(AppContext as React.Context<AppContextType>)
-  const [_state, _dispatch] = useReducer(reducer, peerButtonsInitialState)
+  const [_state, _dispatch] = useReducer(peerReducer, peerInitialState)
 
   useEffect(() => {
     if (!state.selectedPeer) {
@@ -139,20 +89,20 @@ export default function PeerButtons() {
     }
   }
   const handlePing = async () => {
-    _dispatch({ type: PeerButtonsStateChange.PING, payload: ['yellow.200', 'PINGING'] })
+    _dispatch({ type: PeerStateChange.PING, payload: ['yellow.200', 'PINGING'] })
     setTimeout(async () => {
       const pong = await state.provider!.historyProtocol!.sendPing(
         ENR.decodeTxt(state.selectedPeer)
       )
       if (pong) {
-        _dispatch({ type: PeerButtonsStateChange.PING, payload: ['green.200', 'PONG RECEIVED!'] })
+        _dispatch({ type: PeerStateChange.PING, payload: ['green.200', 'PONG RECEIVED!'] })
         setTimeout(() => {
-          _dispatch({ type: PeerButtonsStateChange.PING, payload: ['blue.200', 'PING'] })
+          _dispatch({ type: PeerStateChange.PING, payload: ['blue.200', 'PING'] })
         }, 1500)
       } else {
-        _dispatch({ type: PeerButtonsStateChange.PING, payload: ['red.200', 'PING FAILED'] })
+        _dispatch({ type: PeerStateChange.PING, payload: ['red.200', 'PING FAILED'] })
         setTimeout(() => {
-          _dispatch({ type: PeerButtonsStateChange.PING, payload: ['blue.200', 'PINGING'] })
+          _dispatch({ type: PeerStateChange.PING, payload: ['blue.200', 'PINGING'] })
         }, 1000)
       }
     }, 500)
@@ -321,7 +271,7 @@ export default function PeerButtons() {
               placeholder={'Epoch'}
               onChange={(evt) => {
                 _dispatch({
-                  type: PeerButtonsStateChange.SETEPOCH,
+                  type: PeerStateChange.SETEPOCH,
                   payload: parseInt(evt.target.value),
                 })
               }}
@@ -344,7 +294,7 @@ export default function PeerButtons() {
               placeholder={`BlockNumber (Max: ${state.provider!.historyProtocol!.accumulator.currentHeight()})`}
               onChange={(evt) => {
                 _dispatch({
-                  type: PeerButtonsStateChange.SETEPOCH,
+                  type: PeerStateChange.SETEPOCH,
                   payload: Math.floor(parseInt(evt.target.value) / 8192),
                 })
               }}
@@ -364,7 +314,7 @@ export default function PeerButtons() {
                 placeholder={'Distance'}
                 onChange={(evt) => {
                   _dispatch({
-                    type: PeerButtonsStateChange.SETDISTANCE,
+                    type: PeerStateChange.SETDISTANCE,
                     payload: evt.target.value,
                   })
                 }}
@@ -376,7 +326,7 @@ export default function PeerButtons() {
             value={_state.blockHash}
             placeholder="BlockHash"
             onChange={(evt) =>
-              _dispatch({ type: PeerButtonsStateChange.SETBLOCKHASH, payload: evt.target.value })
+              _dispatch({ type: PeerStateChange.SETBLOCKHASH, payload: evt.target.value })
             }
           />
           <HStack width={'100%'}>

--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -30,7 +30,7 @@ export default function PeerButtons() {
       peerState,
       peerDispatch,
     },
-    state!.historyProtocol!
+    state.provider!.historyProtocol
   )
 
   useEffect(() => {
@@ -54,7 +54,7 @@ export default function PeerButtons() {
 
   return (
     <GridItem>
-      {state && dispatch && (
+      {state && state.provider && (
         <Box border={'1px'}>
           <VStack>
             <HStack>
@@ -64,20 +64,20 @@ export default function PeerButtons() {
                     Peer {peerIdx + 1} / {state!.peers.length}
                   </Heading>
                   <Text size={'sm'} color={'gray.500'}>
-                    {state!.selectedPeer.slice(0, 20)}...
+                    {state.selectedPeer.slice(0, 20)}...
                   </Text>
                 </VStack>
                 <Table size="xs">
-                  {state?.sortedPeers[peerIdx] && (
+                  {state.sortedPeers[peerIdx] && (
                     <Tbody>
                       <Tr>
                         <Td>ENR:</Td>
                         <Th>
-                          <Tooltip label={state!.sortedPeers[peerIdx][1][3]}>
+                          <Tooltip label={state.sortedPeers[peerIdx][1][3]}>
                             <CopyIcon
                               cursor={'pointer'}
                               onClick={() =>
-                                navigator.clipboard.writeText(state!.sortedPeers[peerIdx][1][3])
+                                navigator.clipboard.writeText(state.sortedPeers[peerIdx][1][3])
                               }
                             />
                           </Tooltip>
@@ -86,12 +86,12 @@ export default function PeerButtons() {
                       <Tr>
                         <Td>Addr: </Td>
                         <Td>
-                          {state!.sortedPeers[peerIdx][1][0]}: {state!.sortedPeers[peerIdx][1][1]}
+                          {state.sortedPeers[peerIdx][1][0]}: {state.sortedPeers[peerIdx][1][1]}
                         </Td>
                       </Tr>
                       <Tr>
                         <Td>NodeId: </Td>
-                        <Td>{shortId(ENR.decodeTxt(state!.selectedPeer).nodeId)}</Td>
+                        <Td>{shortId(ENR.decodeTxt(state.selectedPeer).nodeId)}</Td>
                       </Tr>
                     </Tbody>
                   )}
@@ -99,7 +99,7 @@ export default function PeerButtons() {
               </VStack>
               <Button
                 size="lg"
-                onClick={() => peerActions.handlePing(state!.selectedPeer)}
+                onClick={() => peerActions.handlePing(state.selectedPeer)}
                 bgColor={peerState.ping[0]}
               >
                 {peerState.ping[1]}
@@ -114,7 +114,7 @@ export default function PeerButtons() {
             <Divider />
             <HStack width={'100%'}>
               <Button
-                isDisabled={state!.historyProtocol!.accumulator.historicalEpochs.length < 1}
+                isDisabled={state.provider.historyProtocol.accumulator.historicalEpochs.length < 1}
                 width="70%"
                 onClick={() => sendFindContent('epoch')}
               >
@@ -123,7 +123,7 @@ export default function PeerButtons() {
               <Input
                 type={'number'}
                 min={1}
-                max={state!.historyProtocol!.accumulator.historicalEpochs.length}
+                max={state.provider.historyProtocol.accumulator.historicalEpochs.length}
                 width={'30%'}
                 placeholder={'Epoch'}
                 onChange={(evt) => {
@@ -137,7 +137,7 @@ export default function PeerButtons() {
             <Divider />
             <HStack width={'100%'}>
               <Button
-                isDisabled={state!.historyProtocol!.accumulator.historicalEpochs.length < 1}
+                isDisabled={state.provider.historyProtocol.accumulator.historicalEpochs.length < 1}
                 width="70%"
                 onClick={() => sendFindContent('epoch')}
               >
@@ -146,9 +146,9 @@ export default function PeerButtons() {
               <Input
                 type={'number'}
                 min={1}
-                max={state!.historyProtocol!.accumulator.currentHeight()}
+                max={state.provider.historyProtocol.accumulator.currentHeight()}
                 width={'30%'}
-                placeholder={`BlockNumber (Max: ${state!.historyProtocol!.accumulator.currentHeight()})`}
+                placeholder={`BlockNumber (Max: ${state.provider.historyProtocol.accumulator.currentHeight()})`}
                 onChange={(evt) => {
                   peerDispatch({
                     type: PeerStateChange.SETEPOCH,

--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -16,7 +16,7 @@ import {
   Tr,
   VStack,
 } from '@chakra-ui/react'
-import { ENR, shortId } from 'portalnetwork'
+import { ENR, HistoryNetworkContentTypes, shortId } from 'portalnetwork'
 import React, { useContext, useEffect, useReducer, useState } from 'react'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
 import { PeerActions } from '../peerActions'
@@ -188,7 +188,7 @@ export default function PeerButtons() {
             />
             <HStack width={'100%'}>
               <Button
-                width={'33%'}
+                width={'50%'}
                 title="Add content to offer"
                 onClick={() => {
                   sendFindContent('header')
@@ -197,7 +197,7 @@ export default function PeerButtons() {
                 Find Header
               </Button>
               <Button
-                width={'33%'}
+                width={'50%'}
                 title="Add content to offer"
                 onClick={() => {
                   sendFindContent('body')
@@ -205,43 +205,25 @@ export default function PeerButtons() {
               >
                 Find Body
               </Button>
-              <Button
-                width={'33%'}
-                title="Add content to offer"
-                onClick={() => {
-                  sendFindContent('block')
-                }}
-              >
-                Find Block
-              </Button>
             </HStack>
             <HStack width={'100%'}>
               <Button
-                width={'33%'}
+                width={'50%'}
                 title="Add content to offer"
                 onClick={() => {
-                  peerActions.addToOffer('header')
+                  peerActions.addToOffer(HistoryNetworkContentTypes.BlockHeader)
                 }}
               >
                 Offer Header
               </Button>
               <Button
-                width={'33%'}
+                width={'50%'}
                 title="Add content to offer"
                 onClick={() => {
-                  peerActions.addToOffer('body')
+                  peerActions.addToOffer(HistoryNetworkContentTypes.BlockBody)
                 }}
               >
                 Offer Body
-              </Button>
-              <Button
-                width={'33%'}
-                title="Add content to offer"
-                onClick={() => {
-                  peerActions.addToOffer('block')
-                }}
-              >
-                Offer Block
               </Button>
             </HStack>
             <Box width={'90%'} border={'1px'}>

--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -189,7 +189,10 @@ export default function PeerButtons() {
             <HStack width={'100%'}>
               <Button
                 width={'50%'}
-                title="Add content to offer"
+                title={`Send FINDCONTENT to peer for BlockHeader: ${peerState.blockHash.slice(
+                  0,
+                  8
+                )}...`}
                 onClick={() => {
                   sendFindContent('header')
                 }}
@@ -198,7 +201,10 @@ export default function PeerButtons() {
               </Button>
               <Button
                 width={'50%'}
-                title="Add content to offer"
+                title={`Send FINDCONTENT to peer for BlockBody: ${peerState.blockHash.slice(
+                  0,
+                  8
+                )}...`}
                 onClick={() => {
                   sendFindContent('body')
                 }}
@@ -229,7 +235,11 @@ export default function PeerButtons() {
             <Box width={'90%'} border={'1px'}>
               <Text textAlign={'center'}>OFFER: {peerState.offer.length} / 26</Text>
             </Box>
-            <Button width={'100%'} onClick={() => peerActions.handleOffer(state.selectedPeer)}>
+            <Button
+              width={'100%'}
+              title={`Send OFFER to peer with ${peerState.offer.length} pieces of content`}
+              onClick={() => peerActions.handleOffer(state.selectedPeer)}
+            >
               Send Offer
             </Button>
           </VStack>

--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -17,7 +17,7 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import { ENR, shortId } from 'portalnetwork'
-import React, { useContext, useEffect, useReducer } from 'react'
+import React, { useContext, useEffect, useReducer, useState } from 'react'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
 import { PeerActions } from '../peerActions'
 import { PeerContext, PeerContextType, PeerStateChange } from '../peerReducer'
@@ -59,11 +59,14 @@ export default function PeerButtons() {
           <VStack>
             <HStack>
               <VStack>
-                <HStack>
+                <VStack>
                   <Heading size={'md'}>
                     Peer {peerIdx + 1} / {state!.peers.length}
                   </Heading>
-                </HStack>
+                  <Text size={'sm'} color={'gray.500'}>
+                    {state!.selectedPeer.slice(0, 20)}...
+                  </Text>
+                </VStack>
                 <Table size="xs">
                   {state?.sortedPeers[peerIdx] && (
                     <Tbody>

--- a/packages/browser-client/src/Components/PeerButtons.tsx
+++ b/packages/browser-client/src/Components/PeerButtons.tsx
@@ -20,15 +20,15 @@ import { ENR, shortId } from 'portalnetwork'
 import React, { useContext, useEffect, useReducer } from 'react'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
 import { PeerActions } from '../peerActions'
-import { peerInitialState, peerReducer, PeerStateChange } from '../peerReducer'
+import { PeerContext, PeerContextType, PeerStateChange } from '../peerReducer'
 
 export default function PeerButtons() {
   const { state, dispatch } = useContext(AppContext as React.Context<AppContextType>)
-  const [_state, _dispatch] = useReducer(peerReducer, peerInitialState)
+  const { peerState, peerDispatch } = useContext(PeerContext as React.Context<PeerContextType>)
   const peerActions = new PeerActions(
     {
-      state: _state,
-      dispatch: _dispatch,
+      peerState,
+      peerDispatch,
     },
     state!.historyProtocol!
   )
@@ -46,7 +46,7 @@ export default function PeerButtons() {
     .indexOf(state.selectedPeer)
 
   const sendFindContent = async (type: string) => {
-    const block = await peerActions.sendFindContent(type)
+    const block = await peerActions.sendFindContent(type, state!.selectedPeer)
     if (block) {
       dispatch!({ type: StateChange.SETBLOCK, payload: block })
     }
@@ -94,11 +94,18 @@ export default function PeerButtons() {
                   )}
                 </Table>
               </VStack>
-              <Button size="lg" onClick={() => peerActions.handlePing()} bgColor={_state.ping[0]}>
-                {_state.ping[1]}
+              <Button
+                size="lg"
+                onClick={() => peerActions.handlePing(state!.selectedPeer)}
+                bgColor={peerState.ping[0]}
+              >
+                {peerState.ping[1]}
               </Button>
             </HStack>
-            <Button width="100%" onClick={() => peerActions.handleRequestSnapshot()}>
+            <Button
+              width="100%"
+              onClick={() => peerActions.handleRequestSnapshot(state!.selectedPeer)}
+            >
               Request Accumulator Snapshot
             </Button>
             <Divider />
@@ -117,7 +124,7 @@ export default function PeerButtons() {
                 width={'30%'}
                 placeholder={'Epoch'}
                 onChange={(evt) => {
-                  _dispatch({
+                  peerDispatch({
                     type: PeerStateChange.SETEPOCH,
                     payload: parseInt(evt.target.value),
                   })
@@ -140,7 +147,7 @@ export default function PeerButtons() {
                 width={'30%'}
                 placeholder={`BlockNumber (Max: ${state!.historyProtocol!.accumulator.currentHeight()})`}
                 onChange={(evt) => {
-                  _dispatch({
+                  peerDispatch({
                     type: PeerStateChange.SETEPOCH,
                     payload: Math.floor(parseInt(evt.target.value) / 8192),
                   })
@@ -160,7 +167,7 @@ export default function PeerButtons() {
                   width={'30%'}
                   placeholder={'Distance'}
                   onChange={(evt) => {
-                    _dispatch({
+                    peerDispatch({
                       type: PeerStateChange.SETDISTANCE,
                       payload: evt.target.value,
                     })
@@ -170,10 +177,10 @@ export default function PeerButtons() {
             )}
             <Divider />
             <Input
-              value={_state.blockHash}
+              value={peerState.blockHash}
               placeholder="BlockHash"
               onChange={(evt) =>
-                _dispatch({ type: PeerStateChange.SETBLOCKHASH, payload: evt.target.value })
+                peerDispatch({ type: PeerStateChange.SETBLOCKHASH, payload: evt.target.value })
               }
             />
             <HStack width={'100%'}>
@@ -235,9 +242,9 @@ export default function PeerButtons() {
               </Button>
             </HStack>
             <Box width={'90%'} border={'1px'}>
-              <Text textAlign={'center'}>OFFER: {_state.offer.length} / 26</Text>
+              <Text textAlign={'center'}>OFFER: {peerState.offer.length} / 26</Text>
             </Box>
-            <Button width={'100%'} onClick={() => peerActions.handleOffer()}>
+            <Button width={'100%'} onClick={() => peerActions.handleOffer(state.selectedPeer)}>
               Send Offer
             </Button>
           </VStack>

--- a/packages/browser-client/src/Components/RoutingTableView.tsx
+++ b/packages/browser-client/src/Components/RoutingTableView.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useReducer } from 'react'
 import { CopyIcon } from '@chakra-ui/icons'
 import {
   Table,
@@ -15,71 +15,79 @@ import {
 } from '@chakra-ui/react'
 import PeerButtons from './PeerButtons'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
+import { PeerContext, peerInitialState, peerReducer } from '../peerReducer'
 
 export default function RoutingTableView() {
   const { state, dispatch } = useContext(AppContext as React.Context<AppContextType>)
+  const [_state, _dispatch] = useReducer(peerReducer, peerInitialState)
 
   return (
     <Center>
-      <SimpleGrid width={'100%'} columns={[1, 1, 1, 2]}>
-        {state.peers.length > 0 && <PeerButtons />}
-        <GridItem>
-          <Center>
-            <Table size="xs">
-              <TableCaption>Peers: {state.peers.length}</TableCaption>
-              <Thead>
-                <Tr>
-                  <Th>ENR</Th>
-                  <Th>DIST</Th>
-                  <Th>IP</Th>
-                  <Th>PORT</Th>
-                  <Th>NodeId</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {state.sortedPeers.length > 0 &&
-                  state.sortedPeers.map((peer, idx) => {
-                    return (
-                      <Tr
-                        key={peer[1][2]}
-                        onMouseEnter={() => dispatch({ type: StateChange.SETHOVER, payload: idx })}
-                        onMouseLeave={() => {
-                          dispatch({ type: StateChange.SETHOVER, payload: undefined })
-                        }}
-                        onClick={() => {
-                          dispatch({
-                            type: StateChange.SETSELECTEDPEER,
-                            payload: { idx: idx },
-                          })
-                        }}
-                        backgroundColor={
-                          idx === state.hover
-                            ? 'blue.100'
-                            : state.peerIdx === idx
-                            ? 'red.100'
-                            : 'whiteAlpha.100'
-                        }
-                      >
-                        <Td key={peer[1][2] + 'abc'}>
-                          <Tooltip label={peer[1][3]}>
-                            <CopyIcon
-                              cursor={'pointer'}
-                              onClick={() => navigator.clipboard.writeText(peer[1][3])}
-                            />
-                          </Tooltip>
-                        </Td>
-                        <Th>{peer[0]}</Th>
-                        <Td>{peer[1][0]}</Td>
-                        <Td>{peer[1][1]}</Td>
-                        <Td>{peer[1][2].slice(0, 15) + '...'}</Td>
-                      </Tr>
-                    )
-                  })}
-              </Tbody>
-            </Table>
-          </Center>
-        </GridItem>
-      </SimpleGrid>
+      {_state && _dispatch && (
+        <PeerContext.Provider value={{ peerState: _state, peerDispatch: _dispatch }}>
+          <SimpleGrid width={'100%'} columns={[1, 1, 1, 2]}>
+            {state.peers.length > 0 && <PeerButtons />}
+            <GridItem>
+              <Center>
+                <Table size="xs">
+                  <TableCaption>Peers: {state.peers.length}</TableCaption>
+                  <Thead>
+                    <Tr>
+                      <Th>ENR</Th>
+                      <Th>DIST</Th>
+                      <Th>IP</Th>
+                      <Th>PORT</Th>
+                      <Th>NodeId</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {state.sortedPeers.length > 0 &&
+                      state.sortedPeers.map((peer, idx) => {
+                        return (
+                          <Tr
+                            key={peer[1][2]}
+                            onMouseEnter={() =>
+                              dispatch({ type: StateChange.SETHOVER, payload: idx })
+                            }
+                            onMouseLeave={() => {
+                              dispatch({ type: StateChange.SETHOVER, payload: undefined })
+                            }}
+                            onClick={() => {
+                              dispatch({
+                                type: StateChange.SETSELECTEDPEER,
+                                payload: { idx: idx },
+                              })
+                            }}
+                            backgroundColor={
+                              idx === state.hover
+                                ? 'blue.100'
+                                : state.peerIdx === idx
+                                ? 'red.100'
+                                : 'whiteAlpha.100'
+                            }
+                          >
+                            <Td key={peer[1][2] + 'abc'}>
+                              <Tooltip label={peer[1][3]}>
+                                <CopyIcon
+                                  cursor={'pointer'}
+                                  onClick={() => navigator.clipboard.writeText(peer[1][3])}
+                                />
+                              </Tooltip>
+                            </Td>
+                            <Th>{peer[0]}</Th>
+                            <Td>{peer[1][0]}</Td>
+                            <Td>{peer[1][1]}</Td>
+                            <Td>{peer[1][2].slice(0, 15) + '...'}</Td>
+                          </Tr>
+                        )
+                      })}
+                  </Tbody>
+                </Table>
+              </Center>
+            </GridItem>
+          </SimpleGrid>
+        </PeerContext.Provider>
+      )}
     </Center>
   )
 }

--- a/packages/browser-client/src/Components/getBlockByHash.tsx
+++ b/packages/browser-client/src/Components/getBlockByHash.tsx
@@ -1,10 +1,12 @@
 import { Button, FormControl, HStack, Input } from '@chakra-ui/react'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
 
 export default function GetBlockByHash() {
   const { state, dispatch } = useContext(AppContext as React.Context<AppContextType>)
-  const [blockHash, setBlockhash] = useState('')
+  const [blockHash, setBlockhash] = useState(
+    '0xb495a1d7e6663152ae92708da4843337b958146015a2802f4193a410044698c9'
+  )
   async function eth_getBlockByHash(blockHash: string, includeTransactions: boolean) {
     try {
       const block = includeTransactions
@@ -21,6 +23,14 @@ export default function GetBlockByHash() {
     await eth_getBlockByHash(blockHash, true)
     dispatch({ type: StateChange.TOGGLELOADING })
   }
+
+  async function getInitialBlock() {
+    await eth_getBlockByHash(blockHash, true)
+  }
+
+  useEffect(() => {
+    getInitialBlock()
+  }, [])
 
   return (
     <HStack marginY={1}>

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -68,7 +68,7 @@ export class PeerActions {
   }
 
   handleFindNodes = (peer: ENR) => {
-    this.historyProtocol!.sendFindNodes(peer.nodeId, [parseInt(this.state.distance)])
+    this.historyProtocol.sendFindNodes(peer.nodeId, [parseInt(this.state.distance)])
   }
 
   handleRequestSnapshot = (enr: string) => {
@@ -76,11 +76,11 @@ export class PeerActions {
       selector: 4,
       value: { selector: 0, value: null },
     })
-    this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, accumulatorKey)
+    this.historyProtocol.sendFindContent(ENR.decodeTxt(enr).nodeId, accumulatorKey)
   }
 
   handleOffer = async (enr: string) => {
-    await this.historyProtocol!.sendOffer(ENR.decodeTxt(enr).nodeId, this.state.offer)
+    await this.historyProtocol.sendOffer(ENR.decodeTxt(enr).nodeId, this.state.offer)
   }
 
   sendFindContent = async (type: string, enr: string) => {
@@ -92,7 +92,7 @@ export class PeerActions {
           blockHash: fromHexString(this.state.blockHash),
         },
       })
-      const header = await this.historyProtocol!.sendFindContent(
+      const header = await this.historyProtocol.sendFindContent(
         ENR.decodeTxt(enr).nodeId,
         headerKey
       )
@@ -120,7 +120,7 @@ export class PeerActions {
         selector: 3,
         value: {
           chainId: 1,
-          blockHash: this.historyProtocol!.accumulator.historicalEpochs()[this.state.epoch],
+          blockHash: this.historyProtocol.accumulator.historicalEpochs()[this.state.epoch],
         },
       })
     }

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -115,34 +115,6 @@ export class PeerActions {
         },
       })
       this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, bodyKey)
-    } else if (type === 'block') {
-      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: 0,
-        value: {
-          chainId: 1,
-          blockHash: fromHexString(this.state.blockHash),
-        },
-      })
-      const bodyKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: 1,
-        value: {
-          chainId: 1,
-          blockHash: fromHexString(this.state.blockHash),
-        },
-      })
-      try {
-        const header = (
-          await this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, headerKey)
-        )?.value as Uint8Array
-        const _body = await this.historyProtocol!.sendFindContent(
-          ENR.decodeTxt(enr).nodeId,
-          bodyKey
-        )
-        const body: Uint8Array | undefined =
-          _body !== undefined ? (_body.value as Uint8Array) : undefined
-        const block = reassembleBlock(header, body)
-        return block // this.dispatch({ type: StateChange.SETBLOCK, payload: block })
-      } catch {}
     } else if (type === 'epoch') {
       const _epochKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: 3,

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -44,28 +44,6 @@ export class PeerActions {
           }),
         })
         break
-      case 'block':
-        this.dispatch({
-          type: PeerStateChange.ADDTOOFFER,
-          payload: HistoryNetworkContentKeyUnionType.serialize({
-            selector: HistoryNetworkContentTypes.BlockHeader,
-            value: {
-              chainId: 1,
-              blockHash: fromHexString(this.state.blockHash),
-            },
-          }),
-        })
-        this.dispatch({
-          type: PeerStateChange.ADDTOOFFER,
-          payload: HistoryNetworkContentKeyUnionType.serialize({
-            selector: HistoryNetworkContentTypes.BlockBody,
-            value: {
-              chainId: 1,
-              blockHash: fromHexString(this.state.blockHash),
-            },
-          }),
-        })
-        break
       default:
         throw new Error()
     }

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -1,0 +1,178 @@
+import {
+  ENR,
+  fromHexString,
+  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentTypes,
+  HistoryProtocol,
+  reassembleBlock,
+} from 'portalnetwork'
+import { PeerContextType, PeerDispatch, PeerState, PeerStateChange } from './peerReducer'
+
+export class PeerActions {
+  state: PeerState
+  dispatch: PeerDispatch
+  historyProtocol: HistoryProtocol
+  constructor(peerContext: PeerContextType, protocol: HistoryProtocol) {
+    this.state = peerContext.state!
+    this.dispatch = peerContext.dispatch!
+    this.historyProtocol = protocol
+  }
+
+  addToOffer = (type: string): Uint8Array[] => {
+    switch (type) {
+      case 'header':
+        return [
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockHeader,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(this.state.blockHash),
+            },
+          }),
+        ]
+      case 'body':
+        return [
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockBody,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(this.state.blockHash),
+            },
+          }),
+        ]
+
+      case 'block':
+        return [
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockHeader,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(this.state.blockHash),
+            },
+          }),
+          HistoryNetworkContentKeyUnionType.serialize({
+            selector: HistoryNetworkContentTypes.BlockBody,
+            value: {
+              chainId: 1,
+              blockHash: fromHexString(this.state.blockHash),
+            },
+          }),
+        ]
+      default:
+        throw new Error()
+    }
+  }
+
+  handlePing = async () => {
+    this.dispatch({ type: PeerStateChange.PING, payload: ['yellow.200', 'PINGING'] })
+    setTimeout(async () => {
+      const pong = await this.historyProtocol.sendPing(ENR.decodeTxt(this.state.selectedPeer))
+      if (pong) {
+        this.dispatch({ type: PeerStateChange.PING, payload: ['green.200', 'PONG RECEIVED!'] })
+        setTimeout(() => {
+          this.dispatch({ type: PeerStateChange.PING, payload: ['blue.200', 'PING'] })
+        }, 1500)
+      } else {
+        this.dispatch({ type: PeerStateChange.PING, payload: ['red.200', 'PING FAILED'] })
+        setTimeout(() => {
+          this.dispatch({ type: PeerStateChange.PING, payload: ['blue.200', 'PINGING'] })
+        }, 1000)
+      }
+    }, 500)
+  }
+
+  handleFindNodes = (peer: ENR) => {
+    this.historyProtocol!.sendFindNodes(peer.nodeId, [parseInt(this.state.distance)])
+  }
+
+  handleRequestSnapshot = () => {
+    const accumulatorKey = HistoryNetworkContentKeyUnionType.serialize({
+      selector: 4,
+      value: { selector: 0, value: null },
+    })
+    this.historyProtocol!.sendFindContent(
+      ENR.decodeTxt(this.state.selectedPeer).nodeId,
+      accumulatorKey
+    )
+  }
+
+  handleOffer = () => {
+    this.historyProtocol!.sendOffer(ENR.decodeTxt(this.state.selectedPeer).nodeId, this.state.offer)
+  }
+  sendFindContent = async (type: string) => {
+    if (type === 'header') {
+      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 0,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(this.state.blockHash),
+        },
+      })
+      const header = await this.historyProtocol!.sendFindContent(
+        ENR.decodeTxt(this.state.selectedPeer).nodeId,
+        headerKey
+      )
+      const block = reassembleBlock(header!.value as Uint8Array, undefined)
+      return block //
+    } else if (type === 'body') {
+      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 0,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(this.state.blockHash),
+        },
+      })
+      this.historyProtocol!.sendFindContent(
+        ENR.decodeTxt(this.state.selectedPeer).nodeId,
+        headerKey
+      )
+      const bodyKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 1,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(this.state.blockHash),
+        },
+      })
+      this.historyProtocol!.sendFindContent(ENR.decodeTxt(this.state.selectedPeer).nodeId, bodyKey)
+    } else if (type === 'block') {
+      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 0,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(this.state.blockHash),
+        },
+      })
+      const bodyKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 1,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(this.state.blockHash),
+        },
+      })
+      try {
+        const header = (
+          await this.historyProtocol!.sendFindContent(
+            ENR.decodeTxt(this.state.selectedPeer).nodeId,
+            headerKey
+          )
+        )?.value as Uint8Array
+        const _body = await this.historyProtocol!.sendFindContent(
+          ENR.decodeTxt(this.state.selectedPeer).nodeId,
+          bodyKey
+        )
+        const body: Uint8Array | undefined =
+          _body !== undefined ? (_body.value as Uint8Array) : undefined
+        const block = reassembleBlock(header, body)
+        return block // this.dispatch({ type: StateChange.SETBLOCK, payload: block })
+      } catch {}
+    } else if (type === 'epoch') {
+      const _epochKey = HistoryNetworkContentKeyUnionType.serialize({
+        selector: 3,
+        value: {
+          chainId: 1,
+          blockHash: this.historyProtocol!.accumulator.historicalEpochs()[this.state.epoch],
+        },
+      })
+    }
+  }
+}

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -18,35 +18,17 @@ export class PeerActions {
     this.historyProtocol = protocol
   }
 
-  addToOffer = (type: string): void => {
-    switch (type) {
-      case 'header':
-        this.dispatch({
-          type: PeerStateChange.ADDTOOFFER,
-          payload: HistoryNetworkContentKeyUnionType.serialize({
-            selector: HistoryNetworkContentTypes.BlockHeader,
-            value: {
-              chainId: 1,
-              blockHash: fromHexString(this.state.blockHash),
-            },
-          }),
-        })
-        break
-      case 'body':
-        this.dispatch({
-          type: PeerStateChange.ADDTOOFFER,
-          payload: HistoryNetworkContentKeyUnionType.serialize({
-            selector: HistoryNetworkContentTypes.BlockBody,
-            value: {
-              chainId: 1,
-              blockHash: fromHexString(this.state.blockHash),
-            },
-          }),
-        })
-        break
-      default:
-        throw new Error()
-    }
+  addToOffer = (type: HistoryNetworkContentTypes): void => {
+    this.dispatch({
+      type: PeerStateChange.ADDTOOFFER,
+      payload: HistoryNetworkContentKeyUnionType.serialize({
+        selector: type,
+        value: {
+          chainId: 1,
+          blockHash: fromHexString(this.state.blockHash),
+        },
+      }),
+    })
   }
 
   handlePing = async (enr: string) => {

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -18,46 +18,54 @@ export class PeerActions {
     this.historyProtocol = protocol
   }
 
-  addToOffer = (type: string): Uint8Array[] => {
+  addToOffer = (type: string): void => {
     switch (type) {
       case 'header':
-        return [
-          HistoryNetworkContentKeyUnionType.serialize({
+        this.dispatch({
+          type: PeerStateChange.ADDTOOFFER,
+          payload: HistoryNetworkContentKeyUnionType.serialize({
             selector: HistoryNetworkContentTypes.BlockHeader,
             value: {
               chainId: 1,
               blockHash: fromHexString(this.state.blockHash),
             },
           }),
-        ]
+        })
+        break
       case 'body':
-        return [
-          HistoryNetworkContentKeyUnionType.serialize({
+        this.dispatch({
+          type: PeerStateChange.ADDTOOFFER,
+          payload: HistoryNetworkContentKeyUnionType.serialize({
             selector: HistoryNetworkContentTypes.BlockBody,
             value: {
               chainId: 1,
               blockHash: fromHexString(this.state.blockHash),
             },
           }),
-        ]
-
+        })
+        break
       case 'block':
-        return [
-          HistoryNetworkContentKeyUnionType.serialize({
+        this.dispatch({
+          type: PeerStateChange.ADDTOOFFER,
+          payload: HistoryNetworkContentKeyUnionType.serialize({
             selector: HistoryNetworkContentTypes.BlockHeader,
             value: {
               chainId: 1,
               blockHash: fromHexString(this.state.blockHash),
             },
           }),
-          HistoryNetworkContentKeyUnionType.serialize({
+        })
+        this.dispatch({
+          type: PeerStateChange.ADDTOOFFER,
+          payload: HistoryNetworkContentKeyUnionType.serialize({
             selector: HistoryNetworkContentTypes.BlockBody,
             value: {
               chainId: 1,
               blockHash: fromHexString(this.state.blockHash),
             },
           }),
-        ]
+        })
+        break
       default:
         throw new Error()
     }
@@ -93,9 +101,10 @@ export class PeerActions {
     this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, accumulatorKey)
   }
 
-  handleOffer = (enr: string) => {
-    this.historyProtocol!.sendOffer(ENR.decodeTxt(enr).nodeId, this.state.offer)
+  handleOffer = async (enr: string) => {
+    await this.historyProtocol!.sendOffer(ENR.decodeTxt(enr).nodeId, this.state.offer)
   }
+
   sendFindContent = async (type: string, enr: string) => {
     if (type === 'header') {
       const headerKey = HistoryNetworkContentKeyUnionType.serialize({

--- a/packages/browser-client/src/peerReducer.ts
+++ b/packages/browser-client/src/peerReducer.ts
@@ -1,0 +1,63 @@
+import React from 'react'
+
+export interface PeerState {
+  epoch: number
+  offer: Uint8Array[]
+  ping: [string, string]
+  distance: string
+  blockHash: string
+}
+
+export const peerInitialState = {
+  epoch: 0,
+  offer: [],
+  ping: ['blue.100', 'PING'] as [string, string],
+  distance: '',
+  blockHash: '',
+}
+
+export interface PeerStateAction {
+  type: PeerStateChange
+  payload?: any
+}
+export type PeerReducer = React.Reducer<PeerState, PeerStateAction>
+export type ReducerState = React.ReducerState<PeerReducer>
+
+export enum PeerStateChange {
+  SETEPOCH = 'SETEPOCH',
+  ADDTOOFFER = 'ADDTOOFFER',
+  PING = 'PING',
+  SETDISTANCE = 'SETDISTANCE',
+  SETBLOCKHASH = 'SETBLOCKHASH',
+  SETPEERIDX = 'SETPEERIDX',
+}
+
+export const peerReducer = (state: PeerState, action: PeerStateAction) => {
+  const { type, payload } = action
+  switch (type) {
+    case PeerStateChange.SETEPOCH:
+      return state
+    case PeerStateChange.ADDTOOFFER:
+      return {
+        ...state,
+        offer: [...state.offer, payload],
+      }
+    case PeerStateChange.PING:
+      return { ...state, ping: payload }
+    case PeerStateChange.SETDISTANCE:
+      return state
+    case PeerStateChange.SETBLOCKHASH:
+      return { ...state, blockHash: payload }
+    default:
+      throw new Error()
+  }
+}
+
+export type peerReducerType = { dispatch: React.Dispatch<PeerStateAction> }
+
+export type PeerContextType = {
+  state?: PeerState
+  dispatch?: React.Dispatch<PeerStateAction>
+}
+
+export const PeerContext = React.createContext<PeerContextType>({})

--- a/packages/browser-client/src/peerReducer.ts
+++ b/packages/browser-client/src/peerReducer.ts
@@ -6,6 +6,7 @@ export interface PeerState {
   ping: [string, string]
   distance: string
   blockHash: string
+  selectedPeer: string
 }
 
 export const peerInitialState = {
@@ -14,6 +15,7 @@ export const peerInitialState = {
   ping: ['blue.100', 'PING'] as [string, string],
   distance: '',
   blockHash: '',
+  selectedPeer: '',
 }
 
 export interface PeerStateAction {
@@ -30,6 +32,7 @@ export enum PeerStateChange {
   SETDISTANCE = 'SETDISTANCE',
   SETBLOCKHASH = 'SETBLOCKHASH',
   SETPEERIDX = 'SETPEERIDX',
+  SETSELECTEDPEER = 'SETSELECTEDPEER',
 }
 
 export const peerReducer = (state: PeerState, action: PeerStateAction) => {
@@ -48,16 +51,19 @@ export const peerReducer = (state: PeerState, action: PeerStateAction) => {
       return state
     case PeerStateChange.SETBLOCKHASH:
       return { ...state, blockHash: payload }
+    case PeerStateChange.SETSELECTEDPEER:
+      return { ...state, selectedPeer: payload }
     default:
       throw new Error()
   }
 }
 
-export type peerReducerType = { dispatch: React.Dispatch<PeerStateAction> }
+export type PeerDispatch = React.Dispatch<PeerStateAction>
+export type PeerReducerType = { dispatch: PeerDispatch }
 
 export type PeerContextType = {
   state?: PeerState
-  dispatch?: React.Dispatch<PeerStateAction>
+  dispatch?: PeerDispatch
 }
 
 export const PeerContext = React.createContext<PeerContextType>({})

--- a/packages/browser-client/src/peerReducer.ts
+++ b/packages/browser-client/src/peerReducer.ts
@@ -6,7 +6,6 @@ export interface PeerState {
   ping: [string, string]
   distance: string
   blockHash: string
-  selectedPeer: string
 }
 
 export const peerInitialState = {
@@ -15,7 +14,6 @@ export const peerInitialState = {
   ping: ['blue.100', 'PING'] as [string, string],
   distance: '',
   blockHash: '',
-  selectedPeer: '',
 }
 
 export interface PeerStateAction {
@@ -32,7 +30,6 @@ export enum PeerStateChange {
   SETDISTANCE = 'SETDISTANCE',
   SETBLOCKHASH = 'SETBLOCKHASH',
   SETPEERIDX = 'SETPEERIDX',
-  SETSELECTEDPEER = 'SETSELECTEDPEER',
 }
 
 export const peerReducer = (state: PeerState, action: PeerStateAction) => {
@@ -51,8 +48,6 @@ export const peerReducer = (state: PeerState, action: PeerStateAction) => {
       return state
     case PeerStateChange.SETBLOCKHASH:
       return { ...state, blockHash: payload }
-    case PeerStateChange.SETSELECTEDPEER:
-      return { ...state, selectedPeer: payload }
     default:
       throw new Error()
   }
@@ -62,8 +57,8 @@ export type PeerDispatch = React.Dispatch<PeerStateAction>
 export type PeerReducerType = { dispatch: PeerDispatch }
 
 export type PeerContextType = {
-  state?: PeerState
-  dispatch?: PeerDispatch
+  peerState: PeerState
+  peerDispatch: PeerDispatch
 }
 
-export const PeerContext = React.createContext<PeerContextType>({})
+export const PeerContext = React.createContext<PeerContextType | undefined>(undefined)


### PR DESCRIPTION
for issue #358
continuing PR #357

Clean up for useReducer implementation in the `PeerButtons` component.

Creates new utility files:
* peerReducer.ts
  * Handles the state / dispatch logic
* peerActions.ts
  * Handles the portal network calls triggered by clicking buttons

