### PR TITLE
UTP-protocol-stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18767,7 +18767,8 @@
         "prettier": "^2.5.1",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "vitest": "^0.34.1"
       },
       "engines": {
         "node": "^18"

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -412,7 +412,7 @@ export class portal {
               resolve(Uint8Array.from([]))
             }, 2000)
             this._client.uTP.on(
-              'Stream',
+              ProtocolId.HistoryNetwork,
               (_contentType: HistoryNetworkContentType, hash: string, value: Uint8Array) => {
                 if (hash.slice(2) === contentKey.slice(4)) {
                   clearTimeout(timeout)

--- a/packages/portalnetwork/src/subprotocols/beacon/beacon.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/beacon.ts
@@ -40,6 +40,12 @@ export class BeaconLightClientNetwork extends BaseProtocol {
       .extend('Portal')
       .extend('BeaconLightClientNetwork')
     this.routingTable.setLogger(this.logger)
+    client.uTP.on(
+      ProtocolId.BeaconLightClientNetwork,
+      async (contentType: number, hash: string, value: Uint8Array) => {
+        await this.store(contentType, hash, value)
+      },
+    )
   }
 
   public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array | undefined> => {

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -50,6 +50,12 @@ export class HistoryProtocol extends BaseProtocol {
     this.ETH = new ETH(this)
     this.gossipManager = new GossipManager(this)
     this.routingTable.setLogger(this.logger)
+    client.uTP.on(
+      ProtocolId.HistoryNetwork,
+      async (contentType: number, hash: string, value: Uint8Array) => {
+        await this.store(contentType, hash, value)
+      },
+    )
   }
   /**
    *

--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -77,9 +77,6 @@ export abstract class BaseProtocol extends EventEmitter {
         this.metrics?.knownHistoryNodes.set(this.routingTable.size)
       }
     }
-    client.uTP.on('Stream', async (contentType: number, hash: string, value: Uint8Array) => {
-      await this.store(contentType, hash, value)
-    })
   }
 
   abstract store(contentType: any, hashKey: string, value: Uint8Array): Promise<void>

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -296,7 +296,7 @@ export class PortalNetworkUTP extends EventEmitter {
             this.logger.extend(`FINISHED`)(`Missing content...`)
             continue
           } else {
-            this.emit('Stream', k[0], decodedContentKey.blockHash, _content)
+            this.emit(ProtocolId.HistoryNetwork, k[0], decodedContentKey.blockHash, _content)
           }
         }
         break
@@ -312,7 +312,7 @@ export class PortalNetworkUTP extends EventEmitter {
             this.logger.extend(`FINISHED`)(`Missing content...`)
             continue
           } else {
-            this.emit('Stream', k[0], toHexString(k), _content)
+            this.emit(ProtocolId.BeaconLightClientNetwork, k[0], toHexString(k), _content)
           }
         }
         break

--- a/packages/portalnetwork/test/integration/beaconProtocol.spec.ts
+++ b/packages/portalnetwork/test/integration/beaconProtocol.spec.ts
@@ -81,7 +81,7 @@ describe('Find Content tests', () => {
       fromHexString(bootstrap.content_value),
     )
     await new Promise((resolve) => {
-      node2.uTP.on('Stream', async () => {
+      node2.uTP.on(ProtocolId.BeaconLightClientNetwork, async () => {
         const content = await protocol2.findContentLocally(fromHexString(bootstrap.content_key))
         assert.notOk(content === undefined, 'should retrieve content for bootstrap key')
         assert.equal(

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -510,7 +510,7 @@ describe('PortalNetworkUTP test', () => {
     const contentKeys = contentHashes.map((hash) =>
       fromHexString(getContentKey(HistoryNetworkContentType.BlockHeader, fromHexString(hash))),
     )
-    utp.on('Stream', (selector, hash, value) => {
+    utp.on(ProtocolId.HistoryNetwork, (selector, hash, value) => {
       assert.equal(selector, HistoryNetworkContentType.BlockHeader, 'Stream selector correct')
       assert.ok(contentHashes.includes(hash), 'Streamed a requested content hash')
       assert.deepEqual(value, contents[contentHashes.indexOf(hash)], 'Stream content correct')


### PR DESCRIPTION
uTP streams end by emitting a "Stream" event with the compiled content.

While using only 1 network, this was sufficient. 

However, if more than one network is active, the individual subprotocols will each be listening for this `Stream` event, and attempt to process / store any content streamed from uTP.

This PR fixes the issue by changing the `Stream` event.  instead of `Stream`, uTP will emit the protocol id as the event name.

Each subprotocol will listen only for uTP events with its own protocol id.

Note that to do this, the uTP listener setup was moved from the abstract `BaseProtocol` class to the constructors of the individual subprotocols, and each additional sub protocol will need to include this in its constructor.