### PR TITLE
findNodes: remove self enr exclusion

### DIFF
--- a/packages/portalnetwork/src/subprotocols/protocol.ts
+++ b/packages/portalnetwork/src/subprotocols/protocol.ts
@@ -282,8 +282,6 @@ export abstract class BaseProtocol extends EventEmitter {
           nodesPayload.enrs.push(this.enr.toENR().encode())
         } else {
           for (const enr of this.routingTable.valuesOfDistance(distance)) {
-            // Exclude ENR from response if it matches the requesting node
-            if (enr.nodeId === src.nodeId) continue
             // Break from loop if total size of NODES payload would exceed 1200 bytes
             // TODO: Decide what to do about case where we have more ENRs we could send
 


### PR DESCRIPTION
ultralight fails this portal-hive findNodes test:

`node a` is at distance `d` to `node b`
`node a` sends `findNodes` to `node b` for distance `d`
**expected response**: `NODES: [ node_b.enr ]`

ultralight's `handleFindNodes` method was implemented to exclude a node's own `enr` from a `NODES` response.  

this, like other design choices, was made with the assumption that nodes would always choose to `ping/pong` an unknown node before sending another kind of request.  other portal clients were not built with the same assumptions, which became apparent through various **portal-hive** test results.

this fixes the failing portal-hive interop test