### PR TITLE
Revise cli IP command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,9 +77,9 @@ const reportMetrics = async (req: http.IncomingMessage, res: http.ServerResponse
 }
 
 const main = async () => {
-  const cmd = 'hostname -I'
-  const pubIp = execSync(cmd).toString().split(' ')
-  const ip = args.rpcAddr ?? pubIp[0]
+  const cmd = 'hostname -i'
+  const pubIp = execSync(cmd).toString().split(':')
+  const ip = args.rpcAddr ?? pubIp[0].trim()
   const log = debug('ultralight')
   let id: PeerId
   let web3: jayson.Client | undefined


### PR DESCRIPTION
Revise the `cli` to be compatible with docker containers.  `hostname -I` fails inside of `node-18:alpine` containers which is what portal-hive will use for Ultralight going forward.