### PR TITLE
Eviction 3 strikes rule

### DIFF
--- a/packages/portalnetwork/src/rpc/modules/portal.ts
+++ b/packages/portalnetwork/src/rpc/modules/portal.ts
@@ -136,7 +136,7 @@ export class portal {
     const [enr] = params
     const encodedENR = ENR.decodeTxt(enr)
     this.logger(`PING request received on HistoryNetwork for ${shortId(encodedENR.nodeId)}`)
-    const pong = await this._history.sendPing(enr)
+    const pong = await this._history.sendPing(encodedENR)
     if (pong) {
       return `PING/PONG successful with ${encodedENR.nodeId}`
     } else {

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -48,6 +48,7 @@ export class HistoryProtocol extends BaseProtocol {
     this.gossipManager = new GossipManager(this)
     this.receiptManager = new ReceiptsManager(this.client.db, this)
     this.contentManager = new ContentManager(this, nodeRadius ?? 4n)
+    this.routingTable.setLogger(this.logger)
   }
 
   public getEpochByIndex = async (

--- a/packages/portalnetwork/src/subprotocols/nodeLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/nodeLookup.ts
@@ -61,7 +61,7 @@ export class NodeLookup {
               // `nodeSought` was found -- add to table and terminate lookup
               finished = true
               this.protocol.routingTable.insertOrUpdate(decodedEnr, EntryStatus.Connected)
-              this.protocol.sendPing(decodedEnr.nodeId)
+              this.protocol.sendPing(decodedEnr)
             } else if (
               distance(decodedEnr.nodeId, this.nodeSought) < distanceFromSoughtNodeToQueriedNode
             ) {

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -586,7 +586,9 @@ export abstract class BaseProtocol {
       .map((bucket, idx) => {
         return { bucket: bucket, distance: idx }
       })
-      .filter((pair) => pair.distance > 239 && pair.bucket.size() < 16)
+      .filter((pair) => pair.bucket.size() < 16)
+      .reverse()
+      .slice(0, 4)
     const size = this.routingTable.size
     let bucketsToRefresh
     if (size > 48) {

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -581,6 +581,7 @@ export abstract class BaseProtocol {
    * Do the random lookup on this node-id.
    */
   public bucketRefresh = async () => {
+    await this.livenessCheck()
     const notFullBuckets = this.routingTable.buckets
       .map((bucket, idx) => {
         return { bucket: bucket, distance: idx }

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -522,24 +522,13 @@ export abstract class BaseProtocol {
    * @param protocolId subprotocol Id of routing table being updated
    * @param customPayload payload of the PING/PONG message being decoded
    */
-  private updateRoutingTable = (srcId: NodeId | ENR, add = false, customPayload?: any) => {
-    const nodeId = typeof srcId === 'string' ? srcId : srcId.nodeId
-    let enr = typeof srcId === 'string' ? this.routingTable.getValue(srcId) : srcId
-    if (!add) {
-      this.routingTable.evictNode(nodeId)
-      this.logger.extend('Evict')(`removed ${nodeId} from ${this.protocolName} Routing Table`)
-      return
-    }
+  private updateRoutingTable = (enr: ENR, customPayload?: any) => {
+    const nodeId = enr.nodeId
     try {
-      if (!enr) {
-        // See if Discv5 has an ENR for this node if not provided
-        enr = this.client.discv5.getKadValue(nodeId)
-      }
-      if (enr) {
         // Only add node to the routing table if we have an ENR
-        this.routingTable.insertOrUpdate(enr!, EntryStatus.Connected)
-        add && this.logger(`adding ${nodeId} to ${this.protocolName} routing table`)
-      }
+      this.routingTable.getValue(enr.nodeId) === undefined &&
+        this.logger(`adding ${nodeId} to ${this.protocolName} routing table`)
+      this.routingTable.insertOrUpdate(enr, EntryStatus.Connected)
       if (customPayload) {
         const decodedPayload = PingPongCustomDataType.deserialize(Uint8Array.from(customPayload))
         this.routingTable.updateRadius(nodeId, decodedPayload.radius)

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -102,13 +102,11 @@ export abstract class BaseProtocol {
    * @param protocolId subprotocol ID
    * @returns the PING payload specified by the subprotocol or undefined
    */
-  public sendPing = async (nodeId: string | ENR) => {
-    let enr: ENR | undefined = undefined
-    if (nodeId instanceof ENR) {
-      enr = nodeId
-    } else if (typeof nodeId === 'string' && nodeId.startsWith('enr')) {
-      enr = ENR.decodeTxt(nodeId)
-    }
+  public sendPing = async (enr: ENR) => {
+    // 3000ms tolerance for ping timeout
+    setTimeout(() => {
+      return undefined
+    }, 3000)
     if (!enr) {
       this.logger(`Invalid node ID provided. PING aborted`)
       return

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -148,7 +148,8 @@ export abstract class BaseProtocol {
   private handlePing = (src: INodeAddress, id: bigint, pingMessage: PingMessage) => {
     if (!this.routingTable.getValue(src.nodeId)) {
       // Check to see if node is already in corresponding network routing table and add if not
-      this.updateRoutingTable(src.nodeId, true, pingMessage.customPayload)
+      const enr = this.client.discv5.getKadValue(src.nodeId)
+      this.updateRoutingTable(enr!, pingMessage.customPayload)
     } else {
       const radius = PingPongCustomDataType.deserialize(pingMessage.customPayload).radius
       this.routingTable.updateRadius(src.nodeId, radius)

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -209,11 +209,11 @@ export abstract class BaseProtocol {
             }
           })
           if (decoded.total > 0) {
-          this.logger.extend(`NODES`)(
-            `Received ${decoded.total} ENRs from ${shortId(dstId)} with ${
-              decoded.enrs.length - counter
-            } unknown.`
-          )
+            this.logger.extend(`NODES`)(
+              `Received ${decoded.total} ENRs from ${shortId(dstId)} with ${
+                decoded.enrs.length - counter
+              } unknown.`
+            )
           }
 
           return decoded
@@ -256,12 +256,12 @@ export abstract class BaseProtocol {
         value: nodesPayload,
       })
       if (nodesPayload.enrs.length > 0) {
-      this.logger.extend(`NODES`)(
-        `Sending`,
-        nodesPayload.enrs.length.toString(),
-        `ENRs to `,
-        shortId(src.nodeId)
-      )
+        this.logger.extend(`NODES`)(
+          `Sending`,
+          nodesPayload.enrs.length.toString(),
+          `ENRs to `,
+          shortId(src.nodeId)
+        )
       }
       this.client.sendPortalNetworkResponse(src, requestId, encodedPayload)
       this.metrics?.nodesMessagesSent.inc()
@@ -528,7 +528,7 @@ export abstract class BaseProtocol {
   private updateRoutingTable = (enr: ENR, customPayload?: any) => {
     const nodeId = enr.nodeId
     try {
-        // Only add node to the routing table if we have an ENR
+      // Only add node to the routing table if we have an ENR
       this.routingTable.getValue(enr.nodeId) === undefined &&
         this.logger(`adding ${nodeId} to ${this.protocolName} routing table`)
       this.routingTable.insertOrUpdate(enr, EntryStatus.Connected)

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -186,7 +186,6 @@ export abstract class BaseProtocol {
     })
 
     try {
-      this.logger.extend(`FINDNODES`)(`Sending to ${shortId(dstId)}`)
       const enr = this.routingTable.getValue(dstId)
       if (!enr) {
         return
@@ -211,11 +210,13 @@ export abstract class BaseProtocol {
               counter++
             }
           })
+          if (decoded.total > 0) {
           this.logger.extend(`NODES`)(
             `Received ${decoded.total} ENRs from ${shortId(dstId)} with ${
               decoded.enrs.length - counter
             } unknown.`
           )
+          }
 
           return decoded
         }
@@ -256,12 +257,14 @@ export abstract class BaseProtocol {
         selector: MessageCodes.NODES,
         value: nodesPayload,
       })
+      if (nodesPayload.enrs.length > 0) {
       this.logger.extend(`NODES`)(
         `Sending`,
         nodesPayload.enrs.length.toString(),
         `ENRs to `,
         shortId(src.nodeId)
       )
+      }
       this.client.sendPortalNetworkResponse(src, requestId, encodedPayload)
       this.metrics?.nodesMessagesSent.inc()
     } else {

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -107,18 +107,18 @@ export abstract class BaseProtocol {
     setTimeout(() => {
       return undefined
     }, 3000)
-    if (!enr) {
-      this.logger(`Invalid node ID provided. PING aborted`)
+    if (!enr.nodeId) {
+      this.logger(`Invalid ENR provided. PING aborted`)
       return
     }
-    const pingMsg = PortalWireMessageType.serialize({
-      selector: MessageCodes.PING,
-      value: {
-        enrSeq: this.client.discv5.enr.seq,
-        customPayload: PingPongCustomDataType.serialize({ radius: BigInt(this.nodeRadius) }),
-      },
-    })
     try {
+      const pingMsg = PortalWireMessageType.serialize({
+        selector: MessageCodes.PING,
+        value: {
+          enrSeq: this.client.discv5.enr.seq,
+          customPayload: PingPongCustomDataType.serialize({ radius: BigInt(this.nodeRadius) }),
+        },
+      })
       this.logger.extend(`PING`)(`Sent to ${shortId(enr.nodeId)}`)
       const res = await this.client.sendPortalNetworkMessage(
         enr,
@@ -137,8 +137,9 @@ export abstract class BaseProtocol {
         this.routingTable.strike(enr.nodeId)
       }
     } catch (err: any) {
-      this.logger(`Error during PING request to ${shortId(enr.nodeId)}: ${err.toString()}`)
-      this.routingTable.strike(enr.nodeId)
+      this.logger(`Error during PING request: ${err.toString()}`)
+      enr.nodeId && this.routingTable.strike(enr.nodeId)
+      return
     }
   }
 

--- a/packages/portalnetwork/src/subprotocols/rendezvous/rendezvous.ts
+++ b/packages/portalnetwork/src/subprotocols/rendezvous/rendezvous.ts
@@ -96,7 +96,7 @@ export class Rendezvous extends BaseProtocol {
         }
         // Destination node is known, send ENR to requestor
         this.logger(`found ENR for ${shortId(dstId)} - ${enr.encodeTxt()}`)
-        const pingRes = await protocol.sendPing(enr.nodeId)
+        const pingRes = await protocol.sendPing(enr)
         // Ping target node to verify it is reachable from rendezvous node
         if (!pingRes) {
           // If the target node isn't reachable, send null response

--- a/packages/portalnetwork/test/subprotocols/protocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/protocol.spec.ts
@@ -51,6 +51,7 @@ tape('protocol wire message tests', async (t) => {
 
     const remoteEnr =
       'enr:-IS4QG_M1lzTXzQQhUcAViqK-WQKtBgES3IEdQIBbH6tlx3Zb-jCFfS1p_c8Xq0Iie_xT9cHluSyZl0TNCWGlUlRyWcFgmlkgnY0gmlwhKRc9EGJc2VjcDI1NmsxoQMo1NBoJfVY367ZHKA-UBgOE--U7sffGf5NBsNSVG629oN1ZHCCF6Q'
+    const decodedEnr = ENR.decodeTxt(remoteEnr)
     const pongResponse = Buffer.from([
       1, 5, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -66,7 +67,7 @@ tape('protocol wire message tests', async (t) => {
 
     let res = await protocol.sendPing('abc')
     st.ok(res === undefined, 'received undefined when called with invalid ENR/nodeId')
-    res = await protocol.sendPing(remoteEnr)
+    res = await protocol.sendPing(decodedEnr)
     st.ok(res.enrSeq === 5n && res.customPayload[0] === 1, 'received expected PONG response')
     const payload = PingPongCustomDataType.serialize({ radius: BigInt(1) })
     const msg = {
@@ -76,7 +77,6 @@ tape('protocol wire message tests', async (t) => {
         customPayload: payload,
       },
     }
-    const decodedEnr = ENR.decodeTxt(remoteEnr)
     const nodeAddr = {
       socketAddr: decodedEnr.getLocationMultiaddr('udp'),
       nodeId: decodedEnr.nodeId,


### PR DESCRIPTION
#### Addresses issue #370
#### Node eviction logic

- [x] Fixes issue with Ultralight nodes sending PING requests long after supposedly "evicting" a peer.
- [x] Fixes issue with Ultralight nodes trying to evict the same peers over and over


1. Using `routingTable.remove(enr)` instead of `routingTable.removeById(nodeId)` seems to work better
2. Peers are now given 3 chances to respond to PING messages before eviction
3. A successful PING/PONG will reset the strikes. 
4. A liveness check will PING a 20% sample at a regular interval, and log the results.


- Implements a 3 strikes rule for peers failing to respond to PING messages.
- Edits liveness check to use 20% sample of peers
- Enables liveness check in bucketRefresh
- Reduces bucketRefresh to 4 buckets per refresh.
- Reduces logging output for NODES/FINDNODES when result is 0 nodes.
- Adds logger to routing table.
- Sets routing table logger in protocol constructor
- Adds mapping of <nodeId, strikes> to routing table
- Adds `strike` and `clearStrikes` methods to routing table.
- Edits `evict` method to evict using ENR
- Implements 3 strikes rule for evicting Peers
- Adds logic to `sendPing` to add / clear strikes