### PR TITLE
Fix Hive Failures

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -243,8 +243,8 @@ export class portal {
     }
     return (
       pong && {
-        enrSeq: '0x' + pong.enrSeq.toString(16),
-        dataRadius: toHexString(pong.customPayload),
+        enrSeq: pong.enrSeq,
+        dataRadius: pong.customPayload,
       }
     )
   }


### PR DESCRIPTION
PING --
We were returning radius as a hex string instead of number.