### PR TITLE
Add initial support for `LightClientUpdatesByRange`

### DIFF
--- a/packages/portalnetwork/src/subprotocols/beacon/types.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/types.ts
@@ -12,6 +12,7 @@ export enum BeaconLightClientNetworkContentType {
   LightClientUpdatesByRange = 1,
   LightClientFinalityUpdate = 2,
   LightClientOptimisticUpdate = 3,
+  LightClientUpdate = 4, // Added for convenience, not part of the Portal Network Spec
 }
 
 export enum Forks {

--- a/packages/portalnetwork/src/subprotocols/beacon/util.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/util.ts
@@ -6,6 +6,8 @@ import {
   LightClientOptimisticUpdateKey,
   LightClientUpdatesByRange,
 } from './types.js'
+import { EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH } from '@lodestar/params'
+import { Epoch, Slot, SyncPeriod } from '@lodestar/types'
 
 export const attestedHeaderFromJson = (data: any) => {
   return {
@@ -71,3 +73,29 @@ export const decodeBeaconContentKey = (serializedKey: Uint8Array) => {
       throw new Error(`unknown content type ${selector}`)
   }
 }
+
+/******** Borrowed directly from Lodestar **************/
+// Copied from here - https://github.com/ChainSafe/lodestar/blob/unstable/packages/light-client/src/utils/clock.ts
+// Borrowed from Lodestar since we don't want to have to import all of the Lodestar dependency tree for a few helper functions
+// TODO: Remove if we ever decide to fully incorporate the Lodestar light client into our code base
+/**
+ * Return the epoch number at the given slot.
+ */
+export function computeEpochAtSlot(slot: Slot): Epoch {
+  return Math.floor(slot / SLOTS_PER_EPOCH)
+}
+
+/**
+ * Return the sync committee period at epoch
+ */
+export function computeSyncPeriodAtEpoch(epoch: Epoch): SyncPeriod {
+  return Math.floor(epoch / EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+}
+
+/**
+ * Return the sync committee period at slot
+ */
+export function computeSyncPeriodAtSlot(slot: Slot): SyncPeriod {
+  return computeSyncPeriodAtEpoch(computeEpochAtSlot(slot))
+}
+/************************ ****************************/

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -478,7 +478,7 @@ export abstract class BaseProtocol extends EventEmitter {
     )
   }
 
-  private handleFindContent = async (
+  protected handleFindContent = async (
     src: INodeAddress,
     requestId: bigint,
     protocol: Uint8Array,

--- a/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
@@ -314,4 +314,14 @@ it('API tests', async () => {
     6684738,
     'retrieved light client update period number from db',
   )
+
+  const range = await protocol.constructLightClientRange(816, 4)
+  const retrievedRange = await LightClientUpdatesByRange.deserialize(range)
+  const update1 = ssz.capella.LightClientUpdate.deserialize(retrievedRange[0].slice(4))
+  assert.equal(
+    update1.attestedHeader.beacon.slot,
+    6684738,
+    'put the correct update in the correct position in the range',
+  )
+  assert.equal(toHexString(range), updatesByRange.content_value)
 })

--- a/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
@@ -294,16 +294,24 @@ it('API tests', async () => {
     ).attestedHeader.beacon.slot,
     'successfully stored and retrieved optimistic update',
   )
-  // TODO: Update this test once logic for handling light client updates is implemented
+
   const updatesByRange = specTestVectors.updateByRange['6684738']
   try {
     await protocol.store(
       BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
       updatesByRange.content_key,
-      fromHexString(optimisticUpdate.content_value),
+      fromHexString(updatesByRange.content_value),
     )
     assert.fail('should throw')
   } catch {
     assert.ok(true, 'throws when trying to store a batch of light client updates')
   }
+  await protocol.storeUpdateRange(fromHexString(updatesByRange.content_value))
+  const storedUpdate = await protocol.findContentLocally(fromHexString('0x040330'))
+  const deserializedUpdate = ssz.capella.LightClientUpdate.deserialize(storedUpdate!.slice(4))
+  assert.equal(
+    deserializedUpdate.attestedHeader.beacon.slot,
+    6684738,
+    'retrieved light client update period number from db',
+  )
 })

--- a/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
@@ -186,7 +186,7 @@ describe('API tests', async () => {
   })
   const optimisticUpdate = specTestVectors.optimisticUpdate['6718463']
   await protocol.store(
-    BeaconLightClientNetworkContentType.LightClientFinalityUpdate,
+    BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
     optimisticUpdate.content_key,
     fromHexString(optimisticUpdate.content_value),
   )

--- a/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/subprotocols/beacon/beacon.spec.ts
@@ -306,6 +306,7 @@ it('API tests', async () => {
   } catch {
     assert.ok(true, 'throws when trying to store a batch of light client updates')
   }
+
   await protocol.storeUpdateRange(fromHexString(updatesByRange.content_value))
   const storedUpdate = await protocol.findContentLocally(fromHexString('0x040330'))
   const deserializedUpdate = ssz.capella.LightClientUpdate.deserialize(storedUpdate!.slice(4))
@@ -315,13 +316,13 @@ it('API tests', async () => {
     'retrieved light client update period number from db',
   )
 
-  const range = await protocol.constructLightClientRange(816, 4)
-  const retrievedRange = await LightClientUpdatesByRange.deserialize(range)
+  const range = await protocol.findContentLocally(fromHexString(updatesByRange.content_key))
+  const retrievedRange = await LightClientUpdatesByRange.deserialize(range!)
   const update1 = ssz.capella.LightClientUpdate.deserialize(retrievedRange[0].slice(4))
   assert.equal(
     update1.attestedHeader.beacon.slot,
     6684738,
     'put the correct update in the correct position in the range',
   )
-  assert.equal(toHexString(range), updatesByRange.content_value)
+  assert.equal(toHexString(range!), updatesByRange.content_value)
 })


### PR DESCRIPTION
This adds a minimal support for the `LightClientUpdatesByRange` in the Beacon network.  

1) Adds an additional `LightClientUpdate` type to the Beacon Network that allows us to store individual light client updates
2) Should seamlessly allow for construction of light client update ranges and then transmit them over the network
3) Removes ENRs from `handleFindContent` message handler for Beacon network since all nodes are expected to maintain all the data for this network