### PR TITLE
Fix handleFindContent

### DIFF
--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -449,7 +449,7 @@ export abstract class BaseProtocol {
 
     const lookupKey = serializedContentKeyToContentId(decodedContentMessage.contentKey)
     const value = await this.findContentLocally(decodedContentMessage.contentKey)
-    if (!value) {
+    if (!value || value.length === 0) {
       // Discv5 calls for maximum of 16 nodes per NODES message
       const ENRs = this.routingTable.nearest(lookupKey, 16)
       const encodedEnrs = ENRs.map((enr) => {


### PR DESCRIPTION
Network content lookups were broken.
Peers would respond with FOUNDCONTENT for content keys not in their DB.

The reason was that during `protocol.handleFindContent`, when we check our local DB for content, we would only check if the return value was `undefined`.  Sometimes this return value is an empty Uint8Array, so we would return this empty array is if it was the requested content.

Fixed by adding a check for `value.length === 0` after `protocol.findContentLocally`