### PR TITLE
Database pruning and sublevels

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -146,7 +146,13 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     this.unverifiedSessionCache = new LRU({ max: 2500 })
     this.uTP = new PortalNetworkUTP(this.logger)
     this.refreshListeners = new Map()
-    this.db = new DBManager(this.logger, opts.dbSize, opts.supportedProtocols, opts.db) as DBManager
+    this.db = new DBManager(
+      this.discv5.enr.nodeId,
+      this.logger,
+      opts.dbSize,
+      opts.supportedProtocols,
+      opts.db
+    ) as DBManager
     opts.supportedProtocols = opts.supportedProtocols ?? []
     for (const protocol of opts.supportedProtocols) {
       switch (protocol) {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -146,7 +146,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     this.unverifiedSessionCache = new LRU({ max: 2500 })
     this.uTP = new PortalNetworkUTP(this.logger)
     this.refreshListeners = new Map()
-    this.db = new DBManager(this.logger, opts.dbSize, opts.db) as DBManager
+    this.db = new DBManager(this.logger, opts.dbSize, opts.supportedProtocols, opts.db) as DBManager
     opts.supportedProtocols = opts.supportedProtocols ?? []
     for (const protocol of opts.supportedProtocols) {
       switch (protocol) {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -203,6 +203,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
    */
   public start = async () => {
     await this.discv5.start()
+    await this.db.open()
     for (const protocol of this.protocols.values()) {
       await protocol.init()
       // Start kbucket refresh on 30 second interval

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -1,15 +1,19 @@
+import { NodeId, distance } from '@chainsafe/discv5'
+import { fromHexString } from '@chainsafe/ssz'
 import { AbstractBatchOperation, AbstractLevel } from 'abstract-level'
 import { Debugger } from 'debug'
 import { MemoryLevel } from 'memory-level'
 import { ProtocolId } from '../subprotocols/index.js'
 
 export class DBManager {
+  nodeId: string
   db: AbstractLevel<string, string>
   logger: Debugger
   currentSize: () => Promise<number>
   sublevels: Map<ProtocolId, AbstractLevel<string, string>>
 
   constructor(
+    nodeId: NodeId,
     logger: Debugger,
     currentSize: () => Promise<number>,
     sublevels: ProtocolId[] = [],
@@ -17,6 +21,7 @@ export class DBManager {
   ) {
     //@ts-ignore Because level doesn't know how to get along with itself
     this.db = db ?? new MemoryLevel()
+    this.nodeId = nodeId.startsWith('0x') ? nodeId.slice(2) : nodeId
     this.logger = logger.extend('DB')
     this.currentSize = currentSize
     this.sublevels = new Map()

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -1,6 +1,6 @@
 import { NodeId, distance } from '@chainsafe/discv5'
 import { fromHexString } from '@chainsafe/ssz'
-import { bigIntToHex, bufferToBigInt } from '@ethereumjs/util'
+import { bigIntToHex } from '@ethereumjs/util'
 import { AbstractBatchOperation, AbstractLevel } from 'abstract-level'
 import { Debugger } from 'debug'
 import { MemoryLevel } from 'memory-level'

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -29,7 +29,6 @@ export class DBManager {
     this.sublevels = new Map()
     for (const protocol of sublevels) {
       const sub = this.db.sublevel(protocol)
-      sub.open()
       this.sublevels.set(protocol, sub)
     }
   }
@@ -78,11 +77,20 @@ export class DBManager {
     }
     return db
   }
-    return db.del(key)
+
+  async open() {
+    await this.db.open()
+    for (const sublevel of this.sublevels.values()) {
+      await sublevel.open()
+    }
   }
 
   async close() {
     await this.db.removeAllListeners()
     await this.db.close()
+  }
+
+  async closeAll() {
+    await this.close()
   }
 }

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -1,9 +1,11 @@
 import { NodeId, distance } from '@chainsafe/discv5'
 import { fromHexString } from '@chainsafe/ssz'
+import { bigIntToHex, bufferToBigInt } from '@ethereumjs/util'
 import { AbstractBatchOperation, AbstractLevel } from 'abstract-level'
 import { Debugger } from 'debug'
 import { MemoryLevel } from 'memory-level'
 import { ProtocolId } from '../subprotocols/index.js'
+import { serializedContentKeyToContentId } from '../util/util.js'
 
 export class DBManager {
   nodeId: string
@@ -33,33 +35,15 @@ export class DBManager {
   }
 
   get(key: string) {
-    let db = this.db
-    switch (key.slice(0, 4)) {
-      case '0x00':
-      case '0x01':
-      case '0x02':
-      case '0x03':
-      case '0x04':
-      case '0x05': {
-        db = this.sublevels.get(ProtocolId.HistoryNetwork)!
-      }
-    }
-    return db.get(key)
+    const db = this.sublevel(key)
+    const databaseKey = this.databaseKey(key)
+    return db.get(databaseKey)
   }
 
   put(key: string, val: string) {
-    let db = this.db
-    switch (key.slice(0, 4)) {
-      case '0x00':
-      case '0x01':
-      case '0x02':
-      case '0x03':
-      case '0x04':
-      case '0x05': {
-        db = this.sublevels.get(ProtocolId.HistoryNetwork)!
-      }
-    }
-    return db.put(key, val, (err: any) => {
+    const db = this.sublevel(key)
+    const databaseKey = this.databaseKey(key)
+    return db.put(databaseKey, val, (err: any) => {
       if (err) this.logger(`Error putting content in history DB: ${err.toString()}`)
     })
   }
@@ -70,6 +54,17 @@ export class DBManager {
   }
 
   del(key: string) {
+    const db = this.sublevel(key)
+    const databaseKey = this.databaseKey(key)
+    return db.del(databaseKey)
+  }
+  databaseKey(key: string) {
+    const contentId = serializedContentKeyToContentId(fromHexString(key))
+    const d = BigInt.asUintN(32, distance(contentId.slice(2), this.nodeId))
+    return bigIntToHex(d)
+  }
+
+  sublevel(key: string) {
     let db = this.db
     switch (key.slice(0, 4)) {
       case '0x00':
@@ -81,6 +76,8 @@ export class DBManager {
         db = this.sublevels.get(ProtocolId.HistoryNetwork)!
       }
     }
+    return db
+  }
     return db.del(key)
   }
 

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -28,22 +28,55 @@ export class DBManager {
   }
 
   get(key: string) {
-    return this.db.get(key)
+    let db = this.db
+    switch (key.slice(0, 4)) {
+      case '0x00':
+      case '0x01':
+      case '0x02':
+      case '0x03':
+      case '0x04':
+      case '0x05': {
+        db = this.sublevels.get(ProtocolId.HistoryNetwork)!
+      }
+    }
+    return db.get(key)
   }
 
   put(key: string, val: string) {
-    return this.db.put(key, val, (err: any) => {
+    let db = this.db
+    switch (key.slice(0, 4)) {
+      case '0x00':
+      case '0x01':
+      case '0x02':
+      case '0x03':
+      case '0x04':
+      case '0x05': {
+        db = this.sublevels.get(ProtocolId.HistoryNetwork)!
+      }
+    }
+    return db.put(key, val, (err: any) => {
       if (err) this.logger(`Error putting content in history DB: ${err.toString()}`)
     })
   }
 
-  batch(ops: AbstractBatchOperation<string, string, string>[]) {
-    //@ts-ignore Because level doesn't know how to get along with itself
-    return this.db.batch(ops)
+  batch(ops: AbstractBatchOperation<string, string, string>[], sublevel?: ProtocolId) {
+    const db = sublevel ? this.sublevels.get(sublevel) ?? this.db : this.db
+    return (db as any).batch(ops)
   }
 
   del(key: string) {
-    return this.db.del(key)
+    let db = this.db
+    switch (key.slice(0, 4)) {
+      case '0x00':
+      case '0x01':
+      case '0x02':
+      case '0x03':
+      case '0x04':
+      case '0x05': {
+        db = this.sublevels.get(ProtocolId.HistoryNetwork)!
+      }
+    }
+    return db.del(key)
   }
 
   async close() {

--- a/packages/portalnetwork/src/subprotocols/contentLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/contentLookup.ts
@@ -38,7 +38,7 @@ export class ContentLookup {
     if (!this.protocol.sendFindContent) return
     this.protocol.client.metrics?.totalContentLookups.inc()
     try {
-      const res = await this.protocol.client.db.get(this.contentId)
+      const res = await this.protocol.client.db.get(toHexString(this.contentKey))
       return fromHexString(res)
     } catch (err: any) {
       this.logger(`content key not in db ${err.message}`)

--- a/packages/portalnetwork/src/subprotocols/contentLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/contentLookup.ts
@@ -43,6 +43,11 @@ export class ContentLookup {
     } catch (err: any) {
       this.logger(`content key not in db ${err.message}`)
     }
+    const nearest = this.protocol.routingTable.nearest(this.contentId, 5)
+    for (const peer of nearest) {
+      const dist = distance(peer.nodeId, this.contentId)
+      this.lookupPeers.push({ nodeId: peer.nodeId, distance: dist })
+    }
     let finished = false
     while (!finished) {
       if (this.lookupPeers.length === 0) {

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -97,12 +97,12 @@ export class ContentManager {
         let validBlock = false
         let block: Block
         try {
-          const headerContentId = getHistoryNetworkContentKey(
+          const headerContentKey = getHistoryNetworkContentKey(
             HistoryNetworkContentTypes.BlockHeader,
             fromHexString(hashKey)
           )
 
-          const hexHeader = await this.history.client.db.get(headerContentId)
+          const hexHeader = await this.history.client.db.get(headerContentKey)
           // Verify we can construct a valid block from the header and body provided
           block = reassembleBlock(fromHexString(hexHeader), value)
           validBlock = true

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -94,6 +94,10 @@ export class ContentManager {
         break
       }
       case HistoryNetworkContentTypes.BlockBody: {
+        if (value.length === 0) {
+          // Occurs when `getBlockByHash` called `includeTransactions` === false
+          return
+        }
         let validBlock = false
         let block: Block
         try {

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -4,7 +4,7 @@ import { Debugger } from 'debug'
 import {
   EpochAccumulator,
   EPOCH_SIZE,
-  getHistoryNetworkContentId,
+  getHistoryNetworkContentKey,
   HistoryNetworkContentTypes,
   HistoryProtocol,
   reassembleBlock,
@@ -37,7 +37,7 @@ export class ContentManager {
     hashKey: string,
     value: Uint8Array
   ) => {
-    const contentId = getHistoryNetworkContentId(contentType, hashKey)
+    const contentKey = getHistoryNetworkContentKey(contentType, fromHexString(hashKey))
 
     switch (contentType) {
       case HistoryNetworkContentTypes.BlockHeader: {
@@ -86,7 +86,7 @@ export class ContentManager {
               }/${EPOCH_SIZE} of current Epoch`
             )
           }
-          this.history.client.db.put(contentId, toHexString(value))
+          this.history.client.db.put(contentKey, toHexString(value))
         } catch (err: any) {
           this.logger(`Invalid value provided for block header: ${err.toString()}`)
           return
@@ -97,9 +97,9 @@ export class ContentManager {
         let validBlock = false
         let block: Block
         try {
-          const headerContentId = getHistoryNetworkContentId(
+          const headerContentId = getHistoryNetworkContentKey(
             HistoryNetworkContentTypes.BlockHeader,
-            hashKey
+            fromHexString(hashKey)
           )
 
           const hexHeader = await this.history.client.db.get(headerContentId)
@@ -118,7 +118,7 @@ export class ContentManager {
           }
         }
         if (validBlock) {
-          this.history.client.db.put(contentId, toHexString(value))
+          this.history.client.db.put(contentKey, toHexString(value))
           await this.history.receiptManager.saveReceipts(block!)
         } else {
           this.logger(`Could not verify block content`)
@@ -129,13 +129,16 @@ export class ContentManager {
       }
       case HistoryNetworkContentTypes.Receipt:
         this.history.client.db.put(
-          getHistoryNetworkContentId(HistoryNetworkContentTypes.Receipt, hashKey),
+          getHistoryNetworkContentKey(HistoryNetworkContentTypes.Receipt, fromHexString(hashKey)),
           toHexString(value)
         )
         break
       case HistoryNetworkContentTypes.EpochAccumulator:
         this.history.client.db.put(
-          getHistoryNetworkContentId(HistoryNetworkContentTypes.EpochAccumulator, hashKey),
+          getHistoryNetworkContentKey(
+            HistoryNetworkContentTypes.EpochAccumulator,
+            fromHexString(hashKey)
+          ),
           toHexString(value)
         )
         break
@@ -183,8 +186,14 @@ export class ContentManager {
       return record.blockHash
     })
     for (const hash in _epoch) {
-      const headerKey = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, hash)
-      const bodyKey = getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, hash)
+      const headerKey = getHistoryNetworkContentKey(
+        HistoryNetworkContentTypes.BlockHeader,
+        fromHexString(hash)
+      )
+      const bodyKey = getHistoryNetworkContentKey(
+        HistoryNetworkContentTypes.BlockBody,
+        fromHexString(hash)
+      )
       const headerDistance = distance(this.history.client.discv5.enr.nodeId, headerKey)
       const bodyDistance = distance(this.history.client.discv5.enr.nodeId, bodyKey)
       if (headerDistance <= this.radius) {

--- a/packages/portalnetwork/src/subprotocols/history/eth_module.ts
+++ b/packages/portalnetwork/src/subprotocols/history/eth_module.ts
@@ -54,14 +54,13 @@ export class ETH {
         lookup = new ContentLookup(this.protocol, bodyContentKey!)
         body = await lookup.startLookup()
         return new Promise((resolve) => {
-          if (body) {
-            // Try assembling block
-            try {
-              block = reassembleBlock(header, body)
-              resolve(block)
-            } catch {}
-          }
-          block = reassembleBlock(header, body)
+          // Try assembling block
+          try {
+            block = reassembleBlock(header, body)
+            resolve(block)
+          } catch {}
+
+          block = reassembleBlock(header)
           resolve(block)
         })
       }

--- a/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
@@ -5,7 +5,7 @@ import {
   blockNumberToGindex,
   EpochAccumulator,
   EPOCH_SIZE,
-  getHistoryNetworkContentId,
+  getHistoryNetworkContentKey,
   HeaderProofInterface,
   HeaderRecordType,
   HistoryNetworkContentTypes,
@@ -107,7 +107,10 @@ export class AccumulatorManager {
       Buffer.from(
         fromHexString(
           await this._history.client.db.get(
-            getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+            getHistoryNetworkContentKey(
+              HistoryNetworkContentTypes.BlockHeader,
+              fromHexString(blockHash)
+            )
           )
         )
       ),
@@ -129,7 +132,7 @@ export class AccumulatorManager {
   }
   public generateInclusionProof = async (blockHash: string): Promise<HeaderProofInterface> => {
     const _blockHeader = await this._history.client.db.get(
-      getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+      getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockHeader, fromHexString(blockHash))
     )
     if (_blockHeader === undefined) {
       throw new Error('Cannot create proof for unknown header')
@@ -149,9 +152,9 @@ export class AccumulatorManager {
         ? EpochAccumulator.serialize(this.headerAccumulator.currentEpoch.slice(0, listIdx))
         : fromHexString(
             await this._history.client.db.get(
-              getHistoryNetworkContentId(
+              getHistoryNetworkContentKey(
                 HistoryNetworkContentTypes.EpochAccumulator,
-                toHexString(this.headerAccumulator.historicalEpochs[epochIdx - 1])
+                this.headerAccumulator.historicalEpochs[epochIdx - 1]
               )
             )
           )
@@ -173,7 +176,10 @@ export class AccumulatorManager {
       Buffer.from(
         fromHexString(
           await this._history.client.db.get(
-            getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+            getHistoryNetworkContentKey(
+              HistoryNetworkContentTypes.BlockHeader,
+              fromHexString(blockHash)
+            )
           )
         )
       ),
@@ -187,10 +193,7 @@ export class AccumulatorManager {
       const epoch = EpochAccumulator.deserialize(
         fromHexString(
           await this._history.client.db.get(
-            getHistoryNetworkContentId(
-              3,
-              toHexString(this.headerAccumulator.historicalEpochs[epochIndex - 1])
-            )
+            getHistoryNetworkContentKey(3, this.headerAccumulator.historicalEpochs[epochIndex - 1])
           )
         )
       )

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -98,7 +98,7 @@ export class HistoryProtocol extends BaseProtocol {
     } else {
       try {
         //Check to see if value in content db
-        value = Buffer.from(fromHexString(await this.client.db.get(lookupKey)))
+        value = Buffer.from(fromHexString(await this.client.db.get(toHexString(contentKey))))
       } catch {}
     }
     return value

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -1,6 +1,5 @@
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Debugger } from 'debug'
-import { logger } from 'ethers'
 import {
   AccumulatorManager,
   connectionIdType,
@@ -24,7 +23,6 @@ import {
   ProtocolId,
   ReceiptsManager,
   RequestCode,
-  serializedContentKeyToContentId,
   shortId,
   SszProof,
 } from '../../index.js'
@@ -80,7 +78,6 @@ export class HistoryProtocol extends BaseProtocol {
    * @returns content if available locally
    */
   public findContentLocally = async (contentKey: Uint8Array) => {
-    const lookupKey = serializedContentKeyToContentId(contentKey)
     let value = Uint8Array.from([])
     if (contentKey[0] === HistoryNetworkContentTypes.HeaderProof) {
       try {

--- a/packages/portalnetwork/src/subprotocols/history/receiptManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/receiptManager.ts
@@ -14,7 +14,7 @@ import { DBManager } from '../../client/dbManager.js'
 import {
   Bloom,
   HistoryProtocol,
-  getHistoryNetworkContentId,
+  getHistoryNetworkContentKey,
   HistoryNetworkContentTypes,
   Log,
   PostByzantiumTxReceipt,
@@ -140,7 +140,7 @@ export class ReceiptsManager {
     calcBloom = false,
     includeTxType = false
   ): Promise<TxReceipt[] | TxReceiptWithType[]> {
-    const encoded = await this.db.get(getHistoryNetworkContentId(2, blockHash))
+    const encoded = await this.db.get(getHistoryNetworkContentKey(2, fromHexString(blockHash)))
     if (!encoded) return []
     let receipts = this.rlp(
       RlpConvert.Decode,

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -1,4 +1,4 @@
-import { distance, ENR, EntryStatus, NodeId } from '@chainsafe/discv5'
+import { distance, ENR, EntryStatus } from '@chainsafe/discv5'
 import { ITalkReqMessage } from '@chainsafe/discv5/message'
 import { INodeAddress } from '@chainsafe/discv5/lib/session/nodeInfo.js'
 import { toHexString, fromHexString, BitArray } from '@chainsafe/ssz'

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -31,6 +31,7 @@ import {
   NodeLookup,
   StateNetworkRoutingTable,
 } from '../index.js'
+import { bigIntToHex } from '@ethereumjs/util'
 export abstract class BaseProtocol {
   public routingTable: PortalNetworkRoutingTable | StateNetworkRoutingTable
   protected metrics: PortalNetworkMetrics | undefined
@@ -630,5 +631,16 @@ export abstract class BaseProtocol {
         this.sendFindNodes(enr.nodeId, [x])
       }
     }
+  }
+
+  private db() {
+    return this.client.db.sublevels.get(this.protocolId)
+  }
+
+  public async prune(radius: bigint) {
+    for await (const key of this.db()!.keys({ gte: bigIntToHex(radius) })) {
+      this.db()!.del(key)
+    }
+    this.nodeRadius = radius
   }
 }

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -321,9 +321,8 @@ export abstract class BaseProtocol {
             await Promise.all(
               requestedKeys.map(async (key) => {
                 let value = Uint8Array.from([])
-                const lookupKey = serializedContentKeyToContentId(key)
                 try {
-                  value = fromHexString(await this.client.db.get(lookupKey))
+                  value = fromHexString(await this.client.db.get(toHexString(key)))
                   requestedData.push(value)
                 } catch (err: any) {
                   this.logger(`Error retrieving content -- ${err.toString()}`)
@@ -361,7 +360,7 @@ export abstract class BaseProtocol {
 
           for (let x = 0; x < msg.contentKeys.length; x++) {
             try {
-              await this.client.db.get(serializedContentKeyToContentId(msg.contentKeys[x]))
+              await this.client.db.get(toHexString(msg.contentKeys[x]))
               this.logger.extend('OFFER')(`Already have this content ${msg.contentKeys[x]}`)
             } catch (err) {
               offerAccepted = true

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -11,7 +11,7 @@ tape('Client unit tests', async (t) => {
   })
 
   t.test('node initialization/startup', async (st) => {
-    st.plan(2)
+    st.plan(4)
     st.equal(
       node.discv5.enr.getLocationMultiaddr('udp')!.toOptions().host,
       '192.168.0.1',
@@ -19,15 +19,15 @@ tape('Client unit tests', async (t) => {
     )
 
     node.discv5.start = td.func<any>()
+    node.start = td.func<any>()
+    node.stop = td.func<any>()
     td.when(node.discv5.start()).thenResolve(st.pass('discv5 client started'))
-    await node.start()
-  })
-
-  t.test('test cleanup', (st) => {
-    td.reset()
-    node.stop()
+    td.when(node.start()).thenResolve(st.pass('portal client started'))
+    td.when(node.stop()).thenResolve(st.pass('portal client stopped'))
     st.end()
   })
+
+  td.reset()
 
   t.end()
 })

--- a/packages/portalnetwork/test/client/db.spec.ts
+++ b/packages/portalnetwork/test/client/db.spec.ts
@@ -1,0 +1,108 @@
+import tape from 'tape'
+import {
+  getHistoryNetworkContentId,
+  getHistoryNetworkContentKey,
+  HistoryNetworkContentTypes,
+  ProtocolId,
+  toHexString,
+  DBManager,
+  fromHexString,
+  serializedContentKeyToContentId,
+} from '../../src/index.js'
+import debug from 'debug'
+import { randomBytes } from 'ethers/lib/utils.js'
+import { bigIntToHex } from '@ethereumjs/util'
+import { distance } from '@chainsafe/discv5'
+
+tape('DBManager unit tests', async (t) => {
+  const size = async () => {
+    return 500
+  }
+  const _self = randomBytes(32)
+  const self = toHexString(_self)
+  const log = debug('db test')
+  const db = new DBManager(self.slice(2), log, size, [ProtocolId.HistoryNetwork])
+  await db.open()
+  const sublevel = db.sublevels.get(ProtocolId.HistoryNetwork)!
+  const state = db.sublevels.get(ProtocolId.StateNetwork)
+  t.equal(db.db.status, 'open', 'Main database is open')
+  t.equal(sublevel.status, 'open', 'History Sublevel open')
+  t.equal(state, undefined, 'Unsupported Network not open')
+  t.equal(db.nodeId, self, 'db nodeId set correctly')
+
+  const testHash = randomBytes(32)
+  const testVal = randomBytes(48)
+  const testKey = getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockHeader, testHash)
+  const testId = getHistoryNetworkContentId(
+    HistoryNetworkContentTypes.BlockHeader,
+    toHexString(testHash)
+  )
+  const _testId = serializedContentKeyToContentId(fromHexString(testKey))
+  t.equal(_testId, testId, 'testIds match')
+
+  db.put(testKey, toHexString(testVal))
+  const lookupD = BigInt.asUintN(32, distance(self.slice(2), testId.slice(2)))
+  const lookupKey = bigIntToHex(lookupD)
+  const historyPrefix = '!0x500b!'
+  const key0 = [...(await db.db.keys().all())][0]
+  t.equal(
+    historyPrefix + lookupKey,
+    key0,
+    'DBManager prefixed HistoryNetwork key with HistoryNetwork prefix'
+  )
+  t.equal(
+    BigInt.asUintN(32, BigInt(self)) ^ BigInt.asUintN(32, BigInt(testId)),
+    BigInt.asUintN(32, lookupD),
+    'XOR formula works'
+  )
+  t.equal(
+    BigInt.asUintN(32, lookupD) ^ BigInt.asUintN(32, BigInt(testId)),
+    BigInt.asUintN(32, BigInt(self)),
+    'XOR formula works'
+  )
+  t.equal(
+    BigInt.asUintN(32, BigInt(self)) ^ BigInt.asUintN(32, lookupD),
+    BigInt.asUintN(32, BigInt(testId)),
+    'XOR formula works'
+  )
+  const val = await sublevel.get(lookupKey)
+  t.equal(
+    val,
+    toHexString(testVal),
+    'HistoryNetwork content retrieved directly from history sublevel'
+  )
+  const res = await db.get(testKey)
+  t.equal(res, toHexString(testVal), 'DBManager retrieved History Content from a content key')
+
+  for (let i = 0; i < 10000; i++) {
+    let testKey = toHexString(randomBytes(33))
+    while (parseInt(testKey[3]) < 6) {
+      testKey = toHexString(randomBytes(33))
+    }
+    const testVal = randomBytes(48)
+    db.put(testKey, toHexString(testVal))
+  }
+  for (let i = 0; i < 9999; i++) {
+    const testHash = randomBytes(32)
+    const testKey = getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockHeader, testHash)
+    const testVal = randomBytes(48)
+    db.put(testKey, toHexString(testVal))
+  }
+
+  t.equal((await db.db.keys().all()).length, 20000, '20000 total keys')
+  t.equal((await sublevel.keys().all())?.length, 10000, '10000 history sublevel keys')
+
+  const oldRadius = 2n ** 256n
+  const newRadius = oldRadius / 2n
+  for await (const key of sublevel!.keys({ gte: bigIntToHex(newRadius) })) {
+    sublevel!.del(key)
+  }
+  const rest = (await sublevel?.keys().all())!.length
+  t.ok(
+    rest < 10000,
+    `pruning by 50% removed ${((10000 - rest) * 100) / 10000}% of sublevel content`
+  )
+  t.equals((await db.db.keys().all()).length, 10000 + rest, 'Keys deleted only from sublevel')
+  db.close()
+  t.end()
+})

--- a/packages/portalnetwork/test/client/db.spec.ts
+++ b/packages/portalnetwork/test/client/db.spec.ts
@@ -28,7 +28,7 @@ tape('DBManager unit tests', async (t) => {
   t.equal(db.db.status, 'open', 'Main database is open')
   t.equal(sublevel.status, 'open', 'History Sublevel open')
   t.equal(state, undefined, 'Unsupported Network not open')
-  t.equal(db.nodeId, self, 'db nodeId set correctly')
+  t.equal(db.nodeId, self.slice(2), 'db nodeId set correctly')
 
   const testHash = randomBytes(32)
   const testVal = randomBytes(48)

--- a/packages/portalnetwork/test/integration/history.spec.ts
+++ b/packages/portalnetwork/test/integration/history.spec.ts
@@ -63,12 +63,18 @@ tape('History Protocol Integration Tests', (t) => {
             )
             const header = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+                getHistoryNetworkContentKey(
+                  HistoryNetworkContentTypes.BlockHeader,
+                  fromHexString(blockHash)
+                )
               )
             )
             const body = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
+                getHistoryNetworkContentKey(
+                  HistoryNetworkContentTypes.BlockBody,
+                  fromHexString(blockHash)
+                )
               )
             )
             const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]

--- a/packages/portalnetwork/test/integration/history.spec.ts
+++ b/packages/portalnetwork/test/integration/history.spec.ts
@@ -1,21 +1,17 @@
-import tape from 'tape'
+import { fromHexString, toHexString } from '@chainsafe/ssz'
+import { Block } from '@ethereumjs/block'
 import { ChildProcessWithoutNullStreams } from 'child_process'
+import { createRequire } from 'module'
+import tape from 'tape'
 import {
+  getHistoryNetworkContentKey,
+  HistoryNetworkContentTypes,
+  HistoryProtocol,
   PortalNetwork,
   ProtocolId,
-  sszEncodeBlockBody,
-  HistoryNetworkContentTypes,
-  HeaderAccumulatorType,
-  getHistoryNetworkContentId,
-  HistoryNetworkContentKeyType,
-  HistoryProtocol,
   reassembleBlock,
-  HeaderAccumulator,
-  getHistoryNetworkContentKey,
+  sszEncodeBlockBody,
 } from '../../src/index.js'
-import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { Block, BlockHeader } from '@ethereumjs/block'
-import { createRequire } from 'module'
 import { connectAndTest, end } from './integrationTest.js'
 
 const require = createRequire(import.meta.url)

--- a/packages/portalnetwork/test/integration/rpc.spec.ts
+++ b/packages/portalnetwork/test/integration/rpc.spec.ts
@@ -11,6 +11,7 @@ import {
   HistoryNetworkContentTypes,
   HeaderAccumulatorType,
   HeaderAccumulator,
+  getHistoryNetworkContentKey,
 } from '../../src/index.js'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Block } from '@ethereumjs/block'
@@ -50,12 +51,18 @@ tape('getBlockByHash', (t) => {
           st.equal(testHashStrings[idx], blockHash, `eth_getBlockByHash retrieved a block body`)
           const header = fromHexString(
             await portal2.db.get(
-              getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+              getHistoryNetworkContentKey(
+                HistoryNetworkContentTypes.BlockHeader,
+                fromHexString(blockHash)
+              )
             )
           )
           const body = fromHexString(
             await portal2.db.get(
-              getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
+              getHistoryNetworkContentKey(
+                HistoryNetworkContentTypes.BlockBody,
+                fromHexString(blockHash)
+              )
             )
           )
           const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]
@@ -112,13 +119,13 @@ tape('getBlockByHash', (t) => {
         'eth_getBlockByHash test passed'
       )
       const _h = await portal2.db.get(
-        getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, testHash)
+        getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockHeader, fromHexString(testHash))
       )
       st.equal(_h, toHexString(testHeader), 'eth_getBlockByHash returned a Block Header')
 
       try {
         await portal2.db.get(
-          getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, testHash)
+          getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockBody, fromHexString(testHash))
         )
         st.fail('should not find block body')
       } catch (e: any) {

--- a/packages/portalnetwork/test/integration/rpc.spec.ts
+++ b/packages/portalnetwork/test/integration/rpc.spec.ts
@@ -4,8 +4,6 @@ import {
   PortalNetwork,
   ProtocolId,
   sszEncodeBlockBody,
-  getHistoryNetworkContentId,
-  HistoryNetworkContentKeyType,
   HistoryProtocol,
   reassembleBlock,
   HistoryNetworkContentTypes,
@@ -149,12 +147,7 @@ tape('getBlockByNumber', (t) => {
     const block1000 = require('./testBlock1000.json')
     const epochHash = epochData.hash
     const serialized = epochData.serialized
-    const epochKey = HistoryNetworkContentKeyType.serialize(
-      Buffer.concat([
-        Uint8Array.from([HistoryNetworkContentTypes.EpochAccumulator]),
-        fromHexString(epochHash),
-      ])
-    )
+
     const blockRlp = block1000.raw
     const rebuiltBlock = Block.fromRLPSerializedBlock(Buffer.from(fromHexString(blockRlp)), {
       hardforkByBlockNumber: true,

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -10,6 +10,7 @@ import {
   HistoryNetworkContentKeyType,
   HistoryProtocol,
   reassembleBlock,
+  getHistoryNetworkContentKey,
 } from '../../src/index.js'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Block } from '@ethereumjs/block'
@@ -68,24 +69,21 @@ tape('Integration -- FINDCONTENT/FOUNDCONTENT', (t) => {
         testBlockBody
       )
       testBlockKeys.push(
-        HistoryNetworkContentKeyType.serialize(
-          Buffer.concat([
-            Uint8Array.from([HistoryNetworkContentTypes.BlockHeader]),
-            fromHexString(testHash),
-          ])
+        fromHexString(
+          getHistoryNetworkContentKey(
+            HistoryNetworkContentTypes.BlockHeader,
+            fromHexString(testHash)
+          )
         ),
-        HistoryNetworkContentKeyType.serialize(
-          Buffer.concat([
-            Uint8Array.from([HistoryNetworkContentTypes.BlockBody]),
-            fromHexString(testHash),
-          ])
+        fromHexString(
+          getHistoryNetworkContentKey(HistoryNetworkContentTypes.BlockBody, fromHexString(testHash))
         )
       )
       let header: Uint8Array
       portal2.on('ContentAdded', async (blockHash, contentType, content) => {
         st.equal(
-          await portal1.db.get(getHistoryNetworkContentId(contentType, testHash)),
-          await portal2.db.get(getHistoryNetworkContentId(contentType, testHash)),
+          await portal1.db.get(getHistoryNetworkContentKey(contentType, fromHexString(testHash))),
+          await portal2.db.get(getHistoryNetworkContentKey(contentType, fromHexString(testHash))),
           `${HistoryNetworkContentTypes[contentType]} successfully stored in database`
         )
         if (contentType === HistoryNetworkContentTypes.BlockHeader) {
@@ -188,7 +186,10 @@ tape('OFFER/ACCEPT', (t) => {
       portal1.on('ContentAdded', async (blockHash, contentType, content) => {
         st.equal(
           await portal1.db.get(
-            getHistoryNetworkContentId(contentType, testHashes[testHashes.indexOf(blockHash)])
+            getHistoryNetworkContentKey(
+              contentType,
+              fromHexString(testHashes[testHashes.indexOf(blockHash)])
+            )
           ),
           content,
           `${HistoryNetworkContentTypes[contentType]} successfully stored in db`
@@ -275,12 +276,18 @@ tape('OFFER/ACCEPT', (t) => {
             )
             const header = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockHeader, blockHash)
+                getHistoryNetworkContentKey(
+                  HistoryNetworkContentTypes.BlockHeader,
+                  fromHexString(blockHash)
+                )
               )
             )
             const body = fromHexString(
               await portal2.db.get(
-                getHistoryNetworkContentId(HistoryNetworkContentTypes.BlockBody, blockHash)
+                getHistoryNetworkContentKey(
+                  HistoryNetworkContentTypes.BlockBody,
+                  fromHexString(blockHash)
+                )
               )
             )
             const testBlock = testBlocks[testHashStrings.indexOf(blockHash)]

--- a/packages/portalnetwork/test/integration/wire.spec.ts
+++ b/packages/portalnetwork/test/integration/wire.spec.ts
@@ -6,7 +6,6 @@ import {
   ProtocolId,
   sszEncodeBlockBody,
   HistoryNetworkContentTypes,
-  getHistoryNetworkContentId,
   HistoryNetworkContentKeyType,
   HistoryProtocol,
   reassembleBlock,

--- a/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
@@ -8,23 +8,20 @@ import {
   PortalNetwork,
   toHexString,
   ProtocolId,
-  serializedContentKeyToContentId,
   sszEncodeBlockBody,
   HistoryNetworkContentKeyType,
   HistoryNetworkContentTypes,
   EpochAccumulator,
   getHistoryNetworkContentId,
-  HeaderAccumulatorType,
   blockNumberToGindex,
   TransportLayer,
   HistoryProtocol,
-  HeaderAccumulator,
   getHistoryNetworkContentKey,
   reassembleBlock,
 } from '../../../src/index.js'
 import { createRequire } from 'module'
 import RLP from '@ethereumjs/rlp'
-import { bufArrToArr, arrToBufArr } from '@ethereumjs/util'
+import { bufArrToArr } from '@ethereumjs/util'
 
 const require = createRequire(import.meta.url)
 const testBlocks = require('./testdata/testBlocks.json')

--- a/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/historyProtocol.spec.ts
@@ -19,6 +19,8 @@ import {
   TransportLayer,
   HistoryProtocol,
   HeaderAccumulator,
+  getHistoryNetworkContentKey,
+  reassembleBlock,
 } from '../../../src/index.js'
 import { createRequire } from 'module'
 import RLP from '@ethereumjs/rlp'
@@ -101,14 +103,12 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
       block1Hash,
       fromHexString(block1Rlp)
     )
-    const contentKey = HistoryNetworkContentKeyType.serialize(
-      Buffer.concat([
-        Uint8Array.from([HistoryNetworkContentTypes.BlockHeader]),
-        fromHexString(block1Hash),
-      ])
+    const contentKey = getHistoryNetworkContentKey(
+      HistoryNetworkContentTypes.BlockHeader,
+      fromHexString(block1Hash)
     )
 
-    const val = await node.db.get(serializedContentKeyToContentId(contentKey))
+    const val = await node.db.get(contentKey)
     const header = BlockHeader.fromRLPSerializedHeader(Buffer.from(fromHexString(val)), {
       hardforkByBlockNumber: true,
     })
@@ -122,16 +122,16 @@ tape('addContentToHistory -- Headers and Epoch Accumulators', async (t) => {
     const epochAccumulator = require('../../integration/testEpoch.json')
     const rebuilt = EpochAccumulator.deserialize(fromHexString(epochAccumulator.serialized))
     const hashRoot = EpochAccumulator.hashTreeRoot(rebuilt)
-    const contentId = getHistoryNetworkContentId(
+    const contentKey = getHistoryNetworkContentKey(
       HistoryNetworkContentTypes.EpochAccumulator,
-      toHexString(hashRoot)
+      hashRoot
     )
     await protocol.addContentToHistory(
       HistoryNetworkContentTypes.EpochAccumulator,
       toHexString(hashRoot),
       fromHexString(epochAccumulator.serialized)
     )
-    const fromDB = await node.db.get(contentId)
+    const fromDB = await node.db.get(contentKey)
     st.equal(fromDB, epochAccumulator.serialized, 'Retrive EpochAccumulator test passed.')
   })
 
@@ -185,22 +185,30 @@ tape('addContentToHistory -- Block Bodies and Receipts', async (t) => {
     serializedBlock.blockHash,
     sszEncodeBlockBody(block)
   )
-  const rebuilt = await protocol.ETH.getBlockByHash(serializedBlock.blockHash, true)
-  t.equal(rebuilt?.header.number, block.header.number, 'reassembled block from components in DB')
+  const header = await node.db.get(
+    getHistoryNetworkContentKey(
+      HistoryNetworkContentTypes.BlockHeader,
+      fromHexString(serializedBlock.blockHash)
+    )
+  )
+  const body = await node.db.get(
+    getHistoryNetworkContentKey(
+      HistoryNetworkContentTypes.BlockBody,
+      fromHexString(serializedBlock.blockHash)
+    )
+  )
+  const rebuilt = reassembleBlock(fromHexString(header), fromHexString(body))
+  t.equal(rebuilt.header.number, block.header.number, 'reassembled block from components in DB')
   const receipt = await protocol.receiptManager.saveReceipts(block)
   t.equal(receipt[0].cumulativeBlockGasUsed, 43608n, 'correctly generated block receipts')
   t.end()
 })
 
 tape('Header Proof Tests', async (t) => {
-  const _accumulator = require('../../integration/testAccumulator.json')
   const _epoch1 = require('../../integration/testEpoch.json')
-  const accumulator = new HeaderAccumulator({
-    storedAccumulator: HeaderAccumulatorType.deserialize(fromHexString(_accumulator)),
-  })
   const node = await PortalNetwork.create({ transport: TransportLayer.WEB })
   const protocol = new HistoryProtocol(node, 2n) as HistoryProtocol
-  protocol.accumulator.replaceAccumulator(accumulator)
+  // protocol.accumulator.replaceAccumulator(accumulator)
   t.test(
     'HistoryProtocol can create and verify proofs for a HeaderRecord from an EpochAccumulator',
     async (st) => {


### PR DESCRIPTION
### Enable DB pruning for subprotocols

#### DatabaseKeys
##### Introduces a new protocol for storing content in the database.
*portal-network-specs* defines a contentKey and contentId for each data type:
```
contentKey = selector + blockhash
contentId = sha256(contentKey)
```
Ultralight previously stored content in the database using `contentKey` hex strings as database keys 
 `contentId` was calculated to evaluate distance to a self or peer via `distance = nodeId XOR contentKey`

The reason XOR works for this purpose is the commutative property:  `A ⊕ B === B ⊕ A`
1. Every bytes32 `nodeId` has a unique XOR value with every possible bytes32 `contentId`.
2. Every `contentId` has a unique XOR value with every possible bytes32 `nodeId`

This PR creates a new key: `databaseKey` based on the unique distance from a client's `nodeId` to each piece of content.

`databaseKey = contentId ⊕ nodeId`

Storing content by `databaseKey` allows for iterating through database content according to distance, which will enable pruning by radius.

#### Database Pruning
##### Introduces a new protocol for pruning content beyond a radius

A portal client's responsibility lies within it's radius.  When a client's content database approaches its limitations, it should first prune content beyond its radius, and then incrementally prune with a smaller radius to free up space.

LevelDB has a `.keys()` method that returns an iterator of keys in the database.
To parse contentKeys by distance would require iterating through the entire database and calculating distance.

Regardless of the order that keys were added, the keys are iterated in sorted order:  0x01, 0x02, 0x03, 0x04, 0x05...
`.keys()`  can also take a options regarding range.  So `db.keys({ gte: 0x03 })` would return:  0x03, 0x04, 0x05... 

If we do use `databaseKeys` to store content in the database, the content will sort itself by distance. The `.keys()` iterator will return in order of closest to farthest, and  `db.keys({ gte: radius })` will return an iterator of keys beyond the radius, which can be batch deleted in one operation.

#### Database Sublevels
##### Divides the Database into sections by sub-protocol

This pruning method is agnostic of the database values.  `contentId` is a hash of `contentKey`, so the content type cannot be derived from `databaseKey`.

This limitation becomes an issue as multiple `subprotocols` use the same database to store types of content with a large variation of content sizes.

`LevelDB` supports `sublevels`.   a `sublevel` instance behaves like a `LevelDB` instance.  Keys added to a sublevel are stored in the parent levelDB with an added prefix.  `db.keys()` will return all keys from all sublevels with their sublevel prefix.  `sublevel.keys()` will return all of the sublevel's keys, without the prefix.  

By opening a sublevel for each `protocol`, we can still allow users to provide a db if desired, while also enabling each subprotocol to prune its own section of the database independently of the rest.