### PR TITLE
Misc small updates

### DIFF
--- a/packages/portalnetwork/src/rpc/types.ts
+++ b/packages/portalnetwork/src/rpc/types.ts
@@ -1,7 +1,8 @@
 import { Block } from '@ethereumjs/block'
 import { JsonTx, TypedTransaction } from '@ethereumjs/tx'
 import { Address, bigIntToHex, bufferToHex, intToHex } from '@ethereumjs/util'
-import { Log, PostByzantiumTxReceipt, PreByzantiumTxReceipt, TxReceipt } from '../subprotocols'
+import { Log } from '../subprotocols'
+import { PostByzantiumTxReceipt, PreByzantiumTxReceipt, TxReceipt } from '@ethereumjs/vm'
 
 export type GetLogsParams = {
   fromBlock?: string // QUANTITY, block number or "earliest" or "latest" (default: "latest")

--- a/packages/portalnetwork/src/subprotocols/history/contentManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/contentManager.ts
@@ -8,7 +8,7 @@ import {
   HistoryNetworkContentTypes,
   HistoryProtocol,
   reassembleBlock,
-  SszProof,
+  SszProofType,
   HistoryNetworkContentKeyType,
 } from './index.js'
 import { ContentLookup } from '../index.js'
@@ -148,7 +148,7 @@ export class ContentManager {
         break
       case HistoryNetworkContentTypes.HeaderProof: {
         try {
-          const proof = SszProof.deserialize(value)
+          const proof = SszProofType.deserialize(value)
           const verified = await this.history.accumulator.verifyInclusionProof(proof, hashKey)
           this.history.client.emit('Verified', hashKey, verified)
           break

--- a/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/subprotocols/history/headerAccumulator.ts
@@ -7,7 +7,7 @@ import {
   EPOCH_SIZE,
   getHistoryNetworkContentKey,
   HeaderProofInterface,
-  HeaderRecordType,
+  HeaderRecord,
   HistoryNetworkContentTypes,
   HistoryProtocol,
 } from '../index.js'
@@ -20,11 +20,11 @@ const historicalEpochs: Uint8Array[] = accumulator.map((hash: string) => {
 export interface AccumulatorOpts {
   storedAccumulator: {
     historicalEpochs: Uint8Array[]
-    currentEpoch: HeaderRecordType[]
+    currentEpoch: HeaderRecord[]
   }
 }
 export class HeaderAccumulator {
-  private _currentEpoch: HeaderRecordType[]
+  private _currentEpoch: HeaderRecord[]
   private _historicalEpochs: Uint8Array[]
 
   /**

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -24,7 +24,7 @@ import {
   ReceiptsManager,
   RequestCode,
   shortId,
-  SszProof,
+  SszProofType,
 } from '../../index.js'
 
 import { BaseProtocol } from '../protocol.js'
@@ -85,7 +85,7 @@ export class HistoryProtocol extends BaseProtocol {
         this.logger(`Creating proof for ${toHexString(contentKey.subarray(1))}`)
         const proof = await this.generateInclusionProof(toHexString(contentKey.subarray(1)))
         // this.logger(proof)
-        value = SszProof.serialize({
+        value = SszProofType.serialize({
           leaf: proof.leaf,
           witnesses: proof.witnesses,
         })

--- a/packages/portalnetwork/src/subprotocols/history/receipt.ts
+++ b/packages/portalnetwork/src/subprotocols/history/receipt.ts
@@ -9,15 +9,12 @@ import { RLP } from '@ethereumjs/rlp'
 import {
   IReceiptOpts,
   Log,
-  PostByzantiumTxReceipt,
   PostByzantiumTxReceiptWithType,
-  PreByzantiumTxReceipt,
   PreByzantiumTxReceiptWithType,
   rlpReceipt,
-  TxReceipt,
   TxReceiptType,
 } from './types.js'
-
+import { TxReceipt, PostByzantiumTxReceipt, PreByzantiumTxReceipt } from '@ethereumjs/vm'
 export class Receipt {
   cumulativeBlockGasUsed: bigint
   bitvector: Buffer

--- a/packages/portalnetwork/src/subprotocols/history/receiptManager.ts
+++ b/packages/portalnetwork/src/subprotocols/history/receiptManager.ts
@@ -17,14 +17,11 @@ import {
   getHistoryNetworkContentKey,
   HistoryNetworkContentTypes,
   Log,
-  PostByzantiumTxReceipt,
-  PreByzantiumTxReceipt,
-  TxReceipt,
   TxReceiptType,
   TxReceiptWithType,
 } from '../index.js'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { VM } from '@ethereumjs/vm'
+import { TxReceipt, PostByzantiumTxReceipt, PreByzantiumTxReceipt, VM } from '@ethereumjs/vm'
 
 type _GetReceiptByTxHashReturn = [
   receipt: TxReceipt,

--- a/packages/portalnetwork/src/subprotocols/history/types.ts
+++ b/packages/portalnetwork/src/subprotocols/history/types.ts
@@ -4,15 +4,14 @@ import {
   ContainerType,
   ListCompositeType,
   UintBigintType,
-  UnionType,
 } from '@chainsafe/ssz'
+import { PostByzantiumTxReceipt, PreByzantiumTxReceipt, TxReceipt } from '@ethereumjs/vm'
 
 /* ----------------- Constants ----------- */
 // number of header records in a single epoch
 export const EPOCH_SIZE = 8192
 // maximum number of epoch accumulator root hashes stored in historical epochs array
-const MAX_HISTORICAL_EPOCHS = 131072
-
+export const MAX_HISTORICAL_EPOCHS = 131072
 // Block Body SSZ encoding related constants
 export const MAX_TRANSACTION_LENGTH = 2 ** 24
 export const MAX_TRANSACTION_COUNT = 2 ** 14
@@ -20,25 +19,7 @@ export const MAX_RECEIPT_LENGTH = 2 ** 27
 export const MAX_HEADER_LENGTH = 2 ** 13
 export const MAX_ENCODED_UNCLES_LENGTH = MAX_HEADER_LENGTH * 2 ** 4
 
-/* ----------------- Types ----------- */
-/**
- * @property blockHash - byte representation of the hex encoded block hash
- *
- */
-export type HistoryNetworkContentKey = {
-  blockHash: Uint8Array
-}
-
-export const BlockHeaderType = new ContainerType({
-  blockHash: new ByteVectorType(32),
-})
-
-export const BlockBodyType = BlockHeaderType
-
-export const ReceiptType = BlockHeaderType
-
-export const ProofType = BlockHeaderType
-
+/* ----------------- Enums ----------- */
 export enum HistoryNetworkContentTypes {
   BlockHeader = 0,
   BlockBody = 1,
@@ -46,107 +27,20 @@ export enum HistoryNetworkContentTypes {
   EpochAccumulator = 3,
   HeaderProof = 4,
 }
-
-export const HashRoot = new ByteVectorType(32)
-export const Witnesses = new ListCompositeType(HashRoot, 2 ** 16)
-export const gIndex = new UintBigintType(4)
-// export const leaves = new ListCompositeType(HashRoot, 8192)
-
-export const SszProof = new ContainerType({
-  leaf: HashRoot,
-  witnesses: Witnesses,
-})
-
-export const HeaderRecord = new ContainerType({
-  blockHash: new ByteVectorType(32),
-  totalDifficulty: new UintBigintType(32),
-})
-
-export type HeaderRecordType = {
-  blockHash: Uint8Array
-  totalDifficulty: bigint
-}
-export const EpochAccumulator = new ListCompositeType(HeaderRecord, EPOCH_SIZE)
-
-export const HeaderAccumulatorType = new ContainerType({
-  historicalEpochs: new ListCompositeType(new ByteVectorType(32), MAX_HISTORICAL_EPOCHS),
-  currentEpoch: EpochAccumulator,
-})
-
-export type HeaderProofInterface = {
-  epochRoot: Uint8Array
-  gindex: bigint
-  leaf: Uint8Array
-  witnesses: Uint8Array[]
+export enum HistoryNetworkRetrievalMechanism {
+  BlockHeaderByHash = 0,
+  BlockBodyByHash = 1,
+  BlockReceiptsByHash = 3,
+  EpochAccumulatorByHash = 4,
 }
 
-export const HistoryNetworkContentKeyType = new ByteVectorType(33)
-
-export const sszTransaction = new ByteListType(MAX_TRANSACTION_LENGTH)
-export const allTransactions = new ListCompositeType(sszTransaction, MAX_TRANSACTION_COUNT)
-export const sszUncles = new ByteListType(MAX_ENCODED_UNCLES_LENGTH)
-export const BlockBodyContentType = new ContainerType({
-  allTransactions: allTransactions,
-  sszUncles: sszUncles,
-})
-export type BlockBodyContent = { txsRlp: Buffer[]; unclesRlp: Uint8Array }
-
-// Receipt Types
-
-export type rlpReceipt = [
-  postStateOrStatus: Buffer,
-  cumulativeGasUsed: Buffer,
-  bitvector: Buffer,
-  logs: Log[]
-]
-
-export type Log = [address: Buffer, topics: Buffer[], data: Buffer]
-export type TxReceipt = PreByzantiumTxReceipt | PostByzantiumTxReceipt
-
-export const sszReceiptType = new ByteListType(MAX_RECEIPT_LENGTH)
-export const sszReceiptsListType = new ListCompositeType(sszReceiptType, MAX_TRANSACTION_COUNT)
-
-/**
- * Abstract interface with common transaction receipt fields
- */
-export interface BaseTxReceipt {
-  /**
-   * Cumulative gas used in the block including this tx
-   */
-  cumulativeBlockGasUsed: bigint
-  /**
-   * Bloom bitvector
-   */
-  bitvector: Buffer
-  /**
-   * Logs emitted
-   */
-  logs: Log[]
+/* ----------------- Interfaces ----------- */
+export interface HeaderProofInterface {
+  epochRoot: HashRoot
+  gindex: GIndex
+  leaf: Leaf
+  witnesses: Witnesses
 }
-/**
- * Pre-Byzantium receipt type with a field
- * for the intermediary state root
- */
-export interface PreByzantiumTxReceipt extends BaseTxReceipt {
-  /**
-   * Intermediary state root
-   */
-  stateRoot: Buffer
-}
-/**
- * Receipt type for Byzantium and beyond replacing the intermediary
- * state root field with a status code field (EIP-658)
- */
-export interface PostByzantiumTxReceipt extends BaseTxReceipt {
-  /**
-   * Status of transaction, `1` if successful, `0` if an exception occured
-   */
-  status: 0 | 1
-}
-/**
- * TxReceiptWithType extends TxReceipt to provide:
- *  - txType: byte prefix for serializing typed tx receipts
- */
 export interface PreByzantiumTxReceiptWithType extends PreByzantiumTxReceipt {
   /* EIP-2718 Typed Transaction Envelope type */
   txType: number
@@ -155,14 +49,6 @@ export interface PostByzantiumTxReceiptWithType extends PostByzantiumTxReceipt {
   /* EIP-2718 Typed Transaction Envelope type */
   txType: number
 }
-
-/**
- * TxReceiptWithType extends TxReceipt to provide:
- *  - txType: byte prefix for serializing typed tx receipts
- */
-export type TxReceiptWithType = PreByzantiumTxReceiptWithType | PostByzantiumTxReceiptWithType
-
-export type TxReceiptType = TxReceipt | TxReceiptWithType
 export interface IReceiptOpts {
   /**
    * Cumulative gas used in the block including this tx
@@ -187,3 +73,85 @@ export interface IReceiptOpts {
   /* EIP-2718 Typed Transaction Envelope type */
   txType?: number
 }
+
+/* ----------------- Types ----------- */
+export type HashRoot = Uint8Array
+export type TotalDifficulty = bigint
+export type Leaf = Uint8Array
+export type Witnesses = Uint8Array[]
+export type GIndex = bigint
+export type HistoryNetworkContentKey = {
+  selector: HistoryNetworkContentTypes
+  blockHash: HashRoot
+}
+export type SszProof = {
+  leaf: HashRoot
+  witnesses: Witnesses
+}
+export type HeaderRecord = {
+  blockHash: HashRoot
+  totalDifficulty: TotalDifficulty
+}
+export type HistoricalEpoch = Uint8Array
+export type HeaderRecordList = Uint8Array[]
+export type Rlp = Uint8Array
+export type BlockBodyContent = { txsRlp: Rlp[]; unclesRlp: Rlp }
+export type Log = [address: Buffer, topics: Buffer[], data: Buffer]
+export type rlpReceipt = [
+  postStateOrStatus: Buffer,
+  cumulativeGasUsed: Buffer,
+  bitvector: Buffer,
+  logs: Log[]
+]
+
+/**
+ * TxReceiptWithType extends TxReceipt to provide:
+ *  - txType: byte prefix for serializing typed tx receipts
+ */
+export type TxReceiptWithType = PreByzantiumTxReceiptWithType | PostByzantiumTxReceiptWithType
+export type TxReceiptType = TxReceipt | TxReceiptWithType
+
+/* ----------------- SSZ Type Aliases ----------- */
+export const Bytes32Type = new ByteVectorType(32)
+export const HashRootType = Bytes32Type
+export const TotalDifficultyType = new UintBigintType(32)
+export const LeafType = Bytes32Type
+export const WitnessesType = new ListCompositeType(HashRootType, 2 ** 16)
+export const GIndexType = new UintBigintType(4)
+export const HistoryNetworkContentKeyType = new ByteVectorType(33)
+export const HistoryNetworkContentType = new ContainerType({
+  blockHash: HashRootType,
+})
+export const BlockHeaderType = HistoryNetworkContentType
+export const BlockBodyType = HistoryNetworkContentType
+export const ReceiptType = HistoryNetworkContentType
+export const EpochAccumulatorType = HistoryNetworkContentType
+export const ProofType = HistoryNetworkContentType
+export const SszProofType = new ContainerType({
+  leaf: HashRootType,
+  witnesses: WitnessesType,
+})
+export const HeaderRecordType = new ContainerType({
+  blockHash: HashRootType,
+  totalDifficulty: TotalDifficultyType,
+})
+export const HistoricalEpochType = Bytes32Type
+export const HistoricalEpochsType = new ListCompositeType(
+  HistoricalEpochType,
+  MAX_HISTORICAL_EPOCHS
+)
+export const EpochAccumulator = new ListCompositeType(HeaderRecordType, EPOCH_SIZE)
+export const HeaderAccumulatorType = new ContainerType({
+  historicalEpochs: HistoricalEpochsType,
+  currentEpoch: EpochAccumulator,
+})
+export const sszTransactionType = new ByteListType(MAX_TRANSACTION_LENGTH)
+export const allTransactionsType = new ListCompositeType(sszTransactionType, MAX_TRANSACTION_COUNT)
+export const sszUnclesType = new ByteListType(MAX_ENCODED_UNCLES_LENGTH)
+export const BlockBodyContentType = new ContainerType({
+  allTransactions: allTransactionsType,
+  sszUncles: sszUnclesType,
+})
+
+export const sszReceiptType = new ByteListType(MAX_RECEIPT_LENGTH)
+export const sszReceiptsListType = new ListCompositeType(sszReceiptType, MAX_TRANSACTION_COUNT)

--- a/packages/portalnetwork/src/subprotocols/history/util.ts
+++ b/packages/portalnetwork/src/subprotocols/history/util.ts
@@ -4,8 +4,8 @@ import {
   BlockBodyContent,
   BlockBodyContentType,
   HistoryNetworkContentTypes,
-  sszTransaction,
-  sszUncles,
+  sszTransactionType,
+  sszUnclesType,
 } from './types.js'
 import rlp from '@ethereumjs/rlp'
 import {
@@ -66,17 +66,19 @@ export const decodeHistoryNetworkContentKey = (contentKey: string) => {
 
 export const decodeSszBlockBody = (sszBody: Uint8Array): BlockBodyContent => {
   const body = BlockBodyContentType.deserialize(sszBody)
-  const txsRlp = body.allTransactions.map((sszTx) => Buffer.from(sszTransaction.deserialize(sszTx)))
-  const unclesRlp = sszUncles.deserialize(body.sszUncles)
+  const txsRlp = body.allTransactions.map((sszTx) =>
+    Buffer.from(sszTransactionType.deserialize(sszTx))
+  )
+  const unclesRlp = sszUnclesType.deserialize(body.sszUncles)
   return { txsRlp, unclesRlp }
 }
 
 export const sszEncodeBlockBody = (block: Block) => {
-  const encodedSSZTxs = block.transactions.map((tx) => sszTransaction.serialize(tx.serialize()))
+  const encodedSSZTxs = block.transactions.map((tx) => sszTransactionType.serialize(tx.serialize()))
   const encodedUncles = rlp.encode(block.uncleHeaders.map((uh) => uh.raw()))
   return BlockBodyContentType.serialize({
     allTransactions: encodedSSZTxs,
-    sszUncles: sszUncles.serialize(encodedUncles),
+    sszUncles: sszUnclesType.serialize(encodedUncles),
   })
 }
 

--- a/packages/portalnetwork/src/util/helpers.ts
+++ b/packages/portalnetwork/src/util/helpers.ts
@@ -16,8 +16,8 @@ import { TypeOutput, setLengthLeft, toBuffer, toType } from '@ethereumjs/util'
 import { Block, BlockOptions, JsonRpcBlock } from '@ethereumjs/block'
 
 import type { TxData, TypedTransaction } from '@ethereumjs/tx'
-import { Log, TxReceiptType } from '../subprotocols/index.js'
 import { PostByzantiumTxReceipt, PreByzantiumTxReceipt, VM } from '@ethereumjs/vm'
+import { Log, TxReceiptType } from '../subprotocols/index.js'
 export interface ExtendedEthersBlock extends ethers.providers.Block {
   blockReward?: BigNumber
   unclesReward?: BigNumber

--- a/packages/portalnetwork/src/wire/utp/Packets/Packet.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/Packet.ts
@@ -39,8 +39,8 @@ export class Packet {
             version: 1,
             extension: buffer.readUInt8(1),
             connectionId: buffer.readUInt16BE(2),
-            timestamp: buffer.readUInt32BE(4),
-            timestampDiff: buffer.readUInt32BE(8),
+            timestampMicroseconds: buffer.readUInt32BE(4),
+            timestampDifferenceMicroseconds: buffer.readUInt32BE(8),
             wndSize: buffer.readUInt32BE(12),
             seqNr: buffer.readUInt16BE(16),
             ackNr: buffer.readUInt16BE(18),
@@ -57,8 +57,8 @@ export class Packet {
           version: 1,
           extension: 0,
           connectionId: buffer.readUInt16BE(2),
-          timestamp: buffer.readUInt32BE(4),
-          timestampDiff: buffer.readUInt32BE(8),
+          timestampMicroseconds: buffer.readUInt32BE(4),
+          timestampDifferenceMicroseconds: buffer.readUInt32BE(8),
           wndSize: buffer.readUInt32BE(12),
           seqNr: buffer.readUInt16BE(16),
           ackNr: buffer.readUInt16BE(18),
@@ -80,7 +80,7 @@ export class Packet {
         packet = createSynPacket(opts as createSynOpts)
         break
       case PacketType.ST_STATE:
-        if (selectiveAck) {
+        if (selectiveAck === true) {
           packet = createSelectiveAckPacket(opts as createSelectiveAckOpts)
         } else {
           packet = createAckPacket(opts as createAckOpts)
@@ -119,8 +119,8 @@ export class Packet {
     buffer.writeUInt8(typeAndVer, 0)
     buffer.writeUInt8(this.header.extension, 1)
     buffer.writeUInt16BE(this.header.connectionId, 2)
-    buffer.writeUInt32BE(this.header.timestamp, 4)
-    buffer.writeUInt32BE(this.header.timestampDiff, 8)
+    buffer.writeUInt32BE(this.header.timestampMicroseconds, 4)
+    buffer.writeUInt32BE(this.header.timestampDifferenceMicroseconds, 8)
     buffer.writeUInt32BE(this.header.wndSize, 12)
     buffer.writeUInt16BE(this.header.seqNr, 16)
     buffer.writeUInt16BE(this.header.ackNr, 18)

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
@@ -7,8 +7,8 @@ export class PacketHeader {
   version: Uint8
   extension: Uint8
   connectionId: Uint16
-  timestamp: MicroSeconds
-  timestampDiff: MicroSeconds
+  timestampMicroseconds: MicroSeconds
+  timestampDifferenceMicroseconds: MicroSeconds
   wndSize: Uint32
   seqNr: Uint16
   ackNr: Uint16
@@ -19,9 +19,9 @@ export class PacketHeader {
     this.version = options.version ?? VERSION
     this.extension = options.extension ?? 0
     this.connectionId = options.connectionId
-    this.timestamp = options.timestamp ?? Bytes32TimeStamp()
-    this.timestampDiff = options.timestampDiff ?? 0
-    this.wndSize = options.wndSize ?? DEFAULT_WINDOW_SIZE
+    this.timestampMicroseconds = options.timestampMicroseconds ?? Bytes32TimeStamp()
+    this.timestampDifferenceMicroseconds = options.timestampDifferenceMicroseconds ?? 0
+    this.wndSize = options.wndSize
     this.seqNr = options.seqNr
     this.ackNr = options.ackNr
     this.length = 20
@@ -42,8 +42,8 @@ export class SelectiveAckHeader extends PacketHeader {
     buffer[0] = 1
     buffer[1] = 0
     buffer.writeUInt16BE(this.connectionId, 2)
-    buffer.writeUInt32BE(this.timestamp, 4)
-    buffer.writeUInt32BE(this.timestampDiff as number, 8)
+    buffer.writeUInt32BE(this.timestampMicroseconds, 4)
+    buffer.writeUInt32BE(this.timestampDifferenceMicroseconds as number, 8)
     buffer.writeUInt32BE(this.wndSize as number, 12)
     buffer.writeUInt16BE(this.seqNr, 16)
     buffer.writeUInt16BE(this.ackNr, 18)

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
@@ -1,12 +1,16 @@
 import { UtpSocket, ConnectionState } from '../Socket/index.js'
+import { Bytes32TimeStamp } from '../Utils/math.js'
 import { Packet } from './Packet.js'
 import { PacketType } from './PacketTyping.js'
 
 export async function sendSynPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_SYN, {
-    sndConnectionId: socket.sndConnectionId,
+    connectionId: socket.sndConnectionId,
     seqNr: 1,
     ackNr: socket.ackNr,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: socket.rtt_var,
+    wndSize: socket.cur_window,
   })
   socket.state = ConnectionState.SynSent
   await socket.sendSynPacket(packet)
@@ -16,10 +20,11 @@ export async function sendSynPacket(socket: UtpSocket): Promise<Packet> {
 export async function sendSynAckPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_STATE, {
     seqNr: socket.seqNr,
-    sndConnectionId: socket.sndConnectionId,
+    connectionId: socket.sndConnectionId,
     ackNr: socket.ackNr,
-    rtt_var: socket.rtt_var,
-    wndSide: socket.cur_window,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: socket.rtt_var,
+    wndSize: socket.cur_window,
   })
   await socket.sendSynAckPacket(packet)
   return packet
@@ -27,9 +32,12 @@ export async function sendSynAckPacket(socket: UtpSocket): Promise<Packet> {
 export async function sendDataPacket(socket: UtpSocket, payload: Uint8Array): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_DATA, {
     seqNr: socket.seqNr,
-    sndConnectionId: socket.sndConnectionId,
+    connectionId: socket.sndConnectionId,
     ackNr: socket.ackNr,
     payload: payload,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: socket.rtt_var,
+    wndSize: socket.cur_window,
   })
   await socket.sendDataPacket(packet)
   return packet
@@ -37,9 +45,10 @@ export async function sendDataPacket(socket: UtpSocket, payload: Uint8Array): Pr
 export async function sendAckPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_STATE, {
     seqNr: socket.seqNr,
-    sndConnectionId: socket.sndConnectionId,
+    connectionId: socket.sndConnectionId,
     ackNr: socket.ackNr,
-    rtt_var: socket.rtt_var,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: socket.rtt_var,
     wndSize: socket.cur_window,
   })
   await socket.sendStatePacket(packet)
@@ -48,18 +57,23 @@ export async function sendAckPacket(socket: UtpSocket): Promise<Packet> {
 export async function sendResetPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_RESET, {
     seqNr: socket.seqNr++,
-    sndConnectionId: socket.sndConnectionId,
+    connectionId: socket.sndConnectionId,
     ackNr: socket.ackNr,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: socket.rtt_var,
+    wndSize: socket.cur_window,
   })
   await socket.sendResetPacket(packet)
   return packet
 }
 export async function sendFinPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_FIN, {
-    sndConnectionId: socket.sndConnectionId,
+    connectionId: socket.sndConnectionId,
     seqNr: socket.seqNr,
     ackNr: socket.ackNr,
-    wndSide: socket.cur_window,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: socket.rtt_var,
+    wndSize: socket.cur_window,
   })
   socket.finNr = packet.header.seqNr
   await socket.sendFinPacket(packet)
@@ -70,9 +84,10 @@ export async function sendSelectiveAckPacket(socket: UtpSocket, ackNrs: number[]
     PacketType.ST_STATE,
     {
       seqNr: socket.seqNr,
-      sndConnectionId: socket.sndConnectionId,
+      connectionId: socket.sndConnectionId,
       ackNr: socket.ackNr,
-      rtt_var: socket.rtt_var,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: socket.rtt_var,
       wndSize: socket.cur_window,
       ackNrs: ackNrs,
     },

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
@@ -37,8 +37,8 @@ export type PacketHeaderType = {
   version: Uint8
   extension: Uint8
   connectionId: Uint16
-  timestamp: MicroSeconds
-  timestampDiff: MicroSeconds
+  timestampMicroseconds: MicroSeconds
+  timestampDifferenceMicroseconds: MicroSeconds
   wndSize: Uint32
   seqNr: Uint16
   ackNr: Uint16
@@ -52,9 +52,9 @@ export interface IPacketHeader {
   ackNr: Uint16
   version?: Uint8
   extension?: Uint8
-  timestamp?: MicroSeconds
-  timestampDiff?: MicroSeconds
-  wndSize?: Uint32
+  timestampMicroseconds?: MicroSeconds
+  timestampDifferenceMicroseconds?: MicroSeconds
+  wndSize: Uint32
   extensions?: Uint8Array
 }
 
@@ -73,8 +73,8 @@ export interface IPacketHeaderOptions {
   version: Uint8
   extension: Uint8
   connectionId: Uint16
-  timestamp?: MicroSeconds
-  timestampDiff?: MicroSeconds
+  timestampMicroseconds?: MicroSeconds
+  timestampDifferenceMicroseconds?: MicroSeconds
   wndSize?: Uint32
   seqNr?: Uint16
   ackNr?: Uint16

--- a/packages/portalnetwork/src/wire/utp/Packets/create.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/create.ts
@@ -1,57 +1,70 @@
 import { DEFAULT_WINDOW_SIZE } from '../Utils/constants.js'
 import { Packet } from './Packet.js'
 import { PacketHeader, SelectiveAckHeader } from './PacketHeader.js'
-import { PacketType, Uint16, Uint32, protocolVersion } from './PacketTyping.js'
+import { PacketType, Uint16, Uint32, protocolVersion, Uint8 } from './PacketTyping.js'
 
 export type createSynOpts = {
-  sndConnectionId: Uint16
+  version: Uint8
+  connectionId: Uint16
   seqNr: Uint16
   ackNr: number
-  timestamp?: number
-  rtt_var?: number
-  wndSide?: number
+  timestampMicrosecondsMicroseconds?: number
+  wndSize: number
+  timestampMicroseconds?: number
+  timestampDifferenceMicroseconds?: number
 }
 
 export type createAckOpts = {
-  sndConnectionId: Uint16
+  version?: Uint8
+  extension?: Uint8
+  connectionId: Uint16
   seqNr: Uint16
   ackNr: Uint16
-  rtt_var?: number
-  wndSize?: number
-  timestamp?: number
+  wndSize: number
+  timestampMicroseconds?: number
+  timestampDifferenceMicroseconds?: number
 }
 export type createSelectiveAckOpts = {
-  sndConnectionId: Uint16
+  extension?: Uint8
+  version?: Uint8
+  connectionId: Uint16
   seqNr: Uint16
   ackNr: Uint16
-  rtt_var?: number
-  wndSize?: number
+  wndSize: number
   ackNrs: number[]
-  timestamp?: number
+  timestampDifferenceMicroseconds?: number
+  timestampMicroseconds?: number
 }
 export type createDataOpts = {
-  sndConnectionId: Uint16
+  extension?: Uint8
+  version?: Uint8
+  connectionId: Uint16
   seqNr: Uint16
   ackNr: Uint16
-  wndSize?: Uint32
-  rtt_var?: number
-  timestamp?: number
+  wndSize: Uint32
+  timestampMicroseconds?: number
+  timestampDifferenceMicroseconds?: number
   payload: Uint8Array
 }
 export type createResetOpts = {
-  sndConnectionId: Uint16
+  extension?: Uint8
+  version?: Uint8
+  connectionId: Uint16
   seqNr: Uint16
   ackNr: Uint16
-  rtt_var?: number
-  timestamp?: number
+  wndSize: Uint32
+  timestampMicroseconds?: number
+  timestampDifferenceMicroseconds?: number
 }
 export type createFinOpts = {
-  sndConnectionId: Uint16
+  extension?: Uint8
+  version?: Uint8
+  connectionId: Uint16
   seqNr: number
   ackNr: number
-  rtt_var?: number
-  wndSize?: number
-  timestamp?: number
+  wndSize: number
+  timestampMicroseconds?: number
+  timestampDifferenceMicroseconds?: number
 }
 
 export type createPacketOpts =
@@ -65,10 +78,7 @@ export type createPacketOpts =
 export function createSynPacket(opts: createSynOpts): Packet {
   const h: PacketHeader = new PacketHeader({
     pType: PacketType.ST_SYN,
-    connectionId: opts.sndConnectionId,
-    seqNr: opts.seqNr,
-    ackNr: opts.ackNr,
-    timestamp: opts.timestamp,
+    ...opts,
   })
   const packet: Packet = new Packet({ header: h, payload: new Uint8Array() })
   return packet
@@ -77,46 +87,29 @@ export function createSynPacket(opts: createSynOpts): Packet {
 export function createAckPacket(opts: createAckOpts): Packet {
   const h: PacketHeader = new PacketHeader({
     pType: PacketType.ST_STATE,
-    connectionId: opts.sndConnectionId,
-    seqNr: opts.seqNr,
-    ackNr: opts.ackNr,
-    wndSize: opts.wndSize,
-    timestamp: opts.timestamp,
-    timestampDiff: opts.rtt_var,
+    ...opts,
   })
 
-  const packet: Packet = new Packet({ header: h, payload: new Uint8Array(0) })
+  const packet: Packet = new Packet({ header: h, payload: new Uint8Array([]) })
   return packet
 }
 export function createSelectiveAckPacket(opts: createSelectiveAckOpts): Packet {
   const h: SelectiveAckHeader = new SelectiveAckHeader(
     {
       pType: PacketType.ST_STATE,
-      connectionId: opts.sndConnectionId,
-      seqNr: opts.seqNr,
-      ackNr: opts.ackNr,
-      wndSize: opts.wndSize,
-      timestampDiff: opts.rtt_var,
-      timestamp: opts.timestamp,
+      ...opts,
     },
     Uint8Array.from(opts.ackNrs)
   )
 
-  const packet: Packet = new Packet({ header: h, payload: new Uint8Array(0) })
+  const packet: Packet = new Packet({ header: h, payload: new Uint8Array([]) })
   return packet
 }
 
 export function createDataPacket(opts: createDataOpts): Packet {
   const h: PacketHeader = new PacketHeader({
     pType: PacketType.ST_DATA,
-    version: protocolVersion,
-    extension: 0,
-    connectionId: opts.sndConnectionId,
-    timestampDiff: opts.rtt_var,
-    wndSize: opts.wndSize ?? DEFAULT_WINDOW_SIZE,
-    seqNr: opts.seqNr,
-    ackNr: opts.ackNr,
-    timestamp: opts.timestamp,
+    ...opts,
   })
   const packet: Packet = new Packet({ header: h, payload: opts.payload })
   return packet
@@ -124,28 +117,14 @@ export function createDataPacket(opts: createDataOpts): Packet {
 export function createResetPacket(opts: createResetOpts): Packet {
   const h = new PacketHeader({
     pType: PacketType.ST_RESET,
-    version: protocolVersion,
-    extension: 0,
-    connectionId: opts.sndConnectionId,
-    timestamp: opts.timestamp,
-    timestampDiff: 0,
-    wndSize: 0,
-    seqNr: opts.seqNr,
-    ackNr: opts.ackNr,
+    ...opts,
   })
   return new Packet({ header: h, payload: new Uint8Array() })
 }
 export function createFinPacket(opts: createFinOpts): Packet {
   const h = new PacketHeader({
     pType: PacketType.ST_FIN,
-    version: protocolVersion,
-    extension: 0,
-    connectionId: opts.sndConnectionId,
-    timestamp: opts.timestamp,
-    timestampDiff: 0,
-    wndSize: opts.wndSize,
-    seqNr: opts.seqNr,
-    ackNr: opts.ackNr,
+    ...opts,
   })
   return new Packet({ header: h, payload: new Uint8Array() })
 }

--- a/packages/portalnetwork/test/subprotocols/history/headerProof.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/history/headerProof.spec.ts
@@ -4,7 +4,7 @@ import {
   blockNumberToGindex,
   EpochAccumulator,
   HeaderAccumulatorType,
-  HeaderRecord,
+  HeaderRecordType,
 } from '../../../src/index.js'
 import {
   ByteVectorType,
@@ -89,7 +89,7 @@ tape('Header Record Proof tests', (t) => {
     }) as SingleProof
     st.equal(
       toHexString(proof.leaf),
-      toHexString(HeaderRecord.hashTreeRoot(headerRecord)),
+      toHexString(HeaderRecordType.hashTreeRoot(headerRecord)),
       'Successfully created a Proof for Header Record'
     )
     st.equal(proof.witnesses.length, 14, 'proof is correct size')
@@ -116,7 +116,7 @@ tape('Header Record Proof tests', (t) => {
         st.pass('SSZ Tree has a leaf at the expected index')
         st.equal(
           toHexString(leaf.hashTreeRoot()),
-          toHexString(HeaderRecord.hashTreeRoot(headerRecord)),
+          toHexString(HeaderRecordType.hashTreeRoot(headerRecord)),
           'Leaf contains correct Header Record'
         )
       } catch {

--- a/packages/portalnetwork/test/wire/packets.ts
+++ b/packages/portalnetwork/test/wire/packets.ts
@@ -1,5 +1,6 @@
 import {
   BUFFER_SIZE,
+  Bytes32TimeStamp,
   encodeWithVariantPrefix,
   Packet,
   PacketType,
@@ -66,51 +67,72 @@ export function Packets(
   if (type === 'FINDCONTENT_READ') {
     const dataPackets = dataChunks.map((chunk, i) => {
       const p = Packet.create(PacketType.ST_DATA, {
-        sndConnectionId: rcvId,
+        connectionId: rcvId,
         seqNr: DEFAULT_RAND_SEQNR + 1 + i,
         ackNr: 2 + i,
         payload: chunk,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
       return p
     })
     const dataAcks = dataPackets.map((p, i) => {
       return Packet.create(PacketType.ST_STATE, {
-        sndConnectionId: sndId,
+        connectionId: sndId,
         seqNr: 3 + i,
         ackNr: p.header.seqNr,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
 
     const testPackets = {
       send: {
         syn: Packet.create(PacketType.ST_SYN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 1,
           ackNr: DEFAULT_RAND_ACKNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         synackack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 2,
           ackNr: DEFAULT_RAND_SEQNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         dataAcks: dataAcks,
         finack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 2 + dataAcks.length,
           ackNr: DEFAULT_RAND_SEQNR + 1 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
       rec: {
         synack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: DEFAULT_RAND_SEQNR,
           ackNr: 1,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         data: dataPackets,
         fin: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: DEFAULT_RAND_SEQNR + 1 + dataPackets.length,
           ackNr: 2 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
     }
@@ -118,50 +140,71 @@ export function Packets(
   } else if (type === 'FOUNDCONTENT_WRITE') {
     const dataPackets = dataChunks.map((chunk, i) => {
       const p = Packet.create(PacketType.ST_DATA, {
-        sndConnectionId: sndId,
+        connectionId: sndId,
         seqNr: DEFAULT_RAND_SEQNR + 1 + i,
         ackNr: 2 + i,
         payload: chunk,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
       return p
     })
     const dataAcks = dataPackets.map((p, i) => {
       return Packet.create(PacketType.ST_STATE, {
-        sndConnectionId: rcvId,
+        connectionId: rcvId,
         seqNr: 3 + i,
         ackNr: p.header.seqNr,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
     const testPackets = {
       send: {
         synack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: DEFAULT_RAND_SEQNR,
           ackNr: 1,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         data: dataPackets,
         fin: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: DEFAULT_RAND_SEQNR + 1 + dataPackets.length,
           ackNr: 2 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
       rec: {
         syn: Packet.create(PacketType.ST_SYN, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: 1,
           ackNr: DEFAULT_RAND_ACKNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         synackack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: 2,
           ackNr: DEFAULT_RAND_SEQNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         acks: dataAcks,
         finack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: 3 + dataAcks.length,
           ackNr: DEFAULT_RAND_SEQNR + 1 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
     }
@@ -169,43 +212,61 @@ export function Packets(
   } else if (type === 'OFFER_WRITE') {
     const dataPackets = offerChunks.map((chunk, i) => {
       return Packet.create(PacketType.ST_DATA, {
-        sndConnectionId: sndId,
+        connectionId: sndId,
         seqNr: 2 + i,
         ackNr: DEFAULT_RAND_ACKNR + 1 + i,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
     const dataAcks = dataPackets.map((p, i) => {
       return Packet.create(PacketType.ST_STATE, {
-        sndConnectionId: rcvId,
+        connectionId: rcvId,
         seqNr: DEFAULT_RAND_ACKNR + 2 + i,
         ackNr: 2 + i,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
     const testPackets = {
       send: {
         syn: Packet.create(PacketType.ST_SYN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 1,
           ackNr: DEFAULT_RAND_ACKNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         data: dataPackets,
         fin: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 2 + dataPackets.length,
           ackNr: DEFAULT_RAND_ACKNR + 1 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
       rec: {
         synack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: DEFAULT_RAND_SEQNR,
           ackNr: 1,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         acks: dataAcks,
         finack: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: DEFAULT_RAND_ACKNR + 2 + dataAcks.length,
           ackNr: 2 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
     }
@@ -213,44 +274,62 @@ export function Packets(
   } else if (type === 'ACCEPT_READ') {
     const dataPackets = offerChunks.map((chunk, i) => {
       return Packet.create(PacketType.ST_DATA, {
-        sndConnectionId: rcvId,
+        connectionId: rcvId,
         seqNr: 2 + i,
         ackNr: DEFAULT_RAND_ACKNR + 1 + i,
         payload: chunk,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
     const dataAcks = dataPackets.map((p, i) => {
       return Packet.create(PacketType.ST_STATE, {
-        sndConnectionId: sndId,
+        connectionId: sndId,
         seqNr: DEFAULT_RAND_ACKNR + 2 + i,
         ackNr: 2 + i,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
     const testPackets = {
       send: {
         synack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: DEFAULT_RAND_SEQNR,
           ackNr: 1,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         acks: dataAcks,
         finack: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: DEFAULT_RAND_ACKNR + 2 + dataAcks.length,
           ackNr: 2 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
       rec: {
         syn: Packet.create(PacketType.ST_SYN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 1,
           ackNr: DEFAULT_RAND_ACKNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         data: dataPackets,
         fin: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 2 + dataPackets.length,
           ackNr: DEFAULT_RAND_ACKNR + 1 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
     }
@@ -258,51 +337,72 @@ export function Packets(
   } else if (type === 'FINDCONTENT_READ-Block') {
     const dataPackets = blockChunks.map((chunk, i) => {
       const p = Packet.create(PacketType.ST_DATA, {
-        sndConnectionId: rcvId,
+        connectionId: rcvId,
         seqNr: DEFAULT_RAND_SEQNR + 1 + i,
         ackNr: 2 + i,
         payload: chunk,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
       return p
     })
     const dataAcks = dataPackets.map((p, i) => {
       return Packet.create(PacketType.ST_STATE, {
-        sndConnectionId: sndId,
+        connectionId: sndId,
         seqNr: 3 + i,
         ackNr: p.header.seqNr,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: 0,
+        wndSize: 1048576,
       })
     })
 
     const testPackets = {
       send: {
         syn: Packet.create(PacketType.ST_SYN, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 1,
           ackNr: DEFAULT_RAND_ACKNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         synackack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 2,
           ackNr: DEFAULT_RAND_SEQNR,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         dataAcks: dataAcks,
         finack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: sndId,
+          connectionId: sndId,
           seqNr: 2 + dataAcks.length,
           ackNr: DEFAULT_RAND_SEQNR + 1 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
       rec: {
         synack: Packet.create(PacketType.ST_STATE, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: DEFAULT_RAND_SEQNR,
           ackNr: 1,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
         data: dataPackets,
         fin: Packet.create(PacketType.ST_FIN, {
-          sndConnectionId: rcvId,
+          connectionId: rcvId,
           seqNr: DEFAULT_RAND_SEQNR + 1 + dataPackets.length,
           ackNr: 2 + dataPackets.length,
+          timestampMicroseconds: Bytes32TimeStamp(),
+          timestampDifferenceMicroseconds: 0,
+          wndSize: 1048576,
         }),
       },
     }

--- a/packages/portalnetwork/test/wire/utp/basic.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/basic.spec.ts
@@ -56,7 +56,7 @@ tape('Basic uTP Tests', async (t) => {
       seqNr: 1,
       connectionId: socket.sndConnectionId,
       ackNr: socket.ackNr,
-      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampMicroseconds: syn.header.timestampMicroseconds,
       timestampDifferenceMicroseconds: socket.rtt_var,
       wndSize: socket.cur_window,
     })

--- a/packages/portalnetwork/test/wire/utp/basic.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/basic.spec.ts
@@ -2,7 +2,14 @@ import { createSecp256k1PeerId } from '@libp2p/peer-id-factory'
 import { randomBytes } from 'crypto'
 import debug from 'debug'
 import tape from 'tape'
-import { PortalNetworkUTP, RequestCode, BasicUtp, Packet, PacketType } from '../../../src/index.js'
+import {
+  PortalNetworkUTP,
+  RequestCode,
+  BasicUtp,
+  Packet,
+  PacketType,
+  Bytes32TimeStamp,
+} from '../../../src/index.js'
 
 const sampleSize = 50000
 const peerId = await createSecp256k1PeerId()
@@ -34,11 +41,12 @@ tape('Basic uTP Tests', async (t) => {
   const packets = Object.values(chunks).map((chunk, idx) => {
     const packet = Packet.create(PacketType.ST_DATA, {
       seqNr: 2 + idx,
-      sndConnectionId: _socket.sndConnectionId,
+      connectionId: _socket.sndConnectionId,
       ackNr: _socket.ackNr + idx,
-      wndSize: _socket.max_window,
       payload: chunk,
-      rtt_var: _socket.rtt_var,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: socket.rtt_var,
+      wndSize: socket.cur_window,
     })
     return packet
   })
@@ -46,20 +54,23 @@ tape('Basic uTP Tests', async (t) => {
     const syn = await basic.sendSynPacket(socket)
     const synPacket = Packet.create(PacketType.ST_SYN, {
       seqNr: 1,
-      sndConnectionId: socket.sndConnectionId,
+      connectionId: socket.sndConnectionId,
       ackNr: socket.ackNr,
-      timestamp: syn.header.timestamp,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: socket.rtt_var,
+      wndSize: socket.cur_window,
     })
     st.deepEqual(syn, synPacket, 'Basic Sends Syn Packet successfully')
     const _synAck = Packet.create(PacketType.ST_STATE, {
       seqNr: _socket.seqNr,
-      sndConnectionId: _socket.sndConnectionId,
+      connectionId: _socket.sndConnectionId,
       ackNr: _socket.ackNr,
-      rtt_var: _socket.rtt_var,
-      wndSide: _socket.cur_window,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: socket.rtt_var,
+      wndSize: socket.cur_window,
     })
     const synack = await basic.handleSynPacket(_socket, synPacket)
-    ;(_synAck.header.timestamp = synack.header.timestamp),
+    ;(_synAck.header.timestampMicroseconds = synack.header.timestampMicroseconds),
       st.equal(
         (await basic.sendSynAckPacket(_socket)).header.pType,
         PacketType.ST_STATE,
@@ -96,10 +107,11 @@ tape('Basic uTP Tests', async (t) => {
 
     const _finAck = Packet.create(PacketType.ST_STATE, {
       seqNr: 98,
-      sndConnectionId: _socket.sndConnectionId,
+      connectionId: _socket.sndConnectionId,
       ackNr: 100,
-      rtt_var: _socket.rtt_var,
-      wndSize: _socket.cur_window,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: socket.rtt_var,
+      wndSize: socket.cur_window,
     })
     socket.seqNr = 100
     socket.ackNr = 98
@@ -107,11 +119,11 @@ tape('Basic uTP Tests', async (t) => {
     const finReturn = await basic.sendFinPacket(socket)
     const finPacket = Packet.create(PacketType.ST_FIN, {
       seqNr: 100,
-      sndConnectionId: socket.sndConnectionId,
+      connectionId: socket.sndConnectionId,
       ackNr: 98,
-      wndSize: socket.max_window,
-      rtt_var: 0,
-      timestamp: finReturn.header.timestamp,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: socket.rtt_var,
+      wndSize: socket.cur_window,
     })
     st.deepEqual(finReturn.header, finPacket.header, `Basic successfully sent Fin Packet`)
     const _compiled = await basic.handleFinPacket(_socket, finPacket)

--- a/packages/portalnetwork/test/wire/utp/packet.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/packet.spec.ts
@@ -8,12 +8,6 @@ import {
 } from '../../../src/wire/utp/index.js'
 import { createDataOpts, createPacketOpts } from '../../../src/wire/utp/Packets/create.js'
 
-const DEFAULT_TIMESTAMP = 3384187322
-const DEFAULT_RAND_ID = 1234
-const DEFAULT_RAND_SEQNR = 5555
-const DEFAULT_RAND_ACKNR = 4444
-const DEFAULT_RTT_VAR = 20
-
 export const dataPacketTestPayload = fromHexString(
   '0x010004d20e710cbf00000064000001f4007b15b3c190c9463327a10f8c5a48a02f956738979f317668d58cd0bd57c29aa4b60717f476a7ec41d650d04f62d38504ad29f27392b2b8b0f075a391234132e2bd4932c151b6cad2c5e3300e36149d1ba7d6511b9b6aa8a6e37ba1f8e9474fa5f772c4d43d62fd2a277dc3bd70a55337c96a988aa3ea2dcd9bd834ced9dc20814d454e6349eb5f82a5f481a06b27d77f2b02a3795f86fc264b17cc41b7d3ad20a401324909d2e896ddb3e79fe7ed87904564968196ae7becc332e6456cbaa1892e06cacf667f2d94787361de936157e4dd648895e990cec3e57a76c44fe4d41ad247f1dfcce7d242fa7d3575ce40b886e49096c0ed7738966500e23048297d2a9a7dbd17947824a4f5d73ff3a1dd20e7f7f4ff5a3787934ab4e8d8ded5a84113c9160be4d6b7908b40ccd9facf1631950db591e35b50fe285cfe5df141b6c7f5e65a0e434c3dd0d1a070c6f29ef7236770f218b70ceacc79cd0cb2826e0df8262eeb03c4a566221e776ea080ac7972ab71fdd8a3247c00d8fd198fe42673a974cdebb66d5ba77d99347866027b1770560619e3ebb9ad36f62e105a2cee87f276171a2b248df21d66b23dd19b745eecd59626eb98b9b357be872eb480711623fa702483cc2791a60280c5fc9f8ec6a6d0e75935d87512daa68fd9ab4340fddf027365c938336769339a8f8449d70c2cf7c55444f5e0c355'
 )
@@ -21,6 +15,7 @@ export const dataPacketTestPayload = fromHexString(
 export type testParams = {
   type: PacketType
   data: createPacketOpts
+  expectedResult: string
   selective?: boolean
 }
 
@@ -28,62 +23,89 @@ export const packetTestData: Record<string, testParams> = {
   syn: {
     type: PacketType.ST_SYN,
     data: {
-      sndConnectionId: DEFAULT_RAND_ID,
-      seqNr: 1,
-      ackNr: DEFAULT_RAND_ACKNR,
-      timestamp: DEFAULT_TIMESTAMP,
+      version: 1,
+      extension: 0,
+      connectionId: 10049,
+      timestampMicroseconds: 3384187322,
+      timestampDifferenceMicroseconds: 0,
+      wndSize: 1048576,
+      seqNr: 11884,
+      ackNr: 0,
     },
+    expectedResult: '0x41002741c9b699ba00000000001000002e6c0000',
   },
   ack: {
     type: PacketType.ST_STATE,
     data: {
-      sndConnectionId: DEFAULT_RAND_SEQNR,
-      seqNr: DEFAULT_RAND_SEQNR,
-      ackNr: DEFAULT_RAND_ACKNR,
-      rtt_var: DEFAULT_RTT_VAR,
-      timestamp: DEFAULT_TIMESTAMP,
+      version: 1,
+      extension: 0,
+      connectionId: 10049,
+      timestampMicroseconds: 6195294,
+      timestampDifferenceMicroseconds: 916973699,
+      wndSize: 1048576,
+      seqNr: 16807,
+      ackNr: 11885,
     },
+    expectedResult: '0x21002741005e885e36a7e8830010000041a72e6d',
   },
   selectiveAck: {
     type: PacketType.ST_STATE,
     selective: true,
     data: {
-      sndConnectionId: DEFAULT_RAND_SEQNR,
-      seqNr: DEFAULT_RAND_SEQNR,
-      ackNr: DEFAULT_RAND_ACKNR,
-      rtt_var: DEFAULT_RTT_VAR,
-      ackNrs: [5550, 5551, 5552, 5553, 5554],
-      timestamp: DEFAULT_TIMESTAMP,
+      version: 1,
+      extension: 1,
+      connectionId: 10049,
+      timestampMicroseconds: 6195294,
+      timestampDifferenceMicroseconds: 916973699,
+      wndSize: 1048576,
+      seqNr: 16807,
+      ackNr: 11885,
+      ackNrs: [1, 0, 0, 128],
     },
+    expectedResult: '0x21012741005e885e36a7e8830010000041a72e6d000401000080',
   },
   data: {
     type: PacketType.ST_DATA,
     data: {
-      sndConnectionId: DEFAULT_RAND_SEQNR,
-      seqNr: DEFAULT_RAND_SEQNR,
-      ackNr: DEFAULT_RAND_ACKNR,
-      rtt_var: DEFAULT_RTT_VAR,
-      timestamp: DEFAULT_TIMESTAMP,
-      payload: dataPacketTestPayload,
+      version: 1,
+      extension: 0,
+      connectionId: 26237,
+      timestampMicroseconds: 252492495,
+      timestampDifferenceMicroseconds: 242289855,
+      payload: Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      wndSize: 1048576,
+      seqNr: 8334,
+      ackNr: 16806,
     },
+    expectedResult: '0x0100667d0f0cbacf0e710cbf00100000208e41a600010203040506070809',
   },
   fin: {
     type: PacketType.ST_FIN,
     data: {
-      sndConnectionId: DEFAULT_RAND_ID,
-      seqNr: DEFAULT_RAND_SEQNR,
-      ackNr: DEFAULT_RAND_ACKNR,
-      timestamp: DEFAULT_TIMESTAMP,
+      version: 1,
+      extension: 0,
+      connectionId: 19003,
+      timestampMicroseconds: 515227279,
+      timestampDifferenceMicroseconds: 511481041,
+      wndSize: 1048576,
+      seqNr: 41050,
+      ackNr: 16806,
     },
+    expectedResult: '0x11004a3b1eb5be8f1e7c94d100100000a05a41a6',
   },
   reset: {
     type: PacketType.ST_RESET,
     data: {
-      sndConnectionId: DEFAULT_RAND_ID,
-      seqNr: DEFAULT_RAND_SEQNR,
-      ackNr: DEFAULT_RAND_ACKNR,
-      timestamp: DEFAULT_TIMESTAMP,
+      version: 1,
+      extension: 0,
+      connectionId: 62285,
+      timestampMicroseconds: 751226811,
+      timestampDifferenceMicroseconds: 0,
+      wndSize: 0,
+      seqNr: 55413,
+      ackNr: 16807,
     },
+    expectedResult: '0x3100f34d2cc6cfbb0000000000000000d87541a7',
   },
 }
 
@@ -96,12 +118,12 @@ export function encodingTest(
   t: tape.Test,
   packetType: PacketType,
   testData: createPacketOpts,
+  expectedResult: string,
   selective?: boolean
 ) {
   t.test(`${PacketType[packetType]} packet encoding test.`, (st) => {
-    const testPacket: Packet = selective
-      ? Packet.create(packetType, testData, selective)
-      : Packet.create(packetType, testData)
+    const testPacket: Packet = Packet.create(packetType, testData, selective)
+
     const encodedPacket = testPacket.encode()
     const testHeader = testPacket.header
     const decodedPacket = Packet.bufferToPacket(encodedPacket)
@@ -125,6 +147,8 @@ export function encodingTest(
         `Successfully encoded and decoded DATA Packet payload.`
       )
     }
+    st.equal(toHexString(encodedPacket), expectedResult, 'Packet encoding test passed')
+
     st.end()
   })
 }
@@ -132,12 +156,19 @@ export function encodingTest(
 tape('uTP packet tests', (t) => {
   t.throws(() => {
     Packet.create(9, {
-      sndConnectionId: 1,
+      connectionId: 1,
       seqNr: 1,
       ackNr: 1,
+      wndSize: 14508,
     })
   }, 'Packet.create should throw on invalid Packet Type')
   Object.values(packetTestData).map((packetData) => {
-    encodingTest(t, packetData.type, packetData.data, packetData.selective)
+    encodingTest(
+      t,
+      packetData.type,
+      packetData.data,
+      packetData.expectedResult,
+      packetData.selective
+    )
   })
 })

--- a/packages/portalnetwork/test/wire/utp/socket.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/socket.spec.ts
@@ -9,6 +9,7 @@ import {
   UtpSocket,
   PortalNetworkUTP,
   RequestCode,
+  Bytes32TimeStamp,
 } from '../../../src/index.js'
 
 const sampleSize = 50000
@@ -67,10 +68,11 @@ tape('FIND/FOUND Socket Tests', (t) => {
   )
   const synPacket = Packet.create(PacketType.ST_SYN, {
     seqNr: 1,
-    sndConnectionId: findSocket.sndConnectionId,
+    connectionId: findSocket.sndConnectionId,
     ackNr: DEFAULT_RAND_ACKNR,
-    wndSize: findSocket.max_window,
-    rtt_var: findSocket.rtt_var,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: findSocket.rtt_var,
+    wndSize: findSocket.cur_window,
   })
 
   t.test('Packet Sending/Handling', async (st) => {
@@ -84,11 +86,11 @@ tape('FIND/FOUND Socket Tests', (t) => {
     const synAck = await foundSocket.handleSynPacket()
     const _synAck = Packet.create(PacketType.ST_STATE, {
       seqNr: DEFAULT_RAND_SEQNR,
-      sndConnectionId: foundSocket.sndConnectionId,
+      connectionId: foundSocket.sndConnectionId,
       ackNr: synPacket.header.seqNr,
-      rtt_var: foundSocket.rtt_var,
-      wndSide: foundSocket.cur_window,
-      timestamp: synAck.header.timestamp,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: foundSocket.rtt_var,
+      wndSize: foundSocket.cur_window,
     })
     st.deepEqual(synAck, _synAck, `Socket correctly hanldes SYN packet with STATE (Syn-Ack) packet`)
     st.equal(
@@ -109,11 +111,12 @@ tape('FIND/FOUND Socket Tests', (t) => {
     const packets = Object.values(chunks).map((chunk, idx) => {
       const packet = Packet.create(PacketType.ST_DATA, {
         seqNr: 2 + idx,
-        sndConnectionId: foundSocket.sndConnectionId,
+        connectionId: foundSocket.sndConnectionId,
         ackNr: foundSocket.ackNr + idx,
-        wndSize: foundSocket.max_window,
         payload: chunk,
-        rtt_var: foundSocket.rtt_var,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: foundSocket.rtt_var,
+        wndSize: foundSocket.cur_window,
       })
       return packet
     })
@@ -150,16 +153,18 @@ tape('FIND/FOUND Socket Tests', (t) => {
 
     const finPacket = Packet.create(PacketType.ST_FIN, {
       seqNr: 100,
-      sndConnectionId: foundSocket.sndConnectionId,
+      connectionId: foundSocket.sndConnectionId,
       ackNr: foundSocket.ackNr + 98,
-      wndSize: foundSocket.max_window,
-      rtt_var: 0,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: foundSocket.rtt_var,
+      wndSize: foundSocket.cur_window,
     })
     const finAck = Packet.create(PacketType.ST_STATE, {
       seqNr: finPacket.header.ackNr + 1,
-      sndConnectionId: findSocket.sndConnectionId,
+      connectionId: findSocket.sndConnectionId,
       ackNr: 100,
-      rtt_var: findSocket.rtt_var,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: findSocket.rtt_var,
       wndSize: findSocket.cur_window,
     })
     const encoded = await foundSocket.sendFinPacket(finPacket)
@@ -183,10 +188,11 @@ tape('FIND/FOUND Socket Tests', (t) => {
     t.test('socket.handleResetPacket()', async (st) => {
       const reset = Packet.create(PacketType.ST_RESET, {
         seqNr: 1,
-        sndConnectionId: findSocket.sndConnectionId,
+        connectionId: findSocket.sndConnectionId,
         ackNr: DEFAULT_RAND_ACKNR,
-        wndSize: findSocket.max_window,
-        rtt_var: findSocket.rtt_var,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: findSocket.rtt_var,
+        wndSize: findSocket.cur_window,
       })
       await findSocket.sendResetPacket(reset)
       st.equal(
@@ -218,10 +224,11 @@ tape('OFFER/ACCEPT Socket Tests', (t) => {
   )
   const synPacket = Packet.create(PacketType.ST_SYN, {
     seqNr: 1,
-    sndConnectionId: offerSocket.sndConnectionId,
+    connectionId: offerSocket.sndConnectionId,
     ackNr: DEFAULT_RAND_ACKNR,
-    wndSize: offerSocket.max_window,
-    rtt_var: offerSocket.rtt_var,
+    timestampMicroseconds: Bytes32TimeStamp(),
+    timestampDifferenceMicroseconds: offerSocket.rtt_var,
+    wndSize: offerSocket.cur_window,
   })
 
   t.test('Packet Sending/Handling', async (st) => {
@@ -230,11 +237,12 @@ tape('OFFER/ACCEPT Socket Tests', (t) => {
     const packets = Object.values(chunks).map((chunk, idx) => {
       const packet = Packet.create(PacketType.ST_DATA, {
         seqNr: 2 + idx,
-        sndConnectionId: offerSocket.sndConnectionId,
+        connectionId: offerSocket.sndConnectionId,
         ackNr: offerSocket.ackNr + idx,
-        wndSize: offerSocket.max_window,
         payload: chunk,
-        rtt_var: offerSocket.rtt_var,
+        timestampMicroseconds: Bytes32TimeStamp(),
+        timestampDifferenceMicroseconds: offerSocket.rtt_var,
+        wndSize: offerSocket.cur_window,
       })
       return packet
     })
@@ -256,11 +264,11 @@ tape('OFFER/ACCEPT Socket Tests', (t) => {
     )
     const _synAck = Packet.create(PacketType.ST_STATE, {
       seqNr: acceptSocket.seqNr,
-      sndConnectionId: acceptSocket.sndConnectionId,
+      connectionId: acceptSocket.sndConnectionId,
       ackNr: 1,
-      rtt_var: acceptSocket.rtt_var,
-      wndSide: acceptSocket.cur_window,
-      timestamp: synAck.header.timestamp,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: acceptSocket.rtt_var,
+      wndSize: acceptSocket.cur_window,
     })
     st.deepEqual(synAck, _synAck, `Socket correctly hanldes SYN packet with STATE (Syn-Ack) packet`)
     await offerSocket.handleStatePacket(synAck)
@@ -298,16 +306,18 @@ tape('OFFER/ACCEPT Socket Tests', (t) => {
 
     const finPacket = Packet.create(PacketType.ST_FIN, {
       seqNr: 100,
-      sndConnectionId: offerSocket.sndConnectionId,
+      connectionId: offerSocket.sndConnectionId,
       ackNr: offerSocket.ackNr + 98,
-      wndSize: offerSocket.max_window,
-      rtt_var: 0,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: offerSocket.rtt_var,
+      wndSize: offerSocket.cur_window,
     })
     const finAck = Packet.create(PacketType.ST_STATE, {
       seqNr: finPacket.header.ackNr + 1,
-      sndConnectionId: offerSocket.sndConnectionId,
+      connectionId: offerSocket.sndConnectionId,
       ackNr: 100,
-      rtt_var: offerSocket.rtt_var,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: offerSocket.rtt_var,
       wndSize: offerSocket.cur_window,
     })
     const encoded = await offerSocket.sendFinPacket(finPacket)
@@ -332,10 +342,11 @@ tape('OFFER/ACCEPT Socket Tests', (t) => {
   t.test('send reset packet', async (st) => {
     const reset = Packet.create(PacketType.ST_RESET, {
       seqNr: 1,
-      sndConnectionId: offerSocket.sndConnectionId,
+      connectionId: offerSocket.sndConnectionId,
       ackNr: DEFAULT_RAND_ACKNR,
-      wndSize: offerSocket.max_window,
-      rtt_var: offerSocket.rtt_var,
+      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampDifferenceMicroseconds: offerSocket.rtt_var,
+      wndSize: offerSocket.cur_window,
     })
     await offerSocket.sendResetPacket(reset)
     st.equal(

--- a/packages/portalnetwork/test/wire/utp/socket.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/socket.spec.ts
@@ -266,7 +266,7 @@ tape('OFFER/ACCEPT Socket Tests', (t) => {
       seqNr: acceptSocket.seqNr,
       connectionId: acceptSocket.sndConnectionId,
       ackNr: 1,
-      timestampMicroseconds: Bytes32TimeStamp(),
+      timestampMicroseconds: synAck.header.timestampMicroseconds,
       timestampDifferenceMicroseconds: acceptSocket.rtt_var,
       wndSize: acceptSocket.cur_window,
     })

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -166,9 +166,6 @@ tape('uTP Reader/Writer tests', (t) => {
     })
 
     const offerContentIds = offerContentHashes.map((hash) => {
-      const contentKey: HistoryNetworkContentKey = {
-        blockHash: fromHexString(hash),
-      }
       return HistoryNetworkContentKeyType.serialize(
         Buffer.concat([
           Uint8Array.from([HistoryNetworkContentTypes.BlockBody]),


### PR DESCRIPTION
#### Misc updates to History Network

* `subprotocols/history/types.ts` updated for readability and naming consistency.
  * **Naming Structure** to distinguish TS type-names from SSZ type-names:
     * type Example = Uint8Array
     * const ExampleType = new SSZ.ByteVectorType(32)
* Remove duplicated code from `@ethereumjs/vm` and import from pkg instead.
  * Some `TX` and `Receipt` typing had been duplicated before `@ethereumjs/vm` was a dependency.

#### Misc updates to uTP
* uTP packet tests updated to use common test vectors from `portal-network-specs`
* uTP packet creation method parameters expanded for testibility
* uTP packet header namings changed to align with spec
  * sndConnectionId => connectionId
  * timestamp => timestampMicroseconds
  * rtt_var => timestampDifferenceMicroseconds
