### PR TITLE
Hive rpc updates (complete)

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -177,6 +177,9 @@ export class portal {
   }
   async historyGetEnr(params: [string]): Promise<GetEnrResult> {
     const [nodeId] = params
+    if (nodeId === this._client.discv5.enr.nodeId) {
+      return this._client.discv5.enr.encodeTxt()
+    }
     this.logger.extend('portal_historyGetEnr')(` request received for ${nodeId.slice(0, 10)}...`)
     const enr = this._history.routingTable.getWithPending(nodeId)?.value
     if (enr) {

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -358,7 +358,7 @@ export class portal {
     const res = await this._history.findContentLocally(fromHexString(contentKey))
     this.logger.extend(`historyLocalContent`)(`request returned ${res.length} bytes`)
     this.logger.extend(`historyLocalContent`)(`${toHexString(res)}`)
-    return res.length > 0 ? toHexString(res) : undefined
+    return res.length > 0 ? toHexString(res) : '0x'
   }
   async historyFindContent(params: [string, string]) {
     const [enr, contentKey] = params

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -232,6 +232,9 @@ export class portal {
   }
   async historyLookupEnr(params: [string]) {
     const [nodeId] = params
+    if (nodeId === this._client.discv5.enr.nodeId) {
+      return this._client.discv5.enr.encodeTxt()
+    }
     this.logger(`Looking up ENR for NodeId: ${shortId(nodeId)}`)
     const enr = this._history.routingTable.getWithPending(nodeId)?.value.encodeTxt()
     this.logger(`Found: ${enr}`)

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -69,7 +69,7 @@ export class portal {
     this.historyLookupEnr = middleware(this.historyLookupEnr.bind(this), 1, [[validators.hex]])
     this.historyAddBootNode = middleware(this.historyAddBootNode.bind(this), 1, [[validators.enr]])
     this.historyAddEnr = middleware(this.historyAddEnr.bind(this), 1, [[validators.enr]])
-    this.historyGetEnr = middleware(this.historyGetEnr.bind(this), 1, [[validators.hex]])
+    this.historyGetEnr = middleware(this.historyGetEnr.bind(this), 1, [[validators.dstId]])
     this.historyDeleteEnr = middleware(this.historyDeleteEnr.bind(this), 1, [[validators.hex]])
     this.historyAddEnrs = middleware(this.historyAddEnrs.bind(this), 1, [
       [validators.array(validators.enr)],

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -207,9 +207,9 @@ export class portal {
     }
   }
   async historyDeleteEnr(params: [string]): Promise<boolean> {
-    this.logger(`portal_historyDeleteEnr request received.`)
     const [nodeId] = params
-    const remove = this._history.routingTable.removeById(nodeId.slice(2))
+    this.logger(`portal_historyDeleteEnr request received for ${nodeId.slice(0, 10)}...`)
+    const remove = this._history.routingTable.removeById(nodeId)
     return remove !== undefined
   }
   async historyRoutingTableInfo(_params: []): Promise<any> {

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -177,11 +177,14 @@ export class portal {
   }
   async historyGetEnr(params: [string]): Promise<GetEnrResult> {
     const [nodeId] = params
-    this.logger(`portal_historyGetEnr request received for ${nodeId.slice(0, 10)}...`)
-    const enr = this._history.routingTable.getWithPending(nodeId.slice(2))?.value
+    this.logger.extend('portal_historyGetEnr')(` request received for ${nodeId.slice(0, 10)}...`)
+    const enr = this._history.routingTable.getWithPending(nodeId)?.value
     if (enr) {
-      return enr.encodeTxt()
+      const enrTxt = enr.encodeTxt()
+      this.logger.extend('portal_historyGetEnr')(enrTxt)
+      return enrTxt
     }
+    this.logger.extend('portal_historyGetEnr')('ENR not found')
     return ''
   }
 

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -70,7 +70,7 @@ export class portal {
     this.historyAddBootNode = middleware(this.historyAddBootNode.bind(this), 1, [[validators.enr]])
     this.historyAddEnr = middleware(this.historyAddEnr.bind(this), 1, [[validators.enr]])
     this.historyGetEnr = middleware(this.historyGetEnr.bind(this), 1, [[validators.dstId]])
-    this.historyDeleteEnr = middleware(this.historyDeleteEnr.bind(this), 1, [[validators.hex]])
+    this.historyDeleteEnr = middleware(this.historyDeleteEnr.bind(this), 1, [[validators.dstId]])
     this.historyAddEnrs = middleware(this.historyAddEnrs.bind(this), 1, [
       [validators.array(validators.enr)],
     ])

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -66,7 +66,7 @@ export class portal {
     this.methods = middleware(this.methods.bind(this), 0, [])
     this.historyNodeInfo = middleware(this.historyNodeInfo.bind(this), 0, [])
     this.historyRoutingTableInfo = middleware(this.historyRoutingTableInfo.bind(this), 0, [])
-    this.historyLookupEnr = middleware(this.historyLookupEnr.bind(this), 1, [[validators.hex]])
+    this.historyLookupEnr = middleware(this.historyLookupEnr.bind(this), 1, [[validators.dstId]])
     this.historyAddBootNode = middleware(this.historyAddBootNode.bind(this), 1, [[validators.enr]])
     this.historyAddEnr = middleware(this.historyAddEnr.bind(this), 1, [[validators.enr]])
     this.historyGetEnr = middleware(this.historyGetEnr.bind(this), 1, [[validators.dstId]])

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -233,7 +233,7 @@ export class portal {
   async historyLookupEnr(params: [string]) {
     const [nodeId] = params
     this.logger(`Looking up ENR for NodeId: ${shortId(nodeId)}`)
-    const enr = this._history.routingTable.getWithPending(nodeId.slice(2))?.value.encodeTxt()
+    const enr = this._history.routingTable.getWithPending(nodeId)?.value.encodeTxt()
     this.logger(`Found: ${enr}`)
     return enr ?? ''
   }

--- a/packages/cli/src/rpc/validators.ts
+++ b/packages/cli/src/rpc/validators.ts
@@ -115,10 +115,7 @@ export const validators = {
         }
       }
       if (params[index].startsWith('0x')) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: NodeId should be without 0x prefix`,
-        }
+        params[index] = params[index].slice(2)
       }
     }
   },


### PR DESCRIPTION
Updates RPC methods to pass Portal-Hive tests.

- "NodeId" parameters showing up again as "{ raw: byte, byte, byte, byte... }" instead of "0xabcd..."
Current changes should be resilient to another flip-flop.  Validator can parse either input.