### PR TITLE
fix portal_historyLocalContent

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -340,16 +340,13 @@ export class portal {
     this.logger(`historyRecursiveFindNodes request returned ${res}`)
     return res ?? ''
   }
-  async historyLocalContent(params: [string]) {
+  async historyLocalContent(params: [string]): Promise<string> {
     const [contentKey] = params
     this.logger(`Received historyLocalContent request for ${contentKey}`)
-    let res
-    try {
-      res = await this._history.findContentLocally(fromHexString(contentKey))
-    } catch (err) {
-      res = (err as any).message
-    }
-    return res
+
+    const res = await this._history.findContentLocally(fromHexString(contentKey))
+    this.logger(`historyLocalContent request returned ${res.length} bytes`)
+    return toHexString(res)
   }
   async historyFindContent(params: [string, string]) {
     const [nodeId, contentKey] = params

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -60,9 +60,9 @@ export class HistoryProtocol extends BaseProtocol {
    * @param decodedContentMessage content key to be found
    * @returns content if available locally
    */
-  public findContentLocally = async (contentKey: Uint8Array) => {
+  public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array> => {
     const value = await this.retrieve(toHexString(contentKey))
-    return value ? fromHexString(value) : undefined
+    return value ? fromHexString(value) : fromHexString('0x')
   }
 
   public validateHeader = async (value: Uint8Array, contentHash: string) => {


### PR DESCRIPTION
Fixes `portal_historyLocalContent` RPC endpoint.
Issues: #416 and #415 

Client should return '0x' if content not found.
