### PR TITLE
Portal-Hive client-interop fixes

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -351,13 +351,14 @@ export class portal {
     this.logger(`historyRecursiveFindNodes request returned ${res}`)
     return res ?? ''
   }
-  async historyLocalContent(params: [string]): Promise<string> {
+  async historyLocalContent(params: [string]): Promise<string | undefined> {
     const [contentKey] = params
     this.logger(`Received historyLocalContent request for ${contentKey}`)
 
     const res = await this._history.findContentLocally(fromHexString(contentKey))
-    this.logger(`historyLocalContent request returned ${res.length} bytes`)
-    return toHexString(res)
+    this.logger.extend(`historyLocalContent`)(`request returned ${res.length} bytes`)
+    this.logger.extend(`historyLocalContent`)(`${toHexString(res)}`)
+    return res.length > 0 ? toHexString(res) : undefined
   }
   async historyFindContent(params: [string, string]) {
     const [enr, contentKey] = params
@@ -393,7 +394,7 @@ export class portal {
     res.selector === 0 && this.logger.extend('findContent')('utp')
     this.logger.extend('findContent')(content)
     return {
-      content: toHexString(content),
+      content: content.length > 0 ? toHexString(content) : '',
       utpTransfer: res.selector === 0,
     }
   }

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -191,7 +191,7 @@ export class portal {
     const shortEnr = encodedENR.nodeId.slice(0, 15) + '...'
     this.logger(`portal_historyAddEnr request received for ${shortEnr}`)
     try {
-      if (this._history.routingTable.getValue(encodedENR.nodeId)) {
+      if (this._history.routingTable.getWithPending(encodedENR.nodeId)?.value) {
         return true
       }
       this._history.routingTable.insertOrUpdate(encodedENR, EntryStatus.Disconnected)
@@ -284,7 +284,7 @@ export class portal {
     if (!isValidId(dstId)) {
       return 'invalid node id'
     }
-    if (!this._history.routingTable.getValue(dstId)) {
+    if (!this._history.routingTable.getWithPending(dstId)?.value) {
       const pong = await this._history.sendPing(enr)
       if (!pong) {
         return ''
@@ -303,7 +303,7 @@ export class portal {
     const [dstId, distances] = params
     this.logger(`portal_historySendFindNodes`)
     try {
-      const enr = this._history.routingTable.getValue(dstId)
+      const enr = this._history.routingTable.getWithPending(dstId)?.value
       if (!enr) {
         return
       }
@@ -317,7 +317,7 @@ export class portal {
     const [dstId, enrs, requestId] = params
     this.logger(`portal_historySendNodes`)
     try {
-      const enr = this._history.routingTable.getValue(dstId)
+      const enr = this._history.routingTable.getWithPending(dstId)?.value
       if (!enr) {
         return
       }
@@ -362,7 +362,7 @@ export class portal {
   async historyFindContent(params: [string, string]) {
     const [enr, contentKey] = params
     const nodeId = ENR.decodeTxt(enr).nodeId
-    if (!this._history.routingTable.getValue(nodeId)) {
+    if (!this._history.routingTable.getWithPending(nodeId)?.value) {
       const pong = await this._history.sendPing(enr)
       if (!pong) {
         return ''
@@ -400,7 +400,7 @@ export class portal {
   async historySendFindContent(params: [string, string]) {
     const [nodeId, contentKey] = params
     const res = await this._history.sendFindContent(nodeId, fromHexString(contentKey))
-    const enr = this._history.routingTable.getValue(nodeId)
+    const enr = this._history.routingTable.getWithPending(nodeId)?.value
     return res && enr && '0x' + enr.seq.toString(16)
   }
   async historySendContent(params: [string, string]) {
@@ -409,7 +409,7 @@ export class portal {
       selector: 1,
       value: fromHexString(content),
     })
-    const enr = this._history.routingTable.getValue(nodeId)
+    const enr = this._history.routingTable.getWithPending(nodeId)?.value
     this._client.sendPortalNetworkResponse(
       { nodeId, socketAddr: enr?.getLocationMultiaddr('udp')! },
       enr!.seq,
@@ -430,7 +430,7 @@ export class portal {
     const [enrHex, contentKeyHex, contentValueHex] = params
     const enr = ENR.decodeTxt(enrHex)
     const contentKey = decodeContentKey(contentKeyHex)
-    if (this._history.routingTable.getValue(enr.nodeId) === undefined) {
+    if (this._history.routingTable.getWithPending(enr.nodeId)?.value === undefined) {
       const res = await this._history.sendPing(enr)
       if (res === undefined) {
         return '0x'
@@ -448,7 +448,7 @@ export class portal {
     const [dstId, contentKeys] = params
     const keys = contentKeys.map((key) => fromHexString(key))
     const res = await this._history.sendOffer(dstId, keys)
-    const enr = this._history.routingTable.getValue(dstId)
+    const enr = this._history.routingTable.getWithPending(dstId)?.value
     return res && enr && '0x' + enr.seq.toString(16)
   }
   async historySendAccept(params: [string, string, string[]]) {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -194,7 +194,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     this.discv5.on('talkReqReceived', this.onTalkReq)
     this.discv5.on('talkRespReceived', this.onTalkResp)
     this.uTP.on('Send', async (peerId: string, msg: Buffer, protocolId: ProtocolId) => {
-      const enr = this.protocols.get(protocolId)?.routingTable.getValue(peerId)
+      const enr = this.protocols.get(protocolId)?.routingTable.getWithPending(peerId)?.value
       try {
         await this.sendPortalNetworkMessage(enr ?? peerId, msg, protocolId, true)
         this.uTP.emit('Sent')
@@ -365,7 +365,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         // If ENR is not provided, look up ENR in protocol routing table by nodeId
         const protocol = this.protocols.get(protocolId)
         if (protocol) {
-          nodeAddr = protocol.routingTable.getValue(enr)
+          nodeAddr = protocol.routingTable.getWithPending(enr)?.value
           if (!nodeAddr) {
             // Check in unverified sessions cache if no ENR found in routing table
             nodeAddr = this.unverifiedSessionCache.get(enr)

--- a/packages/portalnetwork/src/subprotocols/contentLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/contentLookup.ts
@@ -112,14 +112,14 @@ export class ContentLookup {
                 continue
               }
               // Send a PING request to check liveness of any unknown nodes
-              if (!this.protocol.routingTable.getValue(decodedEnr.nodeId)) {
+              if (!this.protocol.routingTable.getWithPending(decodedEnr.nodeId)?.value) {
                 const ping = await this.protocol.sendPing(decodedEnr)
                 if (!ping) {
                   this.protocol.routingTable.evictNode(decodedEnr.nodeId)
                   continue
                 }
               }
-              if (!this.protocol.routingTable.getValue(decodedEnr.nodeId)) {
+              if (!this.protocol.routingTable.getWithPending(decodedEnr.nodeId)?.value) {
                 continue
               }
               // Calculate distance and add to list of lookup peers

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -98,7 +98,7 @@ export class HistoryProtocol extends BaseProtocol {
    * @returns the value of the FOUNDCONTENT response or undefined
    */
   public sendFindContent = async (dstId: string, key: Uint8Array) => {
-    const enr = this.routingTable.getValue(dstId)
+    const enr = this.routingTable.getWithPending(dstId)?.value
     if (!enr) {
       this.logger(`No ENR found for ${shortId(dstId)}.  FINDCONTENT aborted.`)
       return

--- a/packages/portalnetwork/src/subprotocols/nodeLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/nodeLookup.ts
@@ -85,6 +85,6 @@ export class NodeLookup {
       const res = await this.protocol.sendPing(enr)
       if (res) this.protocol.routingTable.insertOrUpdate(enr, EntryStatus.Connected)
     }
-    return this.protocol.routingTable.getValue(this.nodeSought)?.encodeTxt()
+    return this.protocol.routingTable.getWithPending(this.nodeSought)?.value.encodeTxt()
   }
 }

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -84,6 +84,10 @@ export abstract class BaseProtocol extends EventEmitter {
   abstract store(contentType: any, hashKey: string, value: Uint8Array): Promise<void>
 
   public handle(message: ITalkReqMessage, src: INodeAddress) {
+    const enr = this.findEnr(src.nodeId)
+    if (enr !== undefined) {
+      this.updateRoutingTable(enr)
+    }
     const id = message.id
     const protocol = message.protocol
     const request = message.request
@@ -341,6 +345,7 @@ export abstract class BaseProtocol extends EventEmitter {
               this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(dstId)}`)
               return []
             }
+            this.logger.extend(`OFFER`)(`ACCEPT message received with uTP id: ${id}`)
 
             const requestedData: Uint8Array[] = []
             for await (const key of requestedKeys) {

--- a/packages/portalnetwork/src/subprotocols/rendezvous/rendezvous.ts
+++ b/packages/portalnetwork/src/subprotocols/rendezvous/rendezvous.ts
@@ -79,7 +79,7 @@
 //         this.logger(
 //           `Received Rendezvous FIND request for ${shortId(dstId)} on ${protocolId} network`
 //         )
-//         let enr = protocol.routingTable.getValue(dstId)
+//         let enr = protocol.routingTable.getWithPending(dstId)
 //         if (!enr) {
 //           enr = this.client.discv5.getKadValue(dstId)
 //           if (!enr) {
@@ -108,7 +108,7 @@
 //         this.logger(
 //           `Received Rendezvous SYNC from requestor ${shortId(srcId)} for target ${shortId(dstId)}`
 //         )
-//         const srcEnr = protocol.routingTable.getValue(srcId)
+//         const srcEnr = protocol.routingTable.getWithPending(srcId)
 //         const payload = Buffer.concat([
 //           Uint8Array.from([2]),
 //           Buffer.from(protocolId.slice(2), 'hex'),

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketManager.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketManager.ts
@@ -31,7 +31,7 @@ export class PacketManager {
       ...opts,
       version: 1,
       timestampMicroseconds: Bytes32TimeStamp(),
-      connectionId: this.rcvConnectionId,
+      connectionId: opts.connectionId ?? this.rcvConnectionId,
       timestampDifferenceMicroseconds: this.congestionControl.reply_micro,
       wndSize: Math.min(
         2 ** 32 - 1,

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
@@ -39,11 +39,13 @@ interface IHeaderInput<T extends PacketType> {
 interface IBasicHeaderInput<T extends PacketType> extends IHeaderInput<T> {
   pType: PacketType
   extension: HeaderExtension.none
+  connectionId: Uint16
 }
 export interface ISelectiveAckHeaderInput extends IHeaderInput<PacketType.ST_STATE> {
   pType: PacketType.ST_STATE
   extension: HeaderExtension.selectiveAck
   bitmask: Uint8Array
+  connectionId: Uint16
 }
 export type HeaderInput<T extends PacketType> = IBasicHeaderInput<T> | ISelectiveAckHeaderInput
 
@@ -73,21 +75,25 @@ export interface IPacket<T extends PacketType> {
   pType: T
   seqNr: number
   ackNr: number
+  connectionId: number
   payload?: Uint8Array
 }
 export interface IBasic<T extends PacketType> extends IPacket<T> {
   pType: T
   extension: HeaderExtension.none
+  connectionId: number
 }
 export interface ISelectiveAck extends IPacket<PacketType.ST_STATE> {
   pType: PacketType.ST_STATE
   extension: HeaderExtension.selectiveAck
   bitmask: Uint8Array
+  connectionId: number
 }
 export interface IData extends IPacket<PacketType.ST_DATA> {
   pType: PacketType.ST_DATA
   extension: HeaderExtension.none
   payload: Uint8Array
+  connectionId: number
 }
 export type ICreate<T extends PacketType> = IBasic<T> | ISelectiveAck | IData
 
@@ -105,6 +111,7 @@ export interface UtpSocketOptions {
 
 interface ICreatePacket<T> {
   pType: T
+  connectionId?: number
 }
 interface ICreateSelectiveAck extends ICreatePacket<PacketType.ST_STATE> {
   bitmask: Uint8Array

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -54,7 +54,11 @@ export class ContentRequest {
   }
 
   async sendSyn(): Promise<void> {
-    await this.socket.sendSynPacket()
+    await this.socket.sendSynPacket(
+      this.requestCode === RequestCode.OFFER_WRITE
+        ? this.socket.sndConnectionId
+        : this.socket.rcvConnectionId
+    )
     this.socket.state = ConnectionState.SynSent
   }
 }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -289,7 +289,12 @@ export class PortalNetworkUTP extends EventEmitter {
           ContentType[k[0]]
         } to database`
       )
-      this.emit('Stream', k[0], decodedContentKey.blockHash, _content)
+      if (_content.length === 0) {
+        this.logger.extend(`FINISHED`)(`Missing content...`)
+        continue
+      } else {
+        this.emit('Stream', k[0], decodedContentKey.blockHash, _content)
+      }
     }
   }
 }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
@@ -9,8 +9,8 @@ export enum RequestCode {
   'ACCEPT_READ' = 3,
 }
 
-export function createSocketKey(remoteAddr: string, sndId: number, rcvId: number) {
-  return `${remoteAddr.slice(0, 5)}-${sndId}-${rcvId}`
+export function createSocketKey(remoteAddr: string, id: number) {
+  return `${remoteAddr}-${id}`
 }
 export interface INewRequest {
   protocolId: ProtocolId

--- a/packages/portalnetwork/src/wire/utp/Socket/ContentWriter.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/ContentWriter.ts
@@ -37,9 +37,7 @@ export default class ContentWriter extends EventEmitter {
       bytes = this.dataChunks[this.seqNr] ?? []
       !this.sentChunks.includes(this.seqNr) && this.sentChunks.push(this.seqNr)
       this.logger(
-        `Sending ST-DATA ${this.seqNr - this.startingSeqNr + 1}/${chunks} -- SeqNr: {
-          this.socket.seqNr
-        }`
+        `Sending ST-DATA ${this.seqNr - this.startingSeqNr + 1}/${chunks} -- SeqNr: ${this.seqNr}`
       )
       this.seqNr = this.sentChunks.slice(-1)[0] + 1
 

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -264,14 +264,8 @@ export class UtpSocket extends EventEmitter {
   async handleFinPacket(packet: Packet<PacketType.ST_FIN>): Promise<Uint8Array> {
     this.logger(`Connection State: GotFin`)
     this.state = ConnectionState.GotFin
-    const _content = await this.reader!.run()
-    this.logger(`Packet payloads compiled into ${_content.length} bytes.  Sending FIN-ACK`)
-    this.seqNr = this.seqNr + 1
-    this.ackNr = packet.header.seqNr
-    this.sendAckPacket()
-    this._clearTimeout()
-    this.close()
-    return _content
+    this.finNr = packet.header.seqNr
+    this.logger(`Connection State: GotFin: ${this.finNr}`)
   }
 
   compare(): boolean {

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -101,7 +101,7 @@ export class UtpSocket extends EventEmitter {
   }
 
   setReader(startingSeqNr: number) {
-    this.reader = new ContentReader(startingSeqNr)
+    this.reader = new ContentReader(startingSeqNr - 1)
   }
 
   _clearTimeout() {

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -127,18 +127,22 @@ export class UtpSocket extends EventEmitter {
   ): Packet<T> {
     opts.pType === PacketType.ST_DATA && this.seqNr++
     const extension = 'bitmask' in opts ? 1 : 0
-    const params: ICreate<T> = {
+    const params = {
       ...opts,
       seqNr: this.seqNr,
       ackNr: this.ackNr,
+      connectionId: opts.connectionId ?? this.rcvConnectionId,
       extension,
     }
     return this.packetManager.createPacket<T>(params)
   }
 
-  async sendSynPacket(): Promise<void> {
-    const p = this.createPacket({ pType: PacketType.ST_SYN })
-    await this.sendPacket(p, PacketType.ST_SYN)
+  async sendSynPacket(pktId?: number): Promise<void> {
+    const p = this.createPacket({
+      pType: PacketType.ST_SYN,
+      connectionId: pktId ?? this.rcvConnectionId,
+    })
+    await this.sendPacket<PacketType.ST_SYN>(p)
     this.state = ConnectionState.SynSent
   }
   async sendAckPacket(bitmask?: Uint8Array): Promise<void> {

--- a/packages/portalnetwork/src/wire/utp/Utils/constants.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/constants.ts
@@ -38,8 +38,8 @@ export const MAX_UDP_HEADER_LENGTH = 48
 export const DEF_HEADER_LENGTH = 20
 
 export const startingNrs: Record<RequestCode, { seqNr: number; ackNr: number }> = {
-  0: { seqNr: randUint16(), ackNr: 0 },
-  1: { seqNr: 0, ackNr: 1 },
-  2: { seqNr: 1, ackNr: randUint16() },
-  3: { seqNr: randUint16(), ackNr: 0 },
+  [RequestCode.FOUNDCONTENT_WRITE]: { seqNr: randUint16(), ackNr: 0 },
+  [RequestCode.FINDCONTENT_READ]: { seqNr: randUint16(), ackNr: 1 },
+  [RequestCode.OFFER_WRITE]: { seqNr: randUint16(), ackNr: 0 },
+  [RequestCode.ACCEPT_READ]: { seqNr: randUint16(), ackNr: 0 },
 }

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -76,7 +76,7 @@ tape('gossip test', async (t) => {
   const protocol2 = node2.protocols.get(ProtocolId.HistoryNetwork) as HistoryProtocol
   await protocol1?.sendPing(protocol2?.enr!.toENR())
   t.equal(
-    protocol1?.routingTable.getValue(
+    protocol1?.routingTable.getWithPending(
       '8a47012e91f7e797f682afeeab374fa3b3186c82de848dc44195b4251154a2ed'
     )?.nodeId,
     '8a47012e91f7e797f682afeeab374fa3b3186c82de848dc44195b4251154a2ed',

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -78,7 +78,7 @@ tape('gossip test', async (t) => {
   t.equal(
     protocol1?.routingTable.getWithPending(
       '8a47012e91f7e797f682afeeab374fa3b3186c82de848dc44195b4251154a2ed'
-    )?.nodeId,
+    )?.value.nodeId,
     '8a47012e91f7e797f682afeeab374fa3b3186c82de848dc44195b4251154a2ed',
     'node1 added node2 to routing table'
   )

--- a/packages/portalnetwork/test/wire/utp/socket.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/socket.spec.ts
@@ -185,7 +185,7 @@ tape('createPacket()', (t) => {
       'DATA Packet extension should be none'
     )
     st.equal(write_data.header.connectionId, read.sndConnectionId, 'Packet sndId correctly set')
-    st.equal(write_data.header.seqNr, write.getSeqNr(), 'Packet seqNr correctly set')
+    st.equal(write_data.header.seqNr, write.getSeqNr() - 1, 'Packet seqNr correctly set')
     st.equal(write_data.header.ackNr, write.ackNr, 'Packet ackNr correctly set')
     st.equal(
       toHexString(write_data.payload!),


### PR DESCRIPTION
This PR will bring the portal hive client interop tests to ~~100%~~ 98% passing.

* new ENR's are added to routing table by general packet handler
  * Previously this was only available in the SYN packet handling.
* `findENR` functions now use `getWithPending`, which will return the peerId of peers still in the discv5 `pending` buffer. 
* Corrections made to uTP sockets: 
  * `sndId` / `rcvId` / `connectionId` setup
  * `seqNr` / `ackNr` setup
  * `FIN` handling.
    * Corrected to await end of stream before compiling.
* Added debug logging throughout. 