### PR TITLE
Content key definitions

### DIFF
--- a/packages/browser-client/src/Components/DisplayBlock.tsx
+++ b/packages/browser-client/src/Components/DisplayBlock.tsx
@@ -20,7 +20,7 @@ import { BigNumber } from 'ethers'
 import { _Block } from '@ethersproject/abstract-provider'
 import {
   fromHexString,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   toHexString,
   TxReceiptWithType,
 } from 'portalnetwork'
@@ -260,7 +260,7 @@ const DisplayBlock = () => {
   }, [state!.block])
 
   const headerlookupKey = toHexString(
-    HistoryNetworkContentKeyUnionType.serialize({
+    HistoryNetworkContentKeyType.serialize({
       selector: 0,
       value: {
         blockHash: block.header.hash(),
@@ -269,7 +269,7 @@ const DisplayBlock = () => {
   )
 
   const bodylookupKey = toHexString(
-    HistoryNetworkContentKeyUnionType.serialize({
+    HistoryNetworkContentKeyType.serialize({
       selector: 1,
       value: {
         blockHash: block.header.hash(),

--- a/packages/browser-client/src/Components/GetHeaderProofByHash.tsx
+++ b/packages/browser-client/src/Components/GetHeaderProofByHash.tsx
@@ -2,7 +2,7 @@ import { HStack, Button, useToast } from '@chakra-ui/react'
 import {
   ContentLookup,
   fromHexString,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   SszProof,
 } from 'portalnetwork'
 import React, { useContext } from 'react'
@@ -14,7 +14,7 @@ export default function GetHeaderProofByHash() {
   const toast = useToast()
 
   async function portal_getHeaderProof(blockHash: string) {
-    const lookupKey = HistoryNetworkContentKeyUnionType.serialize({
+    const lookupKey = HistoryNetworkContentKeyType.serialize({
       selector: 5,
       value: {
         blockHash: fromHexString(blockHash),

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -1,7 +1,7 @@
 import {
   ENR,
   fromHexString,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   HistoryNetworkContentTypes,
   HistoryProtocol,
   reassembleBlock,
@@ -21,7 +21,7 @@ export class PeerActions {
   addToOffer = (type: HistoryNetworkContentTypes): void => {
     this.dispatch({
       type: PeerStateChange.ADDTOOFFER,
-      payload: HistoryNetworkContentKeyUnionType.serialize({
+      payload: HistoryNetworkContentKeyType.serialize({
         selector: type,
         value: {
           chainId: 1,
@@ -54,7 +54,7 @@ export class PeerActions {
   }
 
   handleRequestSnapshot = (enr: string) => {
-    const accumulatorKey = HistoryNetworkContentKeyUnionType.serialize({
+    const accumulatorKey = HistoryNetworkContentKeyType.serialize({
       selector: 4,
       value: { selector: 0, value: null },
     })
@@ -67,7 +67,7 @@ export class PeerActions {
 
   sendFindContent = async (type: string, enr: string) => {
     if (type === 'header') {
-      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+      const headerKey = HistoryNetworkContentKeyType.serialize({
         selector: 0,
         value: {
           chainId: 1,
@@ -81,7 +81,7 @@ export class PeerActions {
       const block = reassembleBlock(header!.value as Uint8Array, undefined)
       return block //
     } else if (type === 'body') {
-      const headerKey = HistoryNetworkContentKeyUnionType.serialize({
+      const headerKey = HistoryNetworkContentKeyType.serialize({
         selector: 0,
         value: {
           chainId: 1,
@@ -89,7 +89,7 @@ export class PeerActions {
         },
       })
       this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, headerKey)
-      const bodyKey = HistoryNetworkContentKeyUnionType.serialize({
+      const bodyKey = HistoryNetworkContentKeyType.serialize({
         selector: 1,
         value: {
           chainId: 1,
@@ -98,7 +98,7 @@ export class PeerActions {
       })
       this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, bodyKey)
     } else if (type === 'epoch') {
-      const _epochKey = HistoryNetworkContentKeyUnionType.serialize({
+      const _epochKey = HistoryNetworkContentKeyType.serialize({
         selector: 3,
         value: {
           chainId: 1,

--- a/packages/cli/src/modules/portal.ts
+++ b/packages/cli/src/modules/portal.ts
@@ -161,12 +161,9 @@ export class portal {
       }
     })
     const contentKeys = blockHashes.map((blockHash, idx) => {
-      return HistoryNetworkContentKeyType.serialize({
-        selector: contentTypes[idx],
-        value: {
-          blockHash: fromHexString(blockHash),
-        },
-      })
+      return HistoryNetworkContentKeyType.serialize(
+        Buffer.concat([Uint8Array.from([contentTypes[idx]]), fromHexString(blockHash)])
+      )
     })
     const protocol = this._client.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
     const res = await protocol.sendOffer(dstId, contentKeys)

--- a/packages/cli/src/modules/portal.ts
+++ b/packages/cli/src/modules/portal.ts
@@ -6,7 +6,7 @@ import {
   HistoryNetworkContentTypes,
   fromHexString,
   shortId,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   toHexString,
   HeaderAccumulatorType,
   HistoryProtocol,
@@ -161,7 +161,7 @@ export class portal {
       }
     })
     const contentKeys = blockHashes.map((blockHash, idx) => {
-      return HistoryNetworkContentKeyUnionType.serialize({
+      return HistoryNetworkContentKeyType.serialize({
         selector: contentTypes[idx],
         value: {
           blockHash: fromHexString(blockHash),

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -5,12 +5,11 @@ import {
   EpochAccumulator,
   EPOCH_SIZE,
   getHistoryNetworkContentId,
-  HeaderAccumulatorType,
   HistoryNetworkContentTypes,
   HistoryProtocol,
   reassembleBlock,
   SszProof,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
 } from './index.js'
 import { ContentLookup } from '../index.js'
 import { shortId } from '../../index.js'
@@ -194,12 +193,9 @@ export class ContentManager {
         try {
           this.history.client.db.get(headerKey)
         } catch {
-          const key = HistoryNetworkContentKeyUnionType.serialize({
-            selector: 0,
-            value: {
-              blockHash: fromHexString(hash),
-            },
-          })
+          const key = HistoryNetworkContentKeyType.serialize(
+            Buffer.concat([Uint8Array.from([0]), fromHexString(hash)])
+          )
           this.autoLookup(key, hash, HistoryNetworkContentTypes.BlockHeader)
         }
       }
@@ -207,12 +203,9 @@ export class ContentManager {
         try {
           this.history.client.db.get(bodyKey)
         } catch {
-          const key = HistoryNetworkContentKeyUnionType.serialize({
-            selector: 1,
-            value: {
-              blockHash: fromHexString(hash),
-            },
-          })
+          const key = HistoryNetworkContentKeyType.serialize(
+            Buffer.concat([Uint8Array.from([1]), fromHexString(hash)])
+          )
           this.autoLookup(key, hash, HistoryNetworkContentTypes.BlockBody)
         }
       }

--- a/packages/portalnetwork/src/subprotocols/history/eth_module.ts
+++ b/packages/portalnetwork/src/subprotocols/history/eth_module.ts
@@ -1,7 +1,7 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Block } from '@ethereumjs/block'
 import {
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   EpochAccumulator,
   EPOCH_SIZE,
   reassembleBlock,
@@ -19,16 +19,14 @@ export class ETH {
     blockHash: string,
     includeTransactions: boolean
   ): Promise<Block | undefined> => {
-    const headerContentKey = HistoryNetworkContentKeyUnionType.serialize({
-      selector: 0,
-      value: { blockHash: fromHexString(blockHash) },
-    })
+    const headerContentKey = HistoryNetworkContentKeyType.serialize(
+      Buffer.concat([Uint8Array.from([0]), fromHexString(blockHash)])
+    )
 
     const bodyContentKey = includeTransactions
-      ? HistoryNetworkContentKeyUnionType.serialize({
-          selector: 1,
-          value: { blockHash: fromHexString(blockHash) },
-        })
+      ? HistoryNetworkContentKeyType.serialize(
+          Buffer.concat([Uint8Array.from([1]), fromHexString(blockHash)])
+        )
       : undefined
     let header: any
     let body: any
@@ -93,10 +91,9 @@ export class ETH {
         this.protocol.logger('Error with epoch root lookup')
         return
       }
-      const lookupKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: 3,
-        value: { blockHash: epochRootHash },
-      })
+      const lookupKey = HistoryNetworkContentKeyType.serialize(
+        HistoryNetworkContentKeyType.serialize(Buffer.concat([Uint8Array.from([3]), epochRootHash]))
+      )
 
       const lookup = new ContentLookup(this.protocol, lookupKey)
       const result = await lookup.startLookup()

--- a/packages/portalnetwork/src/subprotocols/history/gossip.ts
+++ b/packages/portalnetwork/src/subprotocols/history/gossip.ts
@@ -1,6 +1,6 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { HistoryProtocol } from './history.js'
-import { HistoryNetworkContentKeyUnionType, HistoryNetworkContentTypes } from './types.js'
+import { HistoryNetworkContentKeyType, HistoryNetworkContentTypes } from './types.js'
 import { getHistoryNetworkContentId } from './util.js'
 
 type Peer = string
@@ -59,12 +59,9 @@ export class GossipManager {
    */
   public add(hash: string, contentType: HistoryNetworkContentTypes): void {
     const id = getHistoryNetworkContentId(contentType, hash)
-    const key = HistoryNetworkContentKeyUnionType.serialize({
-      selector: contentType,
-      value: {
-        blockHash: fromHexString(hash),
-      },
-    })
+    const key = HistoryNetworkContentKeyType.serialize(
+      Buffer.concat([Uint8Array.from([contentType]), fromHexString(hash)])
+    )
     const peers = this.history.routingTable.nearest(id, 5)
     for (const peer of peers) {
       const size = this.enqueue(peer.nodeId, key)

--- a/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
@@ -10,7 +10,7 @@ import {
   HeaderAccumulatorType,
   HeaderProofInterface,
   HeaderRecordType,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   HistoryNetworkContentTypes,
   HistoryProtocol,
   SszProof,
@@ -237,12 +237,10 @@ export class AccumulatorManager {
     for (let i = 0; i < Object.entries(this._verifiers).length; i++) {
       const blockHash = Object.values(this._verifiers)[i]
 
-      const proofLookupKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: HistoryNetworkContentTypes.HeaderProof,
-        value: {
-          blockHash: blockHash,
-        },
-      })
+      const proofLookupKey = HistoryNetworkContentKeyType.serialize(
+        Buffer.concat([Uint8Array.from([HistoryNetworkContentTypes.HeaderProof]), blockHash])
+      )
+
       const proofLookup = new ContentLookup(this._history, proofLookupKey)
       const _proof = await proofLookup.startLookup()
       if (_proof) {

--- a/packages/portalnetwork/src/subprotocols/history/types.ts
+++ b/packages/portalnetwork/src/subprotocols/history/types.ts
@@ -80,13 +80,7 @@ export type HeaderProofInterface = {
   witnesses: Uint8Array[]
 }
 
-export const HistoryNetworkContentKeyUnionType = new UnionType([
-  BlockHeaderType,
-  BlockBodyType,
-  ReceiptType,
-  new ByteVectorType(32),
-  ProofType,
-])
+export const HistoryNetworkContentKeyType = new ByteVectorType(33)
 
 export const sszTransaction = new ByteListType(MAX_TRANSACTION_LENGTH)
 export const allTransactions = new ListCompositeType(sszTransaction, MAX_TRANSACTION_COUNT)

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -1,6 +1,6 @@
 import { digest } from '@chainsafe/as-sha256'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { HistoryNetworkContentKeyUnionType } from './index.js'
+import { HistoryNetworkContentKeyType } from './index.js'
 import {
   BlockBodyContent,
   BlockBodyContentType,
@@ -34,24 +34,12 @@ export const getHistoryNetworkContentId = (
     case HistoryNetworkContentTypes.BlockHeader:
     case HistoryNetworkContentTypes.BlockBody:
     case HistoryNetworkContentTypes.Receipt:
-    case HistoryNetworkContentTypes.HeaderProof: {
-      if (!hash) throw new Error('block hash is required to generate contentId')
-      encodedKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: contentType,
-        value: {
-          blockHash: fromHexString(hash),
-        },
-      })
-      break
-    }
+    case HistoryNetworkContentTypes.HeaderProof:
     case HistoryNetworkContentTypes.EpochAccumulator: {
-      if (!hash) throw new Error('accumulator root hash is required to generate contentId')
-      encodedKey = HistoryNetworkContentKeyUnionType.serialize({
-        selector: contentType,
-        value: {
-          blockHash: fromHexString(hash),
-        },
-      })
+      if (!hash) throw new Error('block hash is required to generate contentId')
+      encodedKey = HistoryNetworkContentKeyType.serialize(
+        Buffer.concat([Uint8Array.from([contentType]), fromHexString(hash)])
+      )
       break
     }
     default:

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -4,7 +4,7 @@ import { ConnectionState, Packet, PacketType, randUint16, UtpSocket } from '../i
 import { ProtocolId } from '../../../index.js'
 import {
   HistoryNetworkContentKey,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   HistoryNetworkContentTypes,
 } from '../../../subprotocols/history/index.js'
 import { sendFinPacket } from '../Packets/PacketSenders.js'
@@ -384,8 +384,8 @@ export class PortalNetworkUTP extends BasicUtp {
     const requestCode = request.requestCode
     const keys = request.contentKeys
     const streamer = async (content: Uint8Array) => {
-      let contentKey = HistoryNetworkContentKeyUnionType.deserialize(keys[0])
-      let decodedContentKey = contentKey.value as HistoryNetworkContentKey
+      let contentKey = HistoryNetworkContentKeyType.deserialize(keys[0])
+      let decodedContentKey = { blockHash: contentKey.subarray(1) } as HistoryNetworkContentKey
       let contents: Uint8Array[]
       if (keys.length > 1) {
         this.logger(`Decompressing stream into ${keys.length} pieces of content`)
@@ -397,20 +397,20 @@ export class PortalNetworkUTP extends BasicUtp {
         throw new Error('Missing content keys')
       }
       keys.forEach((k, idx) => {
-        contentKey = HistoryNetworkContentKeyUnionType.deserialize(k)
-        decodedContentKey = contentKey.value as HistoryNetworkContentKey
+        contentKey = HistoryNetworkContentKeyType.deserialize(k)
+        decodedContentKey = { blockHash: contentKey.subarray(1) } as HistoryNetworkContentKey
         const _content = contents[idx]
         this.logger.extend(`FINISHED`)(
           `${idx + 1}/${keys.length} -- sending ${
-            HistoryNetworkContentTypes[contentKey.selector]
+            HistoryNetworkContentTypes[contentKey[0]]
           } to database`
         )
         // Hack -- decodedContentKey.blockHash is undefined for
         // EpochAccumulator requests...
         this.emit(
           'Stream',
-          contentKey.selector,
-          contentKey.selector > 2
+          contentKey[0],
+          contentKey[0] > 2
             ? toHexString(Uint8Array.from([]))
             : toHexString(decodedContentKey.blockHash),
           _content

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -8,7 +8,7 @@ import {
   HistoryNetworkContentTypes,
   HeaderAccumulatorType,
   getHistoryNetworkContentId,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   HistoryProtocol,
   EpochAccumulator,
   reassembleBlock,
@@ -70,14 +70,12 @@ tape('Integration -- FINDCONTENT/FOUNDCONTENT', (t) => {
         testBlockBody
       )
       testBlockKeys.push(
-        HistoryNetworkContentKeyUnionType.serialize({
-          selector: HistoryNetworkContentTypes.BlockHeader,
-          value: { blockHash: fromHexString(testHash) },
-        }),
-        HistoryNetworkContentKeyUnionType.serialize({
-          selector: HistoryNetworkContentTypes.BlockBody,
-          value: { blockHash: fromHexString(testHash) },
-        })
+        HistoryNetworkContentKeyType.serialize(
+          Buffer.concat([Uint8Array.from([0]), fromHexString(testHash)])
+        ),
+        HistoryNetworkContentKeyType.serialize(
+          Buffer.concat([Uint8Array.from([1]), fromHexString(testHash)])
+        )
       )
       let header: Uint8Array
       portal2.on('ContentAdded', async (blockHash, contentType, content) => {
@@ -166,14 +164,12 @@ tape('OFFER/ACCEPT', (t) => {
           sszEncodeBlockBody(testBlock)
         )
         testBlockKeys.push(
-          HistoryNetworkContentKeyUnionType.serialize({
-            selector: 0,
-            value: { blockHash: Uint8Array.from(testBlock.header.hash()) },
-          }),
-          HistoryNetworkContentKeyUnionType.serialize({
-            selector: 1,
-            value: { blockHash: Uint8Array.from(testBlock.header.hash()) },
-          })
+          HistoryNetworkContentKeyType.serialize(
+            Buffer.concat([Uint8Array.from([0]), testBlock.header.hash()])
+          ),
+          HistoryNetworkContentKeyType.serialize(
+            Buffer.concat([Uint8Array.from([1]), testBlock.header.hash()])
+          )
         )
       }
       let i = 0

--- a/packages/portalnetwork/test/subprotocols/history/types.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/types.spec.ts
@@ -3,7 +3,7 @@ import tape from 'tape'
 import { randomBytes } from 'crypto'
 import {
   getHistoryNetworkContentId,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   Receipt,
   TxReceiptType,
 } from '../../../src/subprotocols/history/index.js'
@@ -13,10 +13,9 @@ import { bufArrToArr } from '@ethereumjs/util'
 tape('History Subprotocol contentKey serialization/deserialization', (t) => {
   t.test('content Key', (st) => {
     let blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
-    let encodedKey = HistoryNetworkContentKeyUnionType.serialize({
-      selector: HistoryNetworkContentTypes.BlockHeader,
-      value: { blockHash: fromHexString(blockHash) },
-    })
+    let encodedKey = HistoryNetworkContentKeyType.serialize(
+      Buffer.concat([Uint8Array.from([0]), fromHexString(blockHash)])
+    )
     let contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
     st.equals(
       toHexString(encodedKey),
@@ -29,10 +28,9 @@ tape('History Subprotocol contentKey serialization/deserialization', (t) => {
       'block header content ID matches'
     )
     blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
-    encodedKey = HistoryNetworkContentKeyUnionType.serialize({
-      selector: HistoryNetworkContentTypes.BlockBody,
-      value: { blockHash: fromHexString(blockHash) },
-    })
+    encodedKey = HistoryNetworkContentKeyType.serialize(
+      Buffer.concat([Uint8Array.from([1]), fromHexString(blockHash)])
+    )
     contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
     st.equals(
       toHexString(encodedKey),
@@ -45,10 +43,12 @@ tape('History Subprotocol contentKey serialization/deserialization', (t) => {
       'block body content ID matches'
     )
     blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
-    encodedKey = HistoryNetworkContentKeyUnionType.serialize({
-      selector: HistoryNetworkContentTypes.Receipt,
-      value: { blockHash: fromHexString(blockHash) },
-    })
+    encodedKey = HistoryNetworkContentKeyType.serialize(
+      Buffer.concat([
+        Uint8Array.from([HistoryNetworkContentTypes.Receipt]),
+        fromHexString(blockHash),
+      ])
+    )
     contentId = getHistoryNetworkContentId(HistoryNetworkContentTypes.Receipt, blockHash)
     st.equals(
       toHexString(encodedKey),

--- a/packages/portalnetwork/test/subprotocols/history/util.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/util.spec.ts
@@ -3,7 +3,7 @@ import { Block } from '@ethereumjs/block'
 import tape from 'tape'
 import {
   getHistoryNetworkContentId,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   HistoryNetworkContentTypes,
   reassembleBlock,
   serializedContentKeyToContentId,
@@ -12,10 +12,9 @@ import {
 
 tape('utility functions', (t) => {
   const block1Hash = '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6'
-  const block1headerContentKey = HistoryNetworkContentKeyUnionType.serialize({
-    selector: 0,
-    value: { blockHash: fromHexString(block1Hash) },
-  })
+  const block1headerContentKey = HistoryNetworkContentKeyType.serialize(
+    Buffer.concat([Uint8Array.from([0]), fromHexString(block1Hash)])
+  )
   t.equal(
     getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, block1Hash),
     serializedContentKeyToContentId(block1headerContentKey),

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -5,7 +5,7 @@ import debug from 'debug'
 import tape from 'tape'
 import {
   HistoryNetworkContentKey,
-  HistoryNetworkContentKeyUnionType,
+  HistoryNetworkContentKeyType,
   HistoryNetworkContentTypes,
   ProtocolId,
   BUFFER_SIZE,
@@ -79,12 +79,9 @@ const offerHashes = Object.keys(blocks).map((key) => {
 })
 
 const offerKeys = offerHashes.map((hash) => {
-  return HistoryNetworkContentKeyUnionType.serialize({
-    selector: 1,
-    value: {
-      blockHash: hash,
-    },
-  })
+  return HistoryNetworkContentKeyType.serialize(
+    Buffer.concat([Uint8Array.from([HistoryNetworkContentTypes.BlockBody]), hash])
+  )
 })
 
 tape('uTP Reader/Writer tests', (t) => {
@@ -169,10 +166,12 @@ tape('uTP Reader/Writer tests', (t) => {
       const contentKey: HistoryNetworkContentKey = {
         blockHash: fromHexString(hash),
       }
-      return HistoryNetworkContentKeyUnionType.serialize({
-        selector: 1,
-        value: contentKey,
-      })
+      return HistoryNetworkContentKeyType.serialize(
+        Buffer.concat([
+          Uint8Array.from([HistoryNetworkContentTypes.BlockBody]),
+          fromHexString(hash),
+        ])
+      )
     })
 
     const _socket2 = uTP.createPortalNetworkUTPSocket(


### PR DESCRIPTION
Updating ContentKey definitions to align with changes in History Protocol spec.

Specs now define `content_key`  as `selector + SSZ.serialize(type_key)` instead of ssz Union.

`HistoryNetworkContentKeyType` replaces  `HistoryNetworkContentKeyUnionType`  as  `ByteVectorType({bytelength: 33})`

To serialize:
```
HistoryNetworkContentKey.serialize(
    Buffer.concat([ Uint8Array.from([ HistoryNetworkContentType ]), block.hash() ])
)
```

To deserialize:
```
selector = HistoryNetworkContentKeyType.deserialize(content_key)[0]
blockHash = HistoryNetworkContentKeyType.deserialize(content_key).subarray(1)
```
