### PR TITLE
Content-Lookup Fix

### DIFF
--- a/packages/browser-client/src/App.tsx
+++ b/packages/browser-client/src/App.tsx
@@ -43,7 +43,7 @@ export const App = () => {
     init()
   }, [])
   React.useEffect(() => {
-    state.provider?.portal.enableLog('*Portal:*')
+    state.provider?.portal.enableLog('*Portal*')
   }, [state.provider])
 
   return (

--- a/packages/browser-client/src/Components/PortalButtons.tsx
+++ b/packages/browser-client/src/Components/PortalButtons.tsx
@@ -65,7 +65,7 @@ export function PortalButton(props: IPortalButton) {
   )
   useEffect(() => {
     setInput(blockHash)
-  }, [])
+  }, [blockHash])
 
   const addToOffer = async (type: HistoryNetworkContentTypes) => {
     const contentKey = getHistoryNetworkContentKey(type, Buffer.from(fromHexString(blockHash)))
@@ -121,7 +121,7 @@ export function PortalButton(props: IPortalButton) {
       }
     },
     4: async () => {
-      peerDispatch({ type: PeerStateChange.SETBLOCKHASH, payload: blockHash })
+      peerDispatch({ type: PeerStateChange.SETEPOCH, payload: parseInt(input) })
       const epoch = await peerActions.sendFindContent('epoch', state.selectedPeer)
       if (epoch) {
         toast({
@@ -134,7 +134,7 @@ export function PortalButton(props: IPortalButton) {
       }
     },
   }
-  const invalid: Record<number, boolean> = {
+  const valid: Record<number, boolean> = {
     0: input.startsWith('0x') && input.length === 66,
     1: input.startsWith('0x') && input.length === 66,
     2: parseInt(input) >= 0 && parseInt(input) < 257,
@@ -165,7 +165,7 @@ export function PortalButton(props: IPortalButton) {
   }
 
   async function handleClick() {
-    if (!invalid[props.inputType]) {
+    if (!valid[props.inputType]) {
       toast({
         title: 'Invalid input',
         status: 'error',
@@ -188,7 +188,7 @@ export function PortalButton(props: IPortalButton) {
           </Box>
         ) : (
           <Box width={'75%'}>
-            <FormControl isInvalid={invalid[props.inputType]}>
+            <FormControl isInvalid={!valid[props.inputType]}>
               <Input
                 width={'100%'}
                 size={'sm'}

--- a/packages/browser-client/src/Components/getBlockByHash.tsx
+++ b/packages/browser-client/src/Components/getBlockByHash.tsx
@@ -14,7 +14,9 @@ export default function GetBlockByHash() {
         ? await state.provider!.getBlockWithTransactions(blockHash)
         : await state.provider!.getBlock(blockHash)
       dispatch({ type: StateChange.SETBLOCK, payload: block })
+      dispatch({ type: StateChange.TOGGLELOADING })
     } catch {
+      dispatch({ type: StateChange.TOGGLELOADING })
       return 'Block not found'
     }
   }
@@ -22,16 +24,9 @@ export default function GetBlockByHash() {
   async function handleClick() {
     dispatch({ type: StateChange.TOGGLELOADING })
     await eth_getBlockByHash(blockHash, true)
-    dispatch({ type: StateChange.TOGGLELOADING })
   }
 
-  async function getInitialBlock() {
-    await eth_getBlockByHash(blockHash, true)
-  }
-
-  useEffect(() => {
-    getInitialBlock()
-  }, [])
+  useEffect(() => {}, [])
 
   return (
     <HStack marginY={1}>

--- a/packages/browser-client/src/peerActions.ts
+++ b/packages/browser-client/src/peerActions.ts
@@ -85,7 +85,7 @@ export class PeerActions {
       const epochContentKey = fromHexString(
         getHistoryNetworkContentKey(
           HistoryNetworkContentTypes.EpochAccumulator,
-          Buffer.from(this.historyProtocol.accumulator.historicalEpochs()[this.state.epoch])
+          this.historyProtocol.accumulator.historicalEpochs()[this.state.epoch]
         )
       )
       this.historyProtocol!.sendFindContent(ENR.decodeTxt(enr).nodeId, epochContentKey)

--- a/packages/browser-client/src/peerReducer.ts
+++ b/packages/browser-client/src/peerReducer.ts
@@ -36,7 +36,7 @@ export const peerReducer = (state: PeerState, action: PeerStateAction) => {
   const { type, payload } = action
   switch (type) {
     case PeerStateChange.SETEPOCH:
-      return state
+      return { ...state, epoch: payload }
     case PeerStateChange.SETOFFER:
       return {
         ...state,

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -283,6 +283,8 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       this.logger(
         `Received TALKREQ message on unsupported protocol ${toHexString(message.protocol)}`
       )
+      await this.sendPortalNetworkResponse(src, message.id, new Uint8Array())
+
       return
     }
 

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -136,6 +136,9 @@ export class HistoryProtocol extends BaseProtocol {
       Buffer.from(payload),
       this.protocolId
     )
+    if (res.length === 0) {
+      return undefined
+    }
 
     try {
       if (parseInt(res.slice(0, 1).toString('hex')) === MessageCodes.CONTENT) {

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -146,7 +146,7 @@ export class HistoryProtocol extends BaseProtocol {
         const decodedKey = HistoryNetworkContentKeyType.deserialize(key)
         switch (decoded.selector) {
           case 0: {
-            const id = connectionIdType.deserialize(decoded.value as Uint8Array)
+            const id = Buffer.from(decoded.value as Uint8Array).readUint16BE()
             this.logger.extend('FOUNDCONTENT')(`received uTP Connection ID ${id}`)
             await this.client.uTP.handleNewRequest({
               contentKeys: [key],

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -406,12 +406,14 @@ export abstract class BaseProtocol {
     desiredContentAccepts: boolean[],
     desiredContentKeys: Uint8Array[]
   ) => {
+    const id = randUint16()
     this.logger.extend('ACCEPT')(
-      `Sent to ${shortId(src.nodeId)} for ${desiredContentKeys.length} pieces of content.`
+      `Sent to ${shortId(src.nodeId)} for ${
+        desiredContentKeys.length
+      } pieces of content.  connectionId: ${id}`
     )
 
     this.metrics?.acceptMessagesSent.inc()
-    const id = randUint16()
     await this.client.uTP.handleNewRequest({
       contentKeys: desiredContentKeys,
       peerId: src.nodeId,
@@ -510,7 +512,8 @@ export abstract class BaseProtocol {
         contents: [value],
       })
 
-      const id = connectionIdType.serialize(_id)
+      const id = Buffer.alloc(2)
+      id.writeUInt16BE(_id)
       this.logger.extend('FOUNDCONTENT')(`Sent message with CONNECTION ID: ${_id}.`)
       const payload = ContentMessageType.serialize({ selector: 0, value: id })
       this.client.sendPortalNetworkResponse(

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
@@ -43,7 +43,7 @@ export class SelectiveAckHeader extends PacketHeader {
     buffer[1] = 0
     buffer.writeUInt16BE(this.connectionId, 2)
     buffer.writeUInt32BE(this.timestampMicroseconds, 4)
-    buffer.writeUInt32BE(this.timestampMicroseconds, 4)
+    buffer.writeUInt32BE(this.timestampDifferenceMicroseconds, 8)
     buffer.writeUInt32BE(this.wndSize, 12)
     buffer.writeUInt16BE(this.seqNr, 16)
     buffer.writeUInt16BE(this.ackNr, 18)

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
@@ -9,8 +9,8 @@ export async function sendSynPacket(socket: UtpSocket): Promise<Packet> {
     seqNr: socket.seqNr,
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),
-    timestampDifferenceMicroseconds: socket.reply_micro,
-    wndSize: socket.cur_window,
+    timestampDifferenceMicroseconds: 0,
+    wndSize: socket.max_window,
   })
   socket.state = ConnectionState.SynSent
   await socket.sendSynPacket(packet)
@@ -24,7 +24,7 @@ export async function sendSynAckPacket(socket: UtpSocket): Promise<Packet> {
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),
     timestampDifferenceMicroseconds: socket.reply_micro,
-    wndSize: socket.cur_window,
+    wndSize: Math.min(2 ** 32 - 1, socket.max_window - socket.cur_window),
   })
   await socket.sendSynAckPacket(packet)
   return packet
@@ -37,7 +37,7 @@ export async function sendDataPacket(socket: UtpSocket, payload: Uint8Array): Pr
     payload: payload,
     timestampMicroseconds: Bytes32TimeStamp(),
     timestampDifferenceMicroseconds: socket.reply_micro,
-    wndSize: socket.cur_window,
+    wndSize: Math.min(2 ** 32 - 1, socket.max_window - socket.cur_window),
   })
   await socket.sendDataPacket(packet)
   return packet
@@ -49,7 +49,7 @@ export async function sendAckPacket(socket: UtpSocket): Promise<Packet> {
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),
     timestampDifferenceMicroseconds: socket.reply_micro,
-    wndSize: socket.cur_window,
+    wndSize: Math.min(2 ** 32 - 1, socket.max_window - socket.cur_window),
   })
   await socket.sendStatePacket(packet)
   return packet
@@ -61,7 +61,7 @@ export async function sendResetPacket(socket: UtpSocket): Promise<Packet> {
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),
     timestampDifferenceMicroseconds: socket.reply_micro,
-    wndSize: socket.cur_window,
+    wndSize: Math.min(2 ** 32 - 1, socket.max_window - socket.cur_window),
   })
   await socket.sendResetPacket(packet)
   return packet
@@ -73,7 +73,7 @@ export async function sendFinPacket(socket: UtpSocket): Promise<Packet> {
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),
     timestampDifferenceMicroseconds: socket.reply_micro,
-    wndSize: socket.cur_window,
+    wndSize: Math.min(2 ** 32 - 1, socket.max_window - socket.cur_window),
   })
   socket.finNr = packet.header.seqNr
   await socket.sendFinPacket(packet)
@@ -87,7 +87,7 @@ export async function sendSelectiveAckPacket(socket: UtpSocket, bitmask: Uint8Ar
       ackNr: socket.ackNr,
       timestampMicroseconds: Bytes32TimeStamp(),
       timestampDifferenceMicroseconds: socket.reply_micro,
-      wndSize: socket.cur_window,
+      wndSize: Math.min(2 ** 32 - 1, socket.max_window - socket.cur_window),
     },
     bitmask,
   })

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
@@ -6,7 +6,7 @@ import { PacketType } from './PacketTyping.js'
 export async function sendSynPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_SYN, {
     connectionId: socket.rcvConnectionId,
-    seqNr: 1,
+    seqNr: socket.seqNr,
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),
     timestampDifferenceMicroseconds: socket.reply_micro,

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketSenders.ts
@@ -5,7 +5,7 @@ import { PacketType } from './PacketTyping.js'
 
 export async function sendSynPacket(socket: UtpSocket): Promise<Packet> {
   const packet = Packet.create(PacketType.ST_SYN, {
-    connectionId: socket.sndConnectionId,
+    connectionId: socket.rcvConnectionId,
     seqNr: 1,
     ackNr: socket.ackNr,
     timestampMicroseconds: Bytes32TimeStamp(),

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -225,11 +225,8 @@ export class PortalNetworkUTP extends BasicUtp {
     const request = this.openContentRequest.get(requestKey)
     if (request) {
       clearTimeout(request.socket.timeoutCounter)
-      request.socket.timeoutCounter = setTimeout(() => {
-        request.socket.throttle()
-      }, request.socket.timeout)
       const packet = Packet.bufferToPacket(packetBuffer)
-      request.socket.updateDelay(packet.header.timestampMicroseconds, timeReceived)
+      request.socket.updateDelay(timeReceived, packet.header.timestampMicroseconds)
 
       switch (packet.header.pType) {
         case PacketType.ST_SYN:
@@ -308,7 +305,7 @@ export class PortalNetworkUTP extends BasicUtp {
             .filter((n) => parseInt(n) <= packet.header.ackNr)
             .map((n) => parseInt(n))
         }
-        if (sentTime != undefined) {
+        if (request.socket.type === 'write' && sentTime != undefined) {
           const rtt = packet.header.timestampMicroseconds - sentTime
           request.socket.updateRTT(rtt)
           request.socket.outBuffer.delete(packet.header.ackNr)

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -284,7 +284,7 @@ export class PortalNetworkUTP extends BasicUtp {
       case RequestCode.FOUNDCONTENT_WRITE:
         this.logger(`SYN received to initiate stream for FINDCONTENT request`)
         request.socket.ackNr = packet.header.seqNr
-        request.socket.seqNr = randUint16()
+        request.socket.seqNr = packet.header.seqNr
         await this.sendSynAckPacket(request.socket)
         writer = await this.createNewWriter(request.socket, request.socket.seqNr)
         request.socket.writer = writer

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -187,9 +187,13 @@ export class UtpSocket extends EventEmitter {
     return bitMask
   }
 
-  async handleDataPacket(packet: Packet): Promise<Packet> {
+  async handleDataPacket(packet: Packet): Promise<Packet | undefined> {
+    clearTimeout(this.timeoutCounter)
     this.state = ConnectionState.Connected
-    const expected = this.ackNr + 1 === packet.header.seqNr
+    let expected = true
+    if (this.ackNrs.length > 1) {
+      expected = this.ackNr + 1 === packet.header.seqNr
+    }
     this.seqNr = this.seqNr + 1
     if (!this.reader) {
       this.reader = new ContentReader(this, packet.header.seqNr)

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -74,16 +74,20 @@ export class UtpSocket extends EventEmitter {
     this.ackNrs = []
     this.received = []
     this.expected = []
-    this.logger = logger.extend(this.remoteAddress.slice(0, 3)).extend(type)
+    this.logger = logger.extend('Socket').extend(this.rcvConnectionId.toString())
     this.outBuffer = new Map()
   }
 
   async sendPacket(packet: Packet, type: PacketType): Promise<Buffer> {
     const msg = packet.encode()
-    type !== PacketType.ST_DATA &&
-      this.logger(
-        `${PacketType[type]} packet sent. seqNr: ${packet.header.seqNr}  ackNr: ${packet.header.ackNr}`
-      )
+    const messageData: Record<PacketType, string> = {
+      0: `seqNr: ${packet.header.seqNr}`,
+      1: `seqNr: ${packet.header.seqNr}`,
+      2: `ackNr: ${packet.header.ackNr}`,
+      3: ``,
+      4: `rcvId: ${this.rcvConnectionId}`,
+    }
+    this.logger(`${PacketType[type]}   sent - ${messageData[type]}`)
     this.utp.emit('Send', this.remoteAddress, msg, ProtocolId.HistoryNetwork, true)
     return msg
   }
@@ -103,9 +107,6 @@ export class UtpSocket extends EventEmitter {
     this.outBuffer.set(packet.header.seqNr, packet.header.timestampMicroseconds)
     this.cur_window = this.outBuffer.size * DEFAULT_PACKET_SIZE
     await this.sendPacket(packet, PacketType.ST_DATA)
-    this.logger(
-      `cur_window increasing from ${this.cur_window - DEFAULT_PACKET_SIZE} to ${this.cur_window}`
-    )
     this.seqNr++
     return packet
   }
@@ -220,43 +221,21 @@ export class UtpSocket extends EventEmitter {
   async handleFinPacket(packet: Packet): Promise<Uint8Array | undefined> {
     this.logger(`Connection State: GotFin`)
     this.state = ConnectionState.GotFin
-    this.readerContent = await this.reader!.run()
-    this.logger(`Packet payloads compiled`)
-    this.logger(this.readerContent)
+    const _content = await this.reader!.run()
+    this.logger(`Packet payloads compiled.  Sending FIN-ACK`)
     this.seqNr = this.seqNr + 1
     this.ackNr = packet.header.seqNr
     await this.utp.sendStatePacket(this)
     clearTimeout(this.timeoutCounter)
-    return this.readerContent
+    return _content
   }
 
   updateRTT(packetRTT: number): void {
     // Updates Round Trip Time (Time between sending DATA packet and receiving ACK packet)
     const delta = this.rtt - packetRTT
-    this.logger.extend('RTT')(`
-    socket.rtt: ${this.rtt}
-    packetRTT: ${packetRTT}
-    delta: ${delta}
-    `)
-    this.logger.extend('RTT')(`
-    Updating socket.rtt_var and socket.rtt:
-    socket.rtt_var: ${this.rtt_var} += abs(delta: ${delta}) - socket.rtt_var: ${
-      this.rtt_var
-    } / 4 = ${this.rtt_var + Math.abs(delta) - this.rtt_var / 4}
-    socket.rtt: ${this.rtt} += (packetRTT: ${packetRTT} - socket.rtt: ${this.rtt}) / 8 = ${
-      this.rtt + packetRTT - this.rtt / 8
-    }
-    `)
     this.rtt_var = this.rtt_var + (Math.abs(delta) - this.rtt_var) / 4
     this.rtt = Math.floor(this.rtt + (packetRTT - this.rtt) / 8)
-    this.logger.extend('RTT')(
-      `Updating Timeout:
-     socket.timeout = this.rtt: ${this.rtt} + this.rtt_var: ${this.rtt_var} * 4 = ${
-        this.rtt + this.rtt_var * 4
-      }`
-    )
     this.timeout = this.rtt + this.rtt_var * 4 > 500 ? this.rtt + this.rtt_var * 4 : 500
-    this.logger.extend('TIMEOUT')(`Timeout reset to: ${this.timeout}`)
     clearTimeout(this.timeoutCounter)
     this.timeoutCounter = setTimeout(() => {
       this.throttle()
@@ -281,16 +260,11 @@ export class UtpSocket extends EventEmitter {
   updateDelay(timestamp: number, timeReceived: number) {
     const delay = Math.abs(timeReceived - timestamp)
     this.reply_micro = delay
-    this.logger.extend('DELAY')(
-      `timeReceived: ${timeReceived} - timestamp: ${timestamp} = delay: ${delay}`
-    )
     this.ourDelay = delay - this.baseDelay.delay
     if (timeReceived - this.baseDelay.timestamp > 120000) {
       this.baseDelay = { delay: delay, timestamp: timeReceived }
-      this.logger.extend('DELAY')(`baseDelay reset to ${this.baseDelay.delay}`)
     } else if (delay < this.baseDelay.delay) {
       this.baseDelay = { delay: delay, timestamp: timeReceived }
-      this.logger.extend('DELAY')(`baseDelay set to ${this.baseDelay.delay}`)
     }
     const offTarget = this.baseDelay.delay / this.ourDelay
     const delayFactor = offTarget / this.baseDelay.delay
@@ -298,22 +272,6 @@ export class UtpSocket extends EventEmitter {
     const scaledGain = MAX_CWND_INCREASE_PACKETS_PER_RTT * delayFactor * windowFactor
     const new_max = this.max_window + scaledGain > 0 ? this.max_window + scaledGain : 0
     this.max_window = new_max
-    this.logger.extend('DELAY')(`
-    ourDelay: ${this.ourDelay}
-    offTarget: ${offTarget}
-    delayFactor: ${delayFactor}
-    windowFactor: ${windowFactor}
-    scaledGain: ${scaledGain}
-    max_window ${
-      new_max === 0
-        ? 'Set to 0'
-        : scaledGain > 0
-        ? `increasing to ${new_max}`
-        : scaledGain < 0
-        ? `decreasing to ${new_max}`
-        : `remaining at ${new_max}`
-    }
-    `)
   }
 
   compare(): boolean {
@@ -336,7 +294,6 @@ export class UtpSocket extends EventEmitter {
 
   close(): void {
     clearInterval(this.timeoutCounter)
-    this.logger.destroy()
     this.removeAllListeners()
   }
 }

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -89,16 +89,13 @@ export class UtpSocket extends EventEmitter {
   }
 
   async sendSynPacket(packet: Packet): Promise<ConnectionState> {
-    this.outBuffer.set(0, packet.header.timestampMicroseconds)
     await this.sendPacket(packet, PacketType.ST_SYN)
     this.state = ConnectionState.SynSent
     return this.state
   }
 
   async sendSynAckPacket(packet: Packet): Promise<void> {
-    this.outBuffer.set(0, packet.header.timestampMicroseconds)
     await this.sendPacket(packet, PacketType.ST_STATE)
-    this.seqNr = this.seqNr + 1
   }
 
   async sendDataPacket(packet: Packet): Promise<Packet> {
@@ -282,7 +279,7 @@ export class UtpSocket extends EventEmitter {
   }
 
   updateDelay(timestamp: number, timeReceived: number) {
-    const delay = timeReceived - timestamp
+    const delay = Math.abs(timeReceived - timestamp)
     this.reply_micro = delay
     this.logger.extend('DELAY')(
       `timeReceived: ${timeReceived} - timestamp: ${timestamp} = delay: ${delay}`

--- a/packages/portalnetwork/test/integration/rpc.spec.ts
+++ b/packages/portalnetwork/test/integration/rpc.spec.ts
@@ -140,9 +140,6 @@ tape('getBlockByHash', (t) => {
 
 tape('getBlockByNumber', (t) => {
   t.test('eth_getBlockByNumber', (st) => {
-    const _accumulator = require('./testAccumulator.json')
-    const accumulator = HeaderAccumulatorType.deserialize(fromHexString(_accumulator))
-
     const epochData = require('./testEpoch.json')
     const block1000 = require('./testBlock1000.json')
     const epochHash = epochData.hash
@@ -174,16 +171,6 @@ tape('getBlockByNumber', (t) => {
         _header
       )
       await protocol1.addContentToHistory(HistoryNetworkContentTypes.BlockBody, blockHash, body)
-      protocol1.accumulator.replaceAccumulator(
-        new HeaderAccumulator({
-          storedAccumulator: accumulator,
-        })
-      )
-      protocol2.accumulator.replaceAccumulator(
-        new HeaderAccumulator({
-          storedAccumulator: accumulator,
-        })
-      )
 
       await protocol1.sendPing(portal2.discv5.enr)
       try {


### PR DESCRIPTION
Loose-ends from recent updates.

1. connectionId
- Fixed issue with wrong-endian encoding
- Settled SYN packet connectionId issue
  - SYN packets contain the socket's own id (socket.rcvId) in the connectionId field.
  - All other packets should contain the packet's destination id (socket.sndId) in the connectionId field.
2. seqNr/ackNr 
- Altered seqNr/ackNr logic to match fluffy.
  - PR #385 introduced new complexity.  Fluffy's strict packet handling exposed differences in our methods. 
3. packet.wndSize
- Packet should communicate open window size.  Which is inverse to socket.cur_window, and relative to socket.max_window
- window attributes require upper limits or can hit INFINITY
4. OFFER encoding/decoding
- Altered OFFER/ACCEPT flow to do prefix encoding / decoding on single item OFFERs
  - PR #311 Introduced a prefix encoding scheme for OFFER content
  - Ultralight did not encode OFFER content with only one item, while other implementations did.
5. Delay/RTT
- Timekeeping needed more controls on which packets to track
6. ContentLookup
- Fixed issue with lookup queue tracking already-asked nodes
7. App
- Small browser app fixes / updates
