### PR TITLE
Miscellaneous fixes

### DIFF
--- a/packages/browser-client/src/Components/ContentManager.tsx
+++ b/packages/browser-client/src/Components/ContentManager.tsx
@@ -7,28 +7,22 @@ import { AppContext, AppContextType, StateChange } from '../globalReducer'
 export default function ContentManager() {
   const { state, dispatch } = useContext(AppContext as React.Context<AppContextType>)
 
-  interface jsonblock {
-    blockHash: string
-    rlp: string
-    number?: number
-  }
-
   const handleUpload = async (evt: React.ChangeEvent<HTMLInputElement>) => {
     const files = evt.target.files
     const reader = new FileReader()
     if (files && files.length > 0) {
       reader.onload = async function () {
         if (reader.result) {
-          const blocks = JSON.parse(reader.result as string) as jsonblock[]
-          let last: jsonblock | undefined = blocks[0]
+          const blocks = Object.entries(JSON.parse(reader.result as string)) as any
+          let last = blocks[0]
           for (const block of blocks) {
-            await addRLPSerializedBlock(block.rlp, block.blockHash, state.provider!.historyProtocol)
+            await addRLPSerializedBlock(block[1].rlp, block[0], state.provider!.historyProtocol)
             last = block
           }
           dispatch({
             type: StateChange.SETBLOCK,
             payload: await ethJsBlockToEthersBlockWithTxs(
-              Block.fromRLPSerializedBlock(Buffer.from(fromHexString(last.rlp)), {
+              Block.fromRLPSerializedBlock(Buffer.from(fromHexString(last[1].rlp)), {
                 hardforkByBlockNumber: true,
               })
             ),

--- a/packages/portalnetwork/src/subprotocols/history/eth_module.ts
+++ b/packages/portalnetwork/src/subprotocols/history/eth_module.ts
@@ -1,7 +1,6 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Block } from '@ethereumjs/block'
 import {
-  HistoryNetworkContentKeyType,
   EpochAccumulator,
   EPOCH_SIZE,
   reassembleBlock,
@@ -22,17 +21,14 @@ export class ETH {
     includeTransactions: boolean
   ): Promise<Block | undefined> => {
     const headerContentKey = fromHexString(
-      getHistoryNetworkContentKey(
-        HistoryNetworkContentTypes.BlockHeader,
-        Buffer.from(fromHexString(blockHash))
-      )
+      getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockHeader, fromHexString(blockHash))
     )
 
     const bodyContentKey = includeTransactions
       ? fromHexString(
           getHistoryNetworkContentKey(
             HistoryNetworkContentTypes.BlockBody,
-            Buffer.from(fromHexString(blockHash))
+            fromHexString(blockHash)
           )
         )
       : undefined

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -26,7 +26,7 @@ import { HistoryProtocol } from './history.js'
  */
 export const getHistoryNetworkContentKey = (
   contentType: HistoryNetworkContentTypes,
-  hash: Buffer
+  hash: Uint8Array
 ): string => {
   let encodedKey
   const prefix = Buffer.alloc(1, contentType)
@@ -37,7 +37,7 @@ export const getHistoryNetworkContentKey = (
     case HistoryNetworkContentTypes.HeaderProof:
     case HistoryNetworkContentTypes.EpochAccumulator: {
       if (!hash) throw new Error('block hash is required to generate contentId')
-      encodedKey = toHexString(prefix) + hash.toString('hex')
+      encodedKey = toHexString(prefix) + toHexString(hash).slice(2)
       break
     }
     default:

--- a/packages/portalnetwork/src/util/helpers.ts
+++ b/packages/portalnetwork/src/util/helpers.ts
@@ -265,7 +265,7 @@ export function blockHeaderFromRpc(blockParams: JsonRpcBlock, options?: BlockOpt
       nonce,
       baseFeePerGas,
     },
-    options
+    { ...options, hardforkByBlockNumber: true }
   )
 
   return blockHeader
@@ -286,7 +286,7 @@ export function blockFromRpc(
   const header = blockHeaderFromRpc(blockParams, options)
 
   const transactions: TypedTransaction[] = []
-  const opts = { common: header._common }
+  const opts = { common: header._common, hardforkByBlockNumber: true }
   for (const _txParams of blockParams.transactions ?? []) {
     const txParams = normalizeTxParams(_txParams)
     const tx = TransactionFactory.fromTxData(txParams as TxData, opts)
@@ -295,5 +295,8 @@ export function blockFromRpc(
 
   const uncleHeaders = uncles.map((uh) => blockHeaderFromRpc(uh, options))
 
-  return Block.fromBlockData({ header, transactions, uncleHeaders }, options)
+  return Block.fromBlockData(
+    { header, transactions, uncleHeaders },
+    { ...options, hardforkByBlockNumber: true }
+  )
 }


### PR DESCRIPTION
- Fixes content upload in browser client
- Fixes `blockFromRpc` to use `hardforkByBlockNumber` when instantiating blocks