### PR TITLE
Remove chainId

### DIFF
--- a/packages/browser-client/src/Components/DisplayBlock.tsx
+++ b/packages/browser-client/src/Components/DisplayBlock.tsx
@@ -244,34 +244,38 @@ const DisplayBlock = () => {
   }
   async function init() {
     try {
-      setContentKeys({
-        header: toHexString(
-          HistoryNetworkContentKeyUnionType.serialize({
-            selector: 0,
-            value: {
-              chainId: 1,
-              blockHash: fromHexString(state.block!.hash),
-            },
-          })
-        ),
-        body: toHexString(
-          HistoryNetworkContentKeyUnionType.serialize({
-            selector: 1,
-            value: {
-              chainId: 1,
-              blockHash: fromHexString(state.block!.hash),
-            },
-          })
-        ),
-      })
-    } catch {}
+      const receipts = await state!.historyProtocol?.receiptManager.getReceipts(block.hash())
+      if (receipts) {
+        setReceipts(receipts)
+      }
+    } catch (err) {
+      console.log((err as any).message)
+    }
   }
 
   useEffect(() => {
-    if (state.block) {
+    if (state!.block!.transactions.length > 0) {
       init()
     }
-  }, [state.block])
+  }, [state!.block])
+
+  const headerlookupKey = toHexString(
+    HistoryNetworkContentKeyUnionType.serialize({
+      selector: 0,
+      value: {
+        blockHash: block.header.hash(),
+      },
+    })
+  )
+
+  const bodylookupKey = toHexString(
+    HistoryNetworkContentKeyUnionType.serialize({
+      selector: 1,
+      value: {
+        blockHash: block.header.hash(),
+      },
+    })
+  )
 
   return (
     <Box>

--- a/packages/browser-client/src/Components/GetHeaderProofByHash.tsx
+++ b/packages/browser-client/src/Components/GetHeaderProofByHash.tsx
@@ -17,7 +17,6 @@ export default function GetHeaderProofByHash() {
     const lookupKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: 5,
       value: {
-        chainId: 1,
         blockHash: fromHexString(blockHash),
       },
     })

--- a/packages/cli/src/modules/portal.ts
+++ b/packages/cli/src/modules/portal.ts
@@ -93,7 +93,6 @@ export class portal {
     try {
       const protocol = this._client.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       protocol.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         blockHash,
         fromHexString(rlpHex)
@@ -182,7 +181,6 @@ export class portal {
       return HistoryNetworkContentKeyUnionType.serialize({
         selector: contentTypes[idx],
         value: {
-          chainId: 1,
           blockHash: fromHexString(blockHash),
         },
       })

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -198,8 +198,8 @@ export class ContentManager {
       return record.blockHash
     })
     for (const hash in _epoch) {
-      const headerKey = getHistoryNetworkContentId(0, hash)
-      const bodyKey = getHistoryNetworkContentId(1, hash)
+      const headerKey = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, hash)
+      const bodyKey = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, hash)
       const headerDistance = distance(this.history.client.discv5.enr.nodeId, headerKey)
       const bodyDistance = distance(this.history.client.discv5.enr.nodeId, bodyKey)
       if (headerDistance <= this.radius) {

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -28,19 +28,17 @@ export class ContentManager {
 
   /**
    * Convenience method to add content for the History Network to the DB
-   * @param chainId - decimal number representing chain Id
    * @param contentType - content type of the data item being stored
    * @param hashKey - hex string representation of blockHash or epochHash
    * @param value - hex string representing RLP encoded blockheader, block body, or block receipt
    * @throws if `blockHash` or `value` is not hex string
    */
   public addContentToHistory = async (
-    chainId: number,
     contentType: HistoryNetworkContentTypes,
     hashKey: string,
     value: Uint8Array
   ) => {
-    const contentId = getHistoryNetworkContentId(chainId, contentType, hashKey)
+    const contentId = getHistoryNetworkContentId(contentType, hashKey)
 
     switch (contentType) {
       case HistoryNetworkContentTypes.BlockHeader: {
@@ -78,7 +76,6 @@ export class ContentManager {
                 EpochAccumulator.hashTreeRoot(this.history.accumulator.currentEpoch())
               )
               this.addContentToHistory(
-                chainId,
                 HistoryNetworkContentTypes.EpochAccumulator,
                 currentEpochHash,
                 currentEpoch
@@ -92,7 +89,7 @@ export class ContentManager {
               }/${EPOCH_SIZE} of current Epoch`
             )
             this.history.client.db.put(
-              getHistoryNetworkContentId(1, HistoryNetworkContentTypes.HeaderAccumulator),
+              getHistoryNetworkContentId(HistoryNetworkContentTypes.HeaderAccumulator),
               toHexString(
                 HeaderAccumulatorType.serialize(this.history.accumulator.masterAccumulator())
               )
@@ -110,7 +107,6 @@ export class ContentManager {
         let block: Block
         try {
           const headerContentId = getHistoryNetworkContentId(
-            1,
             HistoryNetworkContentTypes.BlockHeader,
             hashKey
           )
@@ -142,13 +138,13 @@ export class ContentManager {
       }
       case HistoryNetworkContentTypes.Receipt:
         this.history.client.db.put(
-          getHistoryNetworkContentId(1, HistoryNetworkContentTypes.Receipt, hashKey),
+          getHistoryNetworkContentId(HistoryNetworkContentTypes.Receipt, hashKey),
           toHexString(value)
         )
         break
       case HistoryNetworkContentTypes.EpochAccumulator:
         this.history.client.db.put(
-          getHistoryNetworkContentId(1, HistoryNetworkContentTypes.EpochAccumulator, hashKey),
+          getHistoryNetworkContentId(HistoryNetworkContentTypes.EpochAccumulator, hashKey),
           toHexString(value)
         )
         break
@@ -193,7 +189,7 @@ export class ContentManager {
     const lookup = new ContentLookup(this.history, key)
     try {
       const content = await lookup.startLookup()
-      this.addContentToHistory(1, type, hash, content as Uint8Array)
+      this.addContentToHistory(type, hash, content as Uint8Array)
     } catch {}
   }
 
@@ -202,8 +198,8 @@ export class ContentManager {
       return record.blockHash
     })
     for (const hash in _epoch) {
-      const headerKey = getHistoryNetworkContentId(1, 0, hash)
-      const bodyKey = getHistoryNetworkContentId(1, 1, hash)
+      const headerKey = getHistoryNetworkContentId(0, hash)
+      const bodyKey = getHistoryNetworkContentId(1, hash)
       const headerDistance = distance(this.history.client.discv5.enr.nodeId, headerKey)
       const bodyDistance = distance(this.history.client.discv5.enr.nodeId, bodyKey)
       if (headerDistance <= this.radius) {
@@ -213,7 +209,6 @@ export class ContentManager {
           const key = HistoryNetworkContentKeyUnionType.serialize({
             selector: 0,
             value: {
-              chainId: 1,
               blockHash: fromHexString(hash),
             },
           })
@@ -227,7 +222,6 @@ export class ContentManager {
           const key = HistoryNetworkContentKeyUnionType.serialize({
             selector: 1,
             value: {
-              chainId: 1,
               blockHash: fromHexString(hash),
             },
           })

--- a/packages/portalnetwork/src/subprotocols/history/eth_module.ts
+++ b/packages/portalnetwork/src/subprotocols/history/eth_module.ts
@@ -21,13 +21,13 @@ export class ETH {
   ): Promise<Block | undefined> => {
     const headerContentKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: 0,
-      value: { chainId: 1, blockHash: fromHexString(blockHash) },
+      value: { blockHash: fromHexString(blockHash) },
     })
 
     const bodyContentKey = includeTransactions
       ? HistoryNetworkContentKeyUnionType.serialize({
           selector: 1,
-          value: { chainId: 1, blockHash: fromHexString(blockHash) },
+          value: { blockHash: fromHexString(blockHash) },
         })
       : undefined
     let header: any
@@ -95,7 +95,7 @@ export class ETH {
       }
       const lookupKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: 3,
-        value: { chainId: 1, blockHash: epochRootHash },
+        value: { blockHash: epochRootHash },
       })
 
       const lookup = new ContentLookup(this.protocol, lookupKey)

--- a/packages/portalnetwork/src/subprotocols/history/gossip.ts
+++ b/packages/portalnetwork/src/subprotocols/history/gossip.ts
@@ -58,11 +58,10 @@ export class GossipManager {
    * @param contentType
    */
   public add(hash: string, contentType: HistoryNetworkContentTypes): void {
-    const id = getHistoryNetworkContentId(1, contentType, hash)
+    const id = getHistoryNetworkContentId(contentType, hash)
     const key = HistoryNetworkContentKeyUnionType.serialize({
       selector: contentType,
       value: {
-        chainId: 1,
         blockHash: fromHexString(hash),
       },
     })

--- a/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
@@ -156,7 +156,11 @@ export class AccumulatorManager {
   public verifyInclusionProof = async (proof: any, blockHash: string) => {
     const header = BlockHeader.fromRLPSerializedHeader(
       Buffer.from(
-        fromHexString(await this._history.client.db.get(getHistoryNetworkContentId(0, blockHash)))
+        fromHexString(
+          await this._history.client.db.get(
+            getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+          )
+        )
       ),
       { hardforkByBlockNumber: true }
     )
@@ -218,7 +222,11 @@ export class AccumulatorManager {
   public async getHeaderRecordFromBlockhash(blockHash: string) {
     const header = BlockHeader.fromRLPSerializedHeader(
       Buffer.from(
-        fromHexString(await this._history.client.db.get(getHistoryNetworkContentId(0, blockHash)))
+        fromHexString(
+          await this._history.client.db.get(
+            getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+          )
+        )
       ),
       { hardforkByBlockNumber: true }
     )

--- a/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
@@ -129,7 +129,7 @@ export class AccumulatorManager {
     let storedAccumulator
     try {
       storedAccumulator = await this._history.client.db.get(
-        getHistoryNetworkContentId(1, HistoryNetworkContentTypes.HeaderAccumulator)
+        getHistoryNetworkContentId(HistoryNetworkContentTypes.HeaderAccumulator)
       )
     } catch {}
 
@@ -156,9 +156,7 @@ export class AccumulatorManager {
   public verifyInclusionProof = async (proof: any, blockHash: string) => {
     const header = BlockHeader.fromRLPSerializedHeader(
       Buffer.from(
-        fromHexString(
-          await this._history.client.db.get(getHistoryNetworkContentId(1, 0, blockHash))
-        )
+        fromHexString(await this._history.client.db.get(getHistoryNetworkContentId(0, blockHash)))
       ),
       { hardforkByBlockNumber: true }
     )
@@ -178,7 +176,7 @@ export class AccumulatorManager {
   }
   public generateInclusionProof = async (blockHash: string): Promise<HeaderProofInterface> => {
     const _blockHeader = await this._history.client.db.get(
-      getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockHeader, blockHash)
+      getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
     )
     if (_blockHeader === undefined) {
       throw new Error('Cannot create proof for unknown header')
@@ -199,7 +197,6 @@ export class AccumulatorManager {
         : fromHexString(
             await this._history.client.db.get(
               getHistoryNetworkContentId(
-                1,
                 HistoryNetworkContentTypes.EpochAccumulator,
                 toHexString(this.headerAccumulator.historicalEpochs[epochIdx - 1])
               )
@@ -221,9 +218,7 @@ export class AccumulatorManager {
   public async getHeaderRecordFromBlockhash(blockHash: string) {
     const header = BlockHeader.fromRLPSerializedHeader(
       Buffer.from(
-        fromHexString(
-          await this._history.client.db.get(getHistoryNetworkContentId(1, 0, blockHash))
-        )
+        fromHexString(await this._history.client.db.get(getHistoryNetworkContentId(0, blockHash)))
       ),
       { hardforkByBlockNumber: true }
     )
@@ -236,7 +231,6 @@ export class AccumulatorManager {
         fromHexString(
           await this._history.client.db.get(
             getHistoryNetworkContentId(
-              1,
               3,
               toHexString(this.headerAccumulator.historicalEpochs[epochIndex - 1])
             )
@@ -256,7 +250,6 @@ export class AccumulatorManager {
       const proofLookupKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: HistoryNetworkContentTypes.HeaderProof,
         value: {
-          chainId: 1,
           blockHash: blockHash,
         },
       })
@@ -315,7 +308,7 @@ export class AccumulatorManager {
           'with Accumulator of height',
           newAccumulator.currentHeight()
         )
-        this._history.client.db.put(getHistoryNetworkContentId(1, 4), toHexString(decoded))
+        this._history.client.db.put(getHistoryNetworkContentId(4), toHexString(decoded))
         this.replaceAccumulator(newAccumulator)
       }
     } catch (err: any) {

--- a/packages/portalnetwork/src/subprotocols/history/receiptManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/receiptManager.ts
@@ -112,7 +112,6 @@ export class ReceiptsManager {
     this.protocol.logger.extend('RECEIPT_MANAGER')(`Encoding ${receipts.length} receipts for db`)
     const encoded = this.rlp(RlpConvert.Encode, RlpType.Receipts, receipts)
     await this.protocol.addContentToHistory(
-      1,
       HistoryNetworkContentTypes.Receipt,
       toHexString(block.hash()),
       encoded
@@ -140,9 +139,7 @@ export class ReceiptsManager {
     calcBloom = false,
     includeTxType = false
   ): Promise<TxReceipt[] | TxReceiptWithType[]> {
-    const encoded = await this.db.get(
-      getHistoryNetworkContentId(1, HistoryNetworkContentTypes.Receipt, toHexString(blockHash))
-    )
+    const encoded = await this.db.get(getHistoryNetworkContentId(2, toHexString(blockHash)))
     if (!encoded) return []
     let receipts = this.rlp(
       RlpConvert.Decode,

--- a/packages/portalnetwork/src/subprotocols/history/types.ts
+++ b/packages/portalnetwork/src/subprotocols/history/types.ts
@@ -24,17 +24,14 @@ export const MAX_ENCODED_UNCLES_LENGTH = MAX_HEADER_LENGTH * 2 ** 4
 
 /* ----------------- Types ----------- */
 /**
- * @property chainId - integer representing the chain ID (e.g. Ethereum Mainnet is 1)
  * @property blockHash - byte representation of the hex encoded block hash
  *
  */
 export type HistoryNetworkContentKey = {
-  chainId: number
   blockHash: Uint8Array
 }
 
 export const BlockHeaderType = new ContainerType({
-  chainId: new UintNumberType(2),
   blockHash: new ByteVectorType(32),
 })
 

--- a/packages/portalnetwork/src/subprotocols/history/types.ts
+++ b/packages/portalnetwork/src/subprotocols/history/types.ts
@@ -5,7 +5,6 @@ import {
   ListCompositeType,
   NoneType,
   UintBigintType,
-  UintNumberType,
   UnionType,
 } from '@chainsafe/ssz'
 

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -126,13 +126,11 @@ export const addRLPSerializedBlock = async (
 ) => {
   const decodedBlock = rlp.decode(fromHexString(rlpHex))
   await protocol.addContentToHistory(
-    1,
     HistoryNetworkContentTypes.BlockHeader,
     blockHash,
     rlp.encode((decodedBlock as Buffer[])[0])
   )
   await protocol.addContentToHistory(
-    1,
     HistoryNetworkContentTypes.BlockBody,
     blockHash,
     sszEncodeBlockBody(

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -20,13 +20,12 @@ import { HistoryProtocol } from './history.js'
 
 /**
  * Generates the Content ID used to calculate the distance between a node ID and the content Key
- * @param contentKey an object containing the `chainId` and `blockHash` used to generate the content Key
+ * @param contentKey an object containing the and `blockHash` used to generate the content Key
  * @param contentType a number identifying the type of content (block header, block body, receipt, epochAccumulator, headerAccumulator)
  * @param hash the hash of the content represented (i.e. block hash for header, body, or receipt, or root hash for accumulators)
  * @returns the hex encoded string representation of the SHA256 hash of the serialized contentKey
  */
 export const getHistoryNetworkContentId = (
-  chainId: number,
   contentType: HistoryNetworkContentTypes,
   hash?: string
 ) => {
@@ -40,7 +39,6 @@ export const getHistoryNetworkContentId = (
       encodedKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: contentType,
         value: {
-          chainId: chainId,
           blockHash: fromHexString(hash),
         },
       })
@@ -58,7 +56,6 @@ export const getHistoryNetworkContentId = (
       encodedKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: contentType,
         value: {
-          chainId: chainId,
           blockHash: fromHexString(hash),
         },
       })

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -409,7 +409,6 @@ export class PortalNetworkUTP extends BasicUtp {
         // EpochAccumulator requests...
         this.emit(
           'Stream',
-          1,
           contentKey.selector,
           contentKey.selector > 2
             ? toHexString(Uint8Array.from([]))

--- a/packages/portalnetwork/test/integration/history.spec.ts
+++ b/packages/portalnetwork/test/integration/history.spec.ts
@@ -39,21 +39,19 @@ tape('History Protocol Integration Tests', (t) => {
       const protocol1 = portal1.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       const protocol2 = portal2.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       for (const block of blocks) {
-        portal1.db.put(getHistoryNetworkContentId(1, 0, block.hash), block.rawHeader)
+        portal1.db.put(getHistoryNetworkContentId(0, block.hash), block.rawHeader)
       }
-      portal1.db.put(getHistoryNetworkContentId(1, 3, epoch.hash), epoch.serialized)
+      portal1.db.put(getHistoryNetworkContentId(3, epoch.hash), epoch.serialized)
       const testAccumulator = require('./testAccumulator.json')
       const desAccumulator = HeaderAccumulatorType.deserialize(fromHexString(testAccumulator))
       const rebuiltAccumulator = new HeaderAccumulator({ storedAccumulator: desAccumulator })
 
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         fromHexString(testAccumulator)
       )
       await protocol2.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         blocks[1000].hash,
         fromHexString(blocks[1000].rawHeader)
@@ -116,7 +114,6 @@ tape('History Protocol Integration Tests', (t) => {
       })
 
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         fromHexString(testAccumulator)
@@ -192,43 +189,36 @@ tape('History Protocol Integration Tests', (t) => {
         storedAccumulator: accumulator,
       })
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         HeaderAccumulatorType.serialize(accumulator)
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.EpochAccumulator,
         _epoch1.hash,
         fromHexString(_epoch1.serialized)
       )
       await protocol2.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.EpochAccumulator,
         _epoch1.hash,
         fromHexString(_epoch1.serialized)
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         toHexString(header1000.hash()),
         header1000.serialize()
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         toHexString(header8199.hash()),
         header8199.serialize()
       )
       await protocol2.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         toHexString(header1000.hash()),
         header1000.serialize()
       )
       await protocol2.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         toHexString(header8199.hash()),
         header8199.serialize()
@@ -249,14 +239,12 @@ tape('History Protocol Integration Tests', (t) => {
       const proofKey1000 = HistoryNetworkContentKeyUnionType.serialize({
         selector: HistoryNetworkContentTypes.HeaderProof,
         value: {
-          chainId: 1,
           blockHash: header1000.hash(),
         },
       })
       const proofKey8199 = HistoryNetworkContentKeyUnionType.serialize({
         selector: HistoryNetworkContentTypes.HeaderProof,
         value: {
-          chainId: 1,
           blockHash: header8199.hash(),
         },
       })
@@ -309,12 +297,12 @@ tape('History Protocol Integration Tests', (t) => {
             )
             const header = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockHeader, blockHash)
+                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
               )
             )
             const body = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockBody, blockHash)
+                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
               )
             )
             const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]
@@ -338,13 +326,11 @@ tape('History Protocol Integration Tests', (t) => {
       await protocol1.sendPing(portal2.discv5.enr)
       testBlocks.forEach(async (testBlock: Block, idx: number) => {
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockHeader,
           testHashStrings[idx],
           testBlock.header.serialize()
         )
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockBody,
           testHashStrings[idx],
           sszEncodeBlockBody(testBlock)
@@ -363,7 +349,6 @@ tape('History Protocol Integration Tests', (t) => {
       const epochKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: 3,
         value: {
-          chainId: 1,
           blockHash: fromHexString(epochHash),
         },
       })
@@ -379,13 +364,11 @@ tape('History Protocol Integration Tests', (t) => {
           value: { selector: 0, value: null },
         })
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.HeaderAccumulator,
           toHexString(accumulatorKey),
           fromHexString(accumulatorData)
         )
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.EpochAccumulator,
           toHexString(epochKey),
           fromHexString(serialized)
@@ -424,7 +407,7 @@ tape('History Protocol Integration Tests', (t) => {
               'EpochAccumulator has valid hash for block 1000'
             )
             st.equal(content, epochData.serialized, 'EpochAccumulator matches test Data')
-            const contentId = getHistoryNetworkContentId(1, 3, blockHash)
+            const contentId = getHistoryNetworkContentId(3, blockHash)
             const stored = await portal2.db.get(contentId)
             st.equal(stored, epochData.serialized, 'EpochAccumulator stored in db')
             end(child, [portal1, portal2], st)

--- a/packages/portalnetwork/test/integration/history.spec.ts
+++ b/packages/portalnetwork/test/integration/history.spec.ts
@@ -39,7 +39,10 @@ tape('History Protocol Integration Tests', (t) => {
       const protocol1 = portal1.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       const protocol2 = portal2.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
       for (const block of blocks) {
-        portal1.db.put(getHistoryNetworkContentId(0, block.hash), block.rawHeader)
+        portal1.db.put(
+          getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, block.hash),
+          block.rawHeader
+        )
       }
       portal1.db.put(getHistoryNetworkContentId(3, epoch.hash), epoch.serialized)
       const testAccumulator = require('./testAccumulator.json')

--- a/packages/portalnetwork/test/integration/rpc.spec.ts
+++ b/packages/portalnetwork/test/integration/rpc.spec.ts
@@ -110,11 +110,15 @@ tape('getBlockByHash', (t) => {
         testBlock.header.hash(),
         'eth_getBlockByHash test passed'
       )
-      const _h = await portal2.db.get(getHistoryNetworkContentId(0, testHash))
+      const _h = await portal2.db.get(
+        getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, testHash)
+      )
       st.equal(_h, toHexString(testHeader), 'eth_getBlockByHash returned a Block Header')
 
       try {
-        await portal2.db.get(getHistoryNetworkContentId(1, testHash))
+        await portal2.db.get(
+          getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, testHash)
+        )
         st.fail('should not find block body')
       } catch (e: any) {
         st.equal(
@@ -147,8 +151,14 @@ tape('getBlockByNumber', (t) => {
 
       const block8200Hash = testBlockData[0].blockHash
       const block8200Rlp = testBlockData[0].rlp
-      const headerKey = getHistoryNetworkContentId(0, block8200Hash)
-      const blockKey = getHistoryNetworkContentId(1, block8200Hash)
+      const headerKey = getHistoryNetworkContentId(
+        HistoryNetworkContentTypes.BlockHeader,
+        block8200Hash
+      )
+      const blockKey = getHistoryNetworkContentId(
+        HistoryNetworkContentTypes.BlockBody,
+        block8200Hash
+      )
       const testBlock = Block.fromRLPSerializedBlock(Buffer.from(fromHexString(block8200Rlp)), {
         hardforkByBlockNumber: true,
       })

--- a/packages/portalnetwork/test/integration/rpc.spec.ts
+++ b/packages/portalnetwork/test/integration/rpc.spec.ts
@@ -49,12 +49,12 @@ tape('getBlockByHash', (t) => {
           st.equal(testHashStrings[idx], blockHash, `eth_getBlockByHash retrieved a block body`)
           const header = fromHexString(
             await portal2.db.get(
-              getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockHeader, blockHash)
+              getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
             )
           )
           const body = fromHexString(
             await portal2.db.get(
-              getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockBody, blockHash)
+              getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
             )
           )
           const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]
@@ -69,13 +69,11 @@ tape('getBlockByHash', (t) => {
       })
       testBlocks.forEach(async (testBlock: Block, idx: number) => {
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockHeader,
           testHashStrings[idx],
           testBlock.header.serialize()
         )
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockBody,
           testHashStrings[idx],
           sszEncodeBlockBody(testBlock)
@@ -103,7 +101,7 @@ tape('getBlockByHash', (t) => {
       )
       const testHash = toHexString(testBlock.hash())
       const testHeader = testBlock.header.serialize()
-      await protocol1.addContentToHistory(1, 0, testHash, testHeader)
+      await protocol1.addContentToHistory(0, testHash, testHeader)
 
       await protocol1.sendPing(portal2.discv5.enr)
       const returnedBlock = (await protocol2.ETH.getBlockByHash(testHash, true)) as Block
@@ -112,11 +110,11 @@ tape('getBlockByHash', (t) => {
         testBlock.header.hash(),
         'eth_getBlockByHash test passed'
       )
-      const _h = await portal2.db.get(getHistoryNetworkContentId(1, 0, testHash))
+      const _h = await portal2.db.get(getHistoryNetworkContentId(0, testHash))
       st.equal(_h, toHexString(testHeader), 'eth_getBlockByHash returned a Block Header')
 
       try {
-        await portal2.db.get(getHistoryNetworkContentId(1, 1, testHash))
+        await portal2.db.get(getHistoryNetworkContentId(1, testHash))
         st.fail('should not find block body')
       } catch (e: any) {
         st.equal(
@@ -149,8 +147,8 @@ tape('getBlockByNumber', (t) => {
 
       const block8200Hash = testBlockData[0].blockHash
       const block8200Rlp = testBlockData[0].rlp
-      const headerKey = getHistoryNetworkContentId(1, 0, block8200Hash)
-      const blockKey = getHistoryNetworkContentId(1, 1, block8200Hash)
+      const headerKey = getHistoryNetworkContentId(0, block8200Hash)
+      const blockKey = getHistoryNetworkContentId(1, block8200Hash)
       const testBlock = Block.fromRLPSerializedBlock(Buffer.from(fromHexString(block8200Rlp)), {
         hardforkByBlockNumber: true,
       })
@@ -159,7 +157,6 @@ tape('getBlockByNumber', (t) => {
       portal1.db.put(headerKey, toHexString(block8200Header))
       portal1.db.put(blockKey, toHexString(block8200Body))
       await protocol2.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         fromHexString(testAccumulator)
@@ -196,7 +193,6 @@ tape('getBlockByNumber', (t) => {
     const epochKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: 3,
       value: {
-        chainId: 1,
         blockHash: fromHexString(epochHash),
       },
     })
@@ -220,24 +216,21 @@ tape('getBlockByNumber', (t) => {
         value: { selector: 0, value: null },
       })
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         fromHexString(accumulatorData)
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.EpochAccumulator,
         toHexString(epochKey),
         fromHexString(serialized)
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         blockHash,
         _header
       )
-      await protocol1.addContentToHistory(1, HistoryNetworkContentTypes.BlockBody, blockHash, body)
+      await protocol1.addContentToHistory(HistoryNetworkContentTypes.BlockBody, blockHash, body)
       let header: Uint8Array
       portal2.on('ContentAdded', async (blockHash, contentType, content) => {
         if (contentType === HistoryNetworkContentTypes.HeaderAccumulator) {

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -60,13 +60,11 @@ tape('Integration -- FINDCONTENT/FOUNDCONTENT', (t) => {
       const testBlockKeys: Uint8Array[] = []
 
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         testHash,
         testblockHeader.serialize()
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockBody,
         testHash,
         testBlockBody
@@ -74,18 +72,18 @@ tape('Integration -- FINDCONTENT/FOUNDCONTENT', (t) => {
       testBlockKeys.push(
         HistoryNetworkContentKeyUnionType.serialize({
           selector: HistoryNetworkContentTypes.BlockHeader,
-          value: { chainId: 1, blockHash: fromHexString(testHash) },
+          value: { blockHash: fromHexString(testHash) },
         }),
         HistoryNetworkContentKeyUnionType.serialize({
           selector: HistoryNetworkContentTypes.BlockBody,
-          value: { chainId: 1, blockHash: fromHexString(testHash) },
+          value: { blockHash: fromHexString(testHash) },
         })
       )
       let header: Uint8Array
       portal2.on('ContentAdded', async (blockHash, contentType, content) => {
         st.equal(
-          await portal1.db.get(getHistoryNetworkContentId(1, contentType, testHash)),
-          await portal2.db.get(getHistoryNetworkContentId(1, contentType, testHash)),
+          await portal1.db.get(getHistoryNetworkContentId(contentType, testHash)),
+          await portal2.db.get(getHistoryNetworkContentId(contentType, testHash)),
           `${HistoryNetworkContentTypes[contentType]} successfully stored in database`
         )
         if (contentType === HistoryNetworkContentTypes.BlockHeader) {
@@ -158,13 +156,11 @@ tape('OFFER/ACCEPT', (t) => {
       const testBlockKeys: Uint8Array[] = []
       for (const testBlock of testBlocks) {
         await protocol.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockHeader,
           '0x' + testBlock.header.hash().toString('hex'),
           testBlock.header.serialize()
         )
         await protocol.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockBody,
           '0x' + testBlock.header.hash().toString('hex'),
           sszEncodeBlockBody(testBlock)
@@ -172,11 +168,11 @@ tape('OFFER/ACCEPT', (t) => {
         testBlockKeys.push(
           HistoryNetworkContentKeyUnionType.serialize({
             selector: 0,
-            value: { chainId: 1, blockHash: Uint8Array.from(testBlock.header.hash()) },
+            value: { blockHash: Uint8Array.from(testBlock.header.hash()) },
           }),
           HistoryNetworkContentKeyUnionType.serialize({
             selector: 1,
-            value: { chainId: 1, blockHash: Uint8Array.from(testBlock.header.hash()) },
+            value: { blockHash: Uint8Array.from(testBlock.header.hash()) },
           })
         )
       }
@@ -186,7 +182,7 @@ tape('OFFER/ACCEPT', (t) => {
       portal1.on('ContentAdded', async (blockHash, contentType, content) => {
         st.equal(
           await portal1.db.get(
-            getHistoryNetworkContentId(1, contentType, testHashes[testHashes.indexOf(blockHash)])
+            getHistoryNetworkContentId(contentType, testHashes[testHashes.indexOf(blockHash)])
           ),
           content,
           `${HistoryNetworkContentTypes[contentType]} successfully stored in db`
@@ -273,12 +269,12 @@ tape('OFFER/ACCEPT', (t) => {
             )
             const header = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockHeader, blockHash)
+                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
               )
             )
             const body = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockBody, blockHash)
+                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
               )
             )
             const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]
@@ -303,13 +299,11 @@ tape('OFFER/ACCEPT', (t) => {
       await protocol1.sendPing(portal2.discv5.enr)
       testBlocks.forEach(async (testBlock: Block, idx: number) => {
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockHeader,
           testHashStrings[idx],
           testBlock.header.serialize()
         )
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockBody,
           testHashStrings[idx],
           sszEncodeBlockBody(testBlock)
@@ -351,12 +345,12 @@ tape('getBlockByHash', (t) => {
           st.equal(testHashStrings[idx], blockHash, `eth_getBlockByHash retrieved a block body`)
           const header = fromHexString(
             await portal2.db.get(
-              getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockHeader, blockHash)
+              getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
             )
           )
           const body = fromHexString(
             await portal2.db.get(
-              getHistoryNetworkContentId(1, HistoryNetworkContentTypes.BlockBody, blockHash)
+              getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
             )
           )
           const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]
@@ -371,13 +365,11 @@ tape('getBlockByHash', (t) => {
       })
       testBlocks.forEach(async (testBlock: Block, idx: number) => {
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockHeader,
           testHashStrings[idx],
           testBlock.header.serialize()
         )
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.BlockBody,
           testHashStrings[idx],
           sszEncodeBlockBody(testBlock)
@@ -405,7 +397,7 @@ tape('getBlockByHash', (t) => {
       )
       const testHash = toHexString(testBlock.hash())
       const testHeader = testBlock.header.serialize()
-      await protocol1.addContentToHistory(1, 0, testHash, testHeader)
+      await protocol1.addContentToHistory(0, testHash, testHeader)
 
       await protocol1.sendPing(portal2.discv5.enr)
       const returnedBlock = (await protocol2.ETH.getBlockByHash(testHash, true)) as Block
@@ -414,11 +406,11 @@ tape('getBlockByHash', (t) => {
         testBlock.header.hash(),
         'eth_getBlockByHash test passed'
       )
-      const _h = await portal2.db.get(getHistoryNetworkContentId(1, 0, testHash))
+      const _h = await portal2.db.get(getHistoryNetworkContentId(0, testHash))
       st.equal(_h, toHexString(testHeader), 'eth_getBlockByHash returned a Block Header')
 
       try {
-        await portal2.db.get(getHistoryNetworkContentId(1, 1, testHash))
+        await portal2.db.get(getHistoryNetworkContentId(1, testHash))
         st.fail('should not find block body')
       } catch (e: any) {
         st.equal(
@@ -451,8 +443,8 @@ tape('getBlockByNumber', (t) => {
 
       const block8200Hash = testBlockData[0].blockHash
       const block8200Rlp = testBlockData[0].rlp
-      const headerKey = getHistoryNetworkContentId(1, 0, block8200Hash)
-      const blockKey = getHistoryNetworkContentId(1, 1, block8200Hash)
+      const headerKey = getHistoryNetworkContentId(0, block8200Hash)
+      const blockKey = getHistoryNetworkContentId(1, block8200Hash)
       const testBlock = Block.fromRLPSerializedBlock(Buffer.from(fromHexString(block8200Rlp)), {
         hardforkByBlockNumber: true,
       })
@@ -461,7 +453,6 @@ tape('getBlockByNumber', (t) => {
       portal1.db.put(headerKey, toHexString(block8200Header))
       portal1.db.put(blockKey, toHexString(block8200Body))
       await protocol2.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         fromHexString(testAccumulator)
@@ -499,7 +490,6 @@ tape('getBlockByNumber', (t) => {
       const epochKey = HistoryNetworkContentKeyUnionType.serialize({
         selector: 3,
         value: {
-          chainId: 1,
           blockHash: fromHexString(epochHash),
         },
       })
@@ -515,13 +505,11 @@ tape('getBlockByNumber', (t) => {
           value: { selector: 0, value: null },
         })
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.HeaderAccumulator,
           toHexString(accumulatorKey),
           fromHexString(accumulatorData)
         )
         await protocol1.addContentToHistory(
-          1,
           HistoryNetworkContentTypes.EpochAccumulator,
           toHexString(epochKey),
           fromHexString(serialized)
@@ -560,7 +548,7 @@ tape('getBlockByNumber', (t) => {
               'EpochAccumulator has valid hash for block 1000'
             )
             st.equal(content, epochData.serialized, 'EpochAccumulator matches test Data')
-            const contentId = getHistoryNetworkContentId(1, 3, blockHash)
+            const contentId = getHistoryNetworkContentId(3, blockHash)
             const stored = await portal2.db.get(contentId)
             st.equal(stored, epochData.serialized, 'EpochAccumulator stored in db')
             end(child, [portal1, portal2], st)
@@ -582,7 +570,6 @@ tape('getBlockByNumber', (t) => {
     const epochKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: 3,
       value: {
-        chainId: 1,
         blockHash: fromHexString(epochHash),
       },
     })
@@ -606,24 +593,21 @@ tape('getBlockByNumber', (t) => {
         value: { selector: 0, value: null },
       })
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.HeaderAccumulator,
         toHexString(accumulatorKey),
         fromHexString(accumulatorData)
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.EpochAccumulator,
         toHexString(epochKey),
         fromHexString(serialized)
       )
       await protocol1.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         blockHash,
         _header
       )
-      await protocol1.addContentToHistory(1, HistoryNetworkContentTypes.BlockBody, blockHash, body)
+      await protocol1.addContentToHistory(HistoryNetworkContentTypes.BlockBody, blockHash, body)
       let header: Uint8Array
       portal2.on('ContentAdded', async (blockHash, contentType, content) => {
         if (contentType === HistoryNetworkContentTypes.HeaderAccumulator) {

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -406,11 +406,15 @@ tape('getBlockByHash', (t) => {
         testBlock.header.hash(),
         'eth_getBlockByHash test passed'
       )
-      const _h = await portal2.db.get(getHistoryNetworkContentId(0, testHash))
+      const _h = await portal2.db.get(
+        getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, testHash)
+      )
       st.equal(_h, toHexString(testHeader), 'eth_getBlockByHash returned a Block Header')
 
       try {
-        await portal2.db.get(getHistoryNetworkContentId(1, testHash))
+        await portal2.db.get(
+          getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, testHash)
+        )
         st.fail('should not find block body')
       } catch (e: any) {
         st.equal(
@@ -443,8 +447,14 @@ tape('getBlockByNumber', (t) => {
 
       const block8200Hash = testBlockData[0].blockHash
       const block8200Rlp = testBlockData[0].rlp
-      const headerKey = getHistoryNetworkContentId(0, block8200Hash)
-      const blockKey = getHistoryNetworkContentId(1, block8200Hash)
+      const headerKey = getHistoryNetworkContentId(
+        HistoryNetworkContentTypes.BlockHeader,
+        block8200Hash
+      )
+      const blockKey = getHistoryNetworkContentId(
+        HistoryNetworkContentTypes.BlockBody,
+        block8200Hash
+      )
       const testBlock = Block.fromRLPSerializedBlock(Buffer.from(fromHexString(block8200Rlp)), {
         hardforkByBlockNumber: true,
       })

--- a/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
@@ -48,7 +48,6 @@ tape('history Protocol FINDCONTENT/FOUDNCONTENT message handlers', async (t) => 
   const key = HistoryNetworkContentKeyUnionType.serialize({
     selector: 1,
     value: {
-      chainId: 1,
       blockHash: fromHexString(
         '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6'
       ),
@@ -71,7 +70,6 @@ tape('history Protocol FINDCONTENT/FOUDNCONTENT message handlers', async (t) => 
   td.reset()
 
   await protocol.addContentToHistory(
-    1,
     HistoryNetworkContentTypes.BlockHeader,
     block1Hash,
     fromHexString(block1Rlp)
@@ -79,7 +77,6 @@ tape('history Protocol FINDCONTENT/FOUDNCONTENT message handlers', async (t) => 
   const contentKey = HistoryNetworkContentKeyUnionType.serialize({
     selector: HistoryNetworkContentTypes.BlockHeader,
     value: {
-      chainId: 1,
       blockHash: fromHexString(block1Hash),
     },
   })
@@ -96,7 +93,6 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
       '0xf90211a0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479405a56e2d52c817161883f50c441c3228cfe54d9fa0d67e4d450343046425ae4271474353857ab860dbc0a1dde64b41b5cd3a532bf3a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008503ff80000001821388808455ba422499476574682f76312e302e302f6c696e75782f676f312e342e32a0969b900de27b6ac6a67742365dd65f55a0526c41fd18e1b16f1a1215c2e66f5988539bd4979fef1ec4'
     const block1Hash = '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6'
     await protocol.addContentToHistory(
-      1,
       HistoryNetworkContentTypes.BlockHeader,
       block1Hash,
       fromHexString(block1Rlp)
@@ -104,7 +100,6 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
     const contentKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: HistoryNetworkContentTypes.BlockHeader,
       value: {
-        chainId: 1,
         blockHash: fromHexString(block1Hash),
       },
     })
@@ -123,9 +118,8 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
     const epochAccumulator = require('../../integration/testEpoch.json')
     const rebuilt = EpochAccumulator.deserialize(fromHexString(epochAccumulator.serialized))
     const hashRoot = EpochAccumulator.hashTreeRoot(rebuilt)
-    const contentId = getHistoryNetworkContentId(1, 3, toHexString(hashRoot))
+    const contentId = getHistoryNetworkContentId(3, toHexString(hashRoot))
     await protocol.addContentToHistory(
-      1,
       HistoryNetworkContentTypes.EpochAccumulator,
       toHexString(hashRoot),
       fromHexString(epochAccumulator.serialized)
@@ -144,13 +138,12 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
       const node = await PortalNetwork.create({ transport: TransportLayer.WEB })
       const protocol = new HistoryProtocol(node, 2n) as HistoryProtocol
       protocol.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         toHexString(header.hash()),
         RLP.encode(bufArrToArr(headerValues))
       )
       try {
-        await protocol.client.db.get(getHistoryNetworkContentId(1, 0, toHexString(header.hash())))
+        await protocol.client.db.get(getHistoryNetworkContentId(0, toHexString(header.hash())))
         st.fail('should not find header')
       } catch (err: any) {
         st.equal(
@@ -171,26 +164,22 @@ tape('addContentToHistory -- Block Bodies and Receipts', async (t) => {
   const blockRlp = RLP.decode(fromHexString(serializedBlock.blockRlp)) //@ts-ignore
   const block = Block.fromValuesArray(arrToBufArr(blockRlp), { hardforkByBlockNumber: true })
   protocol.addContentToHistory(
-    1,
     HistoryNetworkContentTypes.BlockHeader,
     serializedBlock.blockHash,
     RLP.encode(blockRlp[0])
   )
 
   await protocol.addContentToHistory(
-    1,
     HistoryNetworkContentTypes.BlockBody,
     serializedBlock.blockHash,
     sszEncodeBlockBody(block)
   )
   const headerId = getHistoryNetworkContentId(
-    1,
     HistoryNetworkContentTypes.BlockHeader,
     serializedBlock.blockHash
   )
 
   const bodyId = getHistoryNetworkContentId(
-    1,
     HistoryNetworkContentTypes.BlockBody,
     serializedBlock.blockHash
   )
@@ -238,7 +227,6 @@ tape('Header Proof Tests', async (t) => {
       totalDifficulty: 1348252821321668n,
     }
     await protocol.addContentToHistory(
-      1,
       HistoryNetworkContentTypes.BlockHeader,
       _block8199.hash,
       fromHexString(_block8199.rawHeader)
@@ -272,13 +260,11 @@ tape('Header Proof Tests', async (t) => {
         totalDifficulty: 22019797038325n,
       }
       await protocol.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.EpochAccumulator,
         _epoch1.hash,
         fromHexString(_epoch1.serialized)
       )
       await protocol.addContentToHistory(
-        1,
         HistoryNetworkContentTypes.BlockHeader,
         _block1000.hash,
         fromHexString(_block1000.rawHeader)

--- a/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
@@ -143,7 +143,12 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
         RLP.encode(bufArrToArr(headerValues))
       )
       try {
-        await protocol.client.db.get(getHistoryNetworkContentId(0, toHexString(header.hash())))
+        await protocol.client.db.get(
+          getHistoryNetworkContentId(
+            HistoryNetworkContentTypes.BlockHeader,
+            toHexString(header.hash())
+          )
+        )
         st.fail('should not find header')
       } catch (err: any) {
         st.equal(

--- a/packages/portalnetwork/test/subprotocols/history/types.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/types.spec.ts
@@ -12,67 +12,59 @@ import { bufArrToArr } from '@ethereumjs/util'
 
 tape('History Subprotocol contentKey serialization/deserialization', (t) => {
   t.test('content Key', (st) => {
-    let chainId = 15
     let blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
     let encodedKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: HistoryNetworkContentTypes.BlockHeader,
-      value: { chainId: chainId, blockHash: fromHexString(blockHash) },
+      value: { blockHash: fromHexString(blockHash) },
     })
-    let contentId = getHistoryNetworkContentId(
-      chainId,
-      HistoryNetworkContentTypes.BlockHeader,
-      blockHash
-    )
+    let contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
     st.equals(
       toHexString(encodedKey),
-      '0x000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d',
+      '0x00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d',
       'blockheader content key equals expected output'
     )
     st.equals(
       contentId,
-      '0x2137f185b713a60dd1190e650d01227b4f94ecddc9c95478e2c591c40557da99',
+      '0x3e86b3767b57402ea72e369ae0496ce47cc15be685bec3b4726b9f316e3895fe',
       'block header content ID matches'
     )
-    chainId = 20
     blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
     encodedKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: HistoryNetworkContentTypes.BlockBody,
-      value: { chainId, blockHash: fromHexString(blockHash) },
+      value: { blockHash: fromHexString(blockHash) },
     })
-    contentId = getHistoryNetworkContentId(chainId, HistoryNetworkContentTypes.BlockBody, blockHash)
+    contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
     st.equals(
       toHexString(encodedKey),
-      '0x011400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d',
+      '0x01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d',
       'blockbody content key equals expected output'
     )
     st.equals(
       contentId,
-      '0x1c6046475f0772132774ab549173ca8487bea031ce539cad8e990c08df5802ca',
+      '0xebe414854629d60c58ddd5bf60fd72e41760a5f7a463fdcb169f13ee4a26786b',
       'block body content ID matches'
     )
-    chainId = 4
     blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
     encodedKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: HistoryNetworkContentTypes.Receipt,
-      value: { chainId, blockHash: fromHexString(blockHash) },
+      value: { blockHash: fromHexString(blockHash) },
     })
-    contentId = getHistoryNetworkContentId(chainId, HistoryNetworkContentTypes.Receipt, blockHash)
+    contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.Receipt, blockHash)
     st.equals(
       toHexString(encodedKey),
-      '0x020400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d',
+      '0x02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d',
       'receipt content key equals expected output'
     )
     st.equals(
       contentId,
-      '0xaa39e1423e92f5a667ace5b79c2c98adbfd79c055d891d0b9c49c40f816563b2',
+      '0xa888f4aafe9109d495ac4d4774a6277c1ada42035e3da5e10a04cc93247c04a4',
       'receipt content ID matches'
     )
-    chainId = 1
     encodedKey = HistoryNetworkContentKeyUnionType.serialize({
       selector: HistoryNetworkContentTypes.HeaderAccumulator,
       value: { selector: 0, value: null },
     })
-    contentId = getHistoryNetworkContentId(chainId, HistoryNetworkContentTypes.HeaderAccumulator)
+    contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.HeaderAccumulator)
     st.equals(contentId, '0xc0ba8a33ac67f44abff5984dfbb6f56c46b880ac2b86e1f23e7fa9c402c53ae7')
     st.end()
   })

--- a/packages/portalnetwork/test/subprotocols/history/util.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/util.spec.ts
@@ -4,6 +4,7 @@ import tape from 'tape'
 import {
   getHistoryNetworkContentId,
   HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentTypes,
   reassembleBlock,
   serializedContentKeyToContentId,
   sszEncodeBlockBody,
@@ -16,7 +17,7 @@ tape('utility functions', (t) => {
     value: { blockHash: fromHexString(block1Hash) },
   })
   t.equal(
-    getHistoryNetworkContentId(0, block1Hash),
+    getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, block1Hash),
     serializedContentKeyToContentId(block1headerContentKey),
     'produced same content id'
   )

--- a/packages/portalnetwork/test/subprotocols/history/util.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/util.spec.ts
@@ -13,10 +13,10 @@ tape('utility functions', (t) => {
   const block1Hash = '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6'
   const block1headerContentKey = HistoryNetworkContentKeyUnionType.serialize({
     selector: 0,
-    value: { chainId: 1, blockHash: fromHexString(block1Hash) },
+    value: { blockHash: fromHexString(block1Hash) },
   })
   t.equal(
-    getHistoryNetworkContentId(1, 0, block1Hash),
+    getHistoryNetworkContentId(0, block1Hash),
     serializedContentKeyToContentId(block1headerContentKey),
     'produced same content id'
   )

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -89,7 +89,6 @@ const offerKeys = offerHashes.map((hash) => {
   return HistoryNetworkContentKeyUnionType.serialize({
     selector: 1,
     value: {
-      chainId: 1,
       blockHash: hash,
     },
   })
@@ -174,7 +173,6 @@ tape('uTP Reader/Writer tests', (t) => {
 
     const offerContentIds = offerContentHashes.map((hash) => {
       const contentKey: HistoryNetworkContentKey = {
-        chainId: 1,
         blockHash: fromHexString(hash),
       }
       return HistoryNetworkContentKeyUnionType.serialize({


### PR DESCRIPTION
Part of meta-issue #372 

Removes ChainId from content key data structures.

Portal Network has no roadmap for supporting multiple chains, so content keys have no need to define a chain Id.

Further changes to the content key specs will follow in another PR.