### PR TITLE
Update discv5 and fix transports interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2049,33 +2049,21 @@
       }
     },
     "node_modules/@chainsafe/discv5/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.6.tgz",
-      "integrity": "sha512-/2QwhnBzAJbR/f6halEzkbQLOrjwodrJsplfCbDfOOOZGOVBlNttNavb4fU6ks58yAs1aQ6bZrar8y08R+bagg==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^0.1.1",
         "dns-over-http-resolver": "^2.1.0",
         "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=8.6.0"
-      }
-    },
-    "node_modules/@chainsafe/discv5/node_modules/bigint-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@chainsafe/discv5/node_modules/lru-cache": {
@@ -3955,9 +3943,9 @@
       }
     },
     "node_modules/@ethereumjs/statemanager/node_modules/ethers": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
-      "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
       "funding": [
         {
           "type": "individual",
@@ -5266,11 +5254,11 @@
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.1.tgz",
-      "integrity": "sha512-Uk+4YnEShx4gfzweYdJCHdLxcA1gAnTiZ8vlvr5DnSHJrg8yUN6VYkk96W3iJQ7H7hqV/ULIoIRQLHjLtDDCkw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.2.tgz",
+      "integrity": "sha512-Q5t27434Mvn+R6AUJlRH+q/jSXarDpP+KXVkyGY7S1fKPI2berqoFPqT61bRRBYsCH2OPZiKBB53VUzxL9uEvg==",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.1.3",
+        "@multiformats/multiaddr": "^12.1.5",
         "abortable-iterator": "^5.0.1",
         "it-pushable": "^3.2.0",
         "it-stream-types": "^2.0.1",
@@ -5327,17 +5315,17 @@
       }
     },
     "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.6.tgz",
-      "integrity": "sha512-/2QwhnBzAJbR/f6halEzkbQLOrjwodrJsplfCbDfOOOZGOVBlNttNavb4fU6ks58yAs1aQ6bZrar8y08R+bagg==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^0.1.1",
         "dns-over-http-resolver": "^2.1.0",
         "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -5370,17 +5358,17 @@
       }
     },
     "node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.6.tgz",
-      "integrity": "sha512-/2QwhnBzAJbR/f6halEzkbQLOrjwodrJsplfCbDfOOOZGOVBlNttNavb4fU6ks58yAs1aQ6bZrar8y08R+bagg==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^0.1.1",
         "dns-over-http-resolver": "^2.1.0",
         "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -5410,17 +5398,17 @@
       }
     },
     "node_modules/@libp2p/interface/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.6.tgz",
-      "integrity": "sha512-/2QwhnBzAJbR/f6halEzkbQLOrjwodrJsplfCbDfOOOZGOVBlNttNavb4fU6ks58yAs1aQ6bZrar8y08R+bagg==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^0.1.1",
         "dns-over-http-resolver": "^2.1.0",
         "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -5462,17 +5450,17 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.6.tgz",
-      "integrity": "sha512-/2QwhnBzAJbR/f6halEzkbQLOrjwodrJsplfCbDfOOOZGOVBlNttNavb4fU6ks58yAs1aQ6bZrar8y08R+bagg==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^0.1.1",
         "dns-over-http-resolver": "^2.1.0",
         "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -5614,17 +5602,17 @@
       }
     },
     "node_modules/@multiformats/mafmt/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.6.tgz",
-      "integrity": "sha512-/2QwhnBzAJbR/f6halEzkbQLOrjwodrJsplfCbDfOOOZGOVBlNttNavb4fU6ks58yAs1aQ6bZrar8y08R+bagg==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^0.1.1",
         "dns-over-http-resolver": "^2.1.0",
         "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -7866,6 +7854,18 @@
         "node": "*"
       }
     },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/bigint-crypto-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
@@ -8418,9 +8418,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001520",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
-      "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
+      "version": "1.0.30001521",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
+      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
       "devOptional": true,
       "funding": [
         {
@@ -8865,9 +8865,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.1.tgz",
+      "integrity": "sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -8876,12 +8876,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.0.tgz",
-      "integrity": "sha512-7a9a3D1k4UCVKnLhrgALyFcP7YCsLOQIxPd0dKjf/6GuPcgyiGP70ewWdCGrSK7evyhymi0qO4EqCmSJofDeYw==",
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.32.1.tgz",
+      "integrity": "sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.21.9"
+        "browserslist": "^4.21.10"
       },
       "funding": {
         "type": "opencollective",
@@ -9658,15 +9658,15 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.490",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.490.tgz",
-      "integrity": "sha512-6s7NVJz+sATdYnIwhdshx/N/9O6rvMxmhVoDSDFdj6iA45gHR8EQje70+RYsF4GeB+k0IeNSBnP7yG9ZXJFr7A==",
+      "version": "1.4.496",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.496.tgz",
+      "integrity": "sha512-qeXC3Zbykq44RCrBa4kr8v/dWzYJA8rAwpyh9Qd+NKWoJfjG5vvJqy9XOJ9H4P/lqulZBCgUWAYi+FeK5AuJ8g==",
       "devOptional": true
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "16.18.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.40.tgz",
-      "integrity": "sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA==",
+      "version": "16.18.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.41.tgz",
+      "integrity": "sha512-YZJjn+Aaw0xihnpdImxI22jqGbp0DCgTFKRycygjGx/Y27NnWFJa5FJ7P+MRT3u07dogEeMVh70pWpbIQollTA==",
       "dev": true
     },
     "node_modules/elementtree": {
@@ -14295,9 +14295,9 @@
       "link": true
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
       "dev": true,
       "funding": [
         {
@@ -14437,9 +14437,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -16624,9 +16624,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16847,6 +16847,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
     "node_modules/uint8arraylist": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
@@ -18018,7 +18027,7 @@
       "license": "MIT",
       "dependencies": {
         "@chainsafe/as-sha256": "^0.3.1",
-        "@chainsafe/discv5": "5.0.1",
+        "@chainsafe/discv5": "5.1.1",
         "@chainsafe/persistent-merkle-tree": "^0.4.1",
         "@chainsafe/ssz": "^0.11.1",
         "@ethereumjs/block": "5.0.0",
@@ -18070,16 +18079,99 @@
         "node": ">=18"
       }
     },
-    "packages/portalnetwork/node_modules/bigint-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-      "hasInstallScript": true,
+    "packages/portalnetwork/node_modules/@chainsafe/discv5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-5.1.1.tgz",
+      "integrity": "sha512-Zcv7fyKirKta305/gTX+wvFA2Ockx+FxUTW+/Yj37+idFjt/UrGho4tcPGyPJC/46cXp+NRGI1wNqsh54+Hnow==",
       "dependencies": {
-        "bindings": "^1.3.0"
+        "@libp2p/crypto": "^2.0.0",
+        "@libp2p/interface": "^0.1.2",
+        "@libp2p/peer-id": "^3.0.1",
+        "@multiformats/multiaddr": "^12.1.3",
+        "base64url": "^3.0.1",
+        "bcrypto": "^5.4.0",
+        "bigint-buffer": "^1.1.5",
+        "debug": "^4.3.1",
+        "dgram": "^1.0.1",
+        "err-code": "^3.0.1",
+        "lru-cache": "^6.0.0",
+        "rlp": "^2.2.6",
+        "strict-event-emitter-types": "^2.0.0",
+        "uint8-varint": "^2.0.1"
+      }
+    },
+    "packages/portalnetwork/node_modules/@chainsafe/discv5/node_modules/@libp2p/peer-id": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-3.0.2.tgz",
+      "integrity": "sha512-133qGXu9UBiqsYm7nBDJaAh4eiKe79DPLKF+/aRu0Z7gKcX7I0+LewEky4kBt3olhYQSF1CAnJIzD8Dmsn40Yw==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.2",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "packages/portalnetwork/node_modules/@chainsafe/discv5/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "packages/portalnetwork/node_modules/@chainsafe/discv5/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/portalnetwork/node_modules/@libp2p/crypto": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-2.0.3.tgz",
+      "integrity": "sha512-VLhjdkJe8b/vedHp7SosDs62Yxq1i05Ej/YdVaEdWQdJsBRHCwbRlS4hPg3vm21U5hLF0g958r/927Vd/wamZw==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.2",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "multiformats": "^12.0.1",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.6"
+      }
+    },
+    "packages/portalnetwork/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/portalnetwork/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "packages/portalnetwork/node_modules/prettier": {

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.3.1",
-    "@chainsafe/discv5": "5.0.1",
+    "@chainsafe/discv5": "5.1.1",
     "@chainsafe/persistent-merkle-tree": "^0.4.1",
     "@chainsafe/ssz": "^0.11.1",
     "@ethereumjs/block": "5.0.0",

--- a/packages/portalnetwork/src/transports/capacitorUdp.ts
+++ b/packages/portalnetwork/src/transports/capacitorUdp.ts
@@ -8,8 +8,7 @@ import {
   ITransportService,
   TransportEventEmitter,
 } from '@chainsafe/discv5/transport'
-import { BaseENR } from '@chainsafe/discv5'
-import { SocketAddress } from '@chainsafe/discv5/lib/util/ip.js'
+import { ENR, SocketAddress, getSocketAddressOnENR } from '@chainsafe/discv5'
 
 /**
  * This class is responsible for encoding outgoing Packets and decoding incoming Packets over UDP
@@ -83,14 +82,7 @@ export class CapacitorUDPTransportService
     }
   }
 
-  getContactableAddr(enr: BaseENR): SocketAddress | undefined {
-    const nodeAddr = this.bindAddrs[0].tuples()
-    return {
-      port: this.bindAddrs[0].nodeAddress().port,
-      ip: {
-        type: 4,
-        octets: nodeAddr[0][1] ?? new Uint8Array([0, 0, 0, 0]),
-      },
-    }
+  getContactableAddr(enr: ENR): SocketAddress | undefined {
+    return getSocketAddressOnENR(enr, this.ipMode)
   }
 }

--- a/packages/portalnetwork/src/transports/websockets.ts
+++ b/packages/portalnetwork/src/transports/websockets.ts
@@ -11,8 +11,7 @@ import {
 import WebSocketAsPromised from 'websocket-as-promised'
 import WebSocket from 'isomorphic-ws'
 import StrictEventEmitter from 'strict-event-emitter-types/types/src'
-import { SocketAddress } from '@chainsafe/discv5/lib/util/ip.js'
-import { BaseENR } from '@chainsafe/discv5'
+import { ENR, SocketAddress, getSocketAddressOnENR } from '@chainsafe/discv5'
 const log = debug('discv5:transport')
 
 interface IWebSocketTransportEvents extends ITransportEvents {
@@ -114,14 +113,7 @@ export class WebSocketTransportService
     }
   }
 
-  getContactableAddr(enr: BaseENR): SocketAddress | undefined {
-    const nodeAddr = this.bindAddrs[0].tuples()
-    return {
-      port: this.bindAddrs[0].nodeAddress().port,
-      ip: {
-        type: 4,
-        octets: nodeAddr[0][1] ?? new Uint8Array([0, 0, 0, 0]),
-      },
-    }
+  getContactableAddr(enr: ENR): SocketAddress | undefined {
+    return getSocketAddressOnENR(enr, this.ipMode)
   }
 }


### PR DESCRIPTION
Updates discv5 to 5.1.1 and fixes our implementation of the `transport` interface for Capacitor and Websockets.