### PR TITLE
Ignore List

### DIFF
--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -5,11 +5,13 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   private radiusMap: Map<NodeId, bigint>
   private gossipMap: Map<NodeId, Set<string>>
   private strikes: Map<NodeId, number>
+  private ignored: Set<NodeId>
   constructor(nodeId: NodeId) {
     super(nodeId)
     this.radiusMap = new Map()
     this.gossipMap = new Map()
     this.strikes = new Map()
+    this.ignored = new Set()
   }
 
   public setLogger(logger: Debugger) {

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -19,13 +19,15 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   }
 
   public strike = (nodeId: NodeId) => {
-    this.logger?.extend('STRIKE')(nodeId)
-    const strikes = this.strikes.get(nodeId) ?? 0
-    if (strikes > 1) {
+    let strikes = this.strikes.get(nodeId) ?? 0
+    strikes++
+    this.logger?.extend('STRIKE').extend(strikes.toString())(nodeId)
+    if (strikes > 2) {
       this.evictNode(nodeId)
-      this.strikes.delete(nodeId)
+      return
     }
-    this.strikes.set(nodeId, strikes + 1)
+    this.strikes.set(nodeId, strikes)
+    return strikes
   }
 
   public clearStrikes = (nodeId: NodeId) => {

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -105,4 +105,13 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
       this.ignored.delete(nodeId)
     }, 120000)
   }
+
+  // Method for Protocol to check if Peer should be ignored.
+  // Mainly prevents self from continuing to PING dead enrs that we receive
+
+  public isIgnored = (nodeId: string) => {
+    if ([...this.ignored].includes(nodeId)) {
+      return true
+    }
+  }
 }

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -209,6 +209,7 @@ export abstract class BaseProtocol {
           const ping = await this.sendPing(decodedEnr)
           if (ping === undefined) {
             this.logger(`New connection failed with:  ${shortId(decodedEnr.nodeId)}`)
+            this.routingTable.evictNode(decodedEnr.nodeId)
           } else {
             this.logger(`New connection with:  ${shortId(decodedEnr.nodeId)}`)
           }


### PR DESCRIPTION
Adds to `PortalNetworkRoutingTable` a list of NodeId's to ignore.

Peers will be added to ignore list for 2 minutes upon eviction.

During this 2 minute period, any enr received in a NODES response will be ignored.

FINDNODES will also now listen for PONG response from unknown peers, and put unresponsive nodes in the same 2 minute ignore buffer.

This especially prevents against the rapid buildup of failing PING attempts when receiving the same unresponsive enr in multiple NODES responses.  

TODO:
Implement same logic in FINDCONTENT when CONTENT response is list of enrs