### PR TITLE
Catch uncaught exceptions

### DIFF
--- a/.github/workflows/devnet-run.yml
+++ b/.github/workflows/devnet-run.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ${{ github.workspace }}
       
       - run: npx ts-node --esm scripts/devnet.ts --numNodes=10 --ip=127.0.0.1 &
-
+      - run: curl -d {"id":"1","jsonrpc":"2.0","method":"portal_beaconLocalContent","params":["0xb4e2502455def072118cf5849d2243f6bc3cd9a834290fdbb55619fd4e593663"]} http://127.0.0.1:8545 -s -S -v -H "Content-Type: application/json" -H "Accept: application/json, */*"
       - run: |
-          sleep 10 &&
+          sleep 20 &&
           npx ts-node --esm scripts/seeder.ts --rpcPort=8545 --sourceFile="./blocks200000-210000.json" --numBlocks=3 --numNodes=10

--- a/.github/workflows/devnet-run.yml
+++ b/.github/workflows/devnet-run.yml
@@ -37,5 +37,5 @@ jobs:
       - run: npx ts-node --esm scripts/devnet.ts --numNodes=10 --ip=127.0.0.1 &
      
       - run: |
-          sleep 20 &&
+          sleep 10 &&
           npx ts-node --esm scripts/seeder.ts --rpcPort=8545 --sourceFile="./blocks200000-210000.json" --numBlocks=3 --numNodes=10

--- a/.github/workflows/devnet-run.yml
+++ b/.github/workflows/devnet-run.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ${{ github.workspace }}
       
       - run: npx ts-node --esm scripts/devnet.ts --numNodes=10 --ip=127.0.0.1 &
-      - run: curl -d {"id":"1","jsonrpc":"2.0","method":"portal_beaconLocalContent","params":["0xb4e2502455def072118cf5849d2243f6bc3cd9a834290fdbb55619fd4e593663"]} http://127.0.0.1:8545 -s -S -v -H "Content-Type: application/json" -H "Accept: application/json, */*"
+     
       - run: |
           sleep 20 &&
           npx ts-node --esm scripts/seeder.ts --rpcPort=8545 --sourceFile="./blocks200000-210000.json" --numBlocks=3 --numNodes=10

--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -37,7 +37,7 @@ const main = async () => {
   const cmd = 'hostname -I'
   const pubIp = execSync(cmd).toString().split(' ')
   const ip = args.ip ?? pubIp[0]
-  console.log(ip)
+
   let children: ChildProcessByStdio<any, any, null>[] = []
   const file = require.resolve(process.cwd() + '/dist/index.js')
   if (args.pks) {

--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -26,7 +26,7 @@ const args: any = yargs(hideBin(process.argv))
     }).option('port', {
         describe: 'starting port number',
         number: true,
-        default: 8545
+        default: 9000
     }).option('networks', {
       describe: 'supported subnetworks',
       array: true,
@@ -37,6 +37,7 @@ const main = async () => {
   const cmd = 'hostname -I'
   const pubIp = execSync(cmd).toString().split(' ')
   const ip = args.ip ?? pubIp[0]
+  console.log(ip)
   let children: ChildProcessByStdio<any, any, null>[] = []
   const file = require.resolve(process.cwd() + '/dist/index.js')
   if (args.pks) {
@@ -46,11 +47,13 @@ const main = async () => {
         process.execPath,
         [
           file,
+          `--rpc`,
           `--rpcAddr=${ip}`,
           `--pk=${key}`,
           `--rpcPort=${8545 + idx}`,
           `--metrics=true`,
           `--metricsPort=${18545 + idx}`,
+          `--bindAddress-${ip}:${args.port + idx}`,
           args.networks ? `--networks=${(args.networks as Array<string>).join(' ')}` : ''
         ],
         { stdio: ['pipe', 'pipe', process.stderr] }
@@ -67,6 +70,7 @@ const main = async () => {
           `--rpcPort=${8545 + x}`,
           `--metrics=true`,
           `--metricsPort=${18545 + x}`,
+          `--bindAddress=${ip}:${args.port + x}`,
           args.networks ? `--networks=${(args.networks as Array<string>).join(' ')}` : ''
         ],
         { stdio: ['pipe', 'pipe', process.stderr] }

--- a/packages/cli/scripts/seeder.ts
+++ b/packages/cli/scripts/seeder.ts
@@ -56,10 +56,10 @@ type TestClient = {
 const numBlocks = 4
 
 const main = async () => {
-  const ultralight = Client.http({ port: args.rpcPort })
-  const peer1 = Client.http({ port: args.rpcPort + 1 })
-  const peer2 = Client.http({ port: args.rpcPort + 2 })
-  const peer3 = Client.http({ port: args.rpcPort + 3 })
+  const ultralight = Client.http({ port: args.rpcPort, host: '127.0.0.1' })
+  const peer1 = Client.http({ port: args.rpcPort + 1, host: '127.0.0.1' })
+  const peer2 = Client.http({ port: args.rpcPort + 2, host: '127.0.0.1' })
+  const peer3 = Client.http({ port: args.rpcPort + 3, host: '127.0.0.1' })
   const clients = [ultralight, peer1, peer2, peer3]
   const clientInfo: Record<Clients, TestClient> = {
     ultralight: { client: ultralight, enr: '', nodeId: '' },
@@ -183,4 +183,4 @@ const main = async () => {
   await testRes([clients[2]], 'eth_getBlockByNumber', [['0x3e8', false]])
 }
 
-main()
+main().catch(err => console.log(err))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -103,7 +103,7 @@ const main = async () => {
     id = await createFromProtobuf(fromHexString(args.pk))
   }
   const enr = SignableENR.createFromPeerId(id)
-  const initMa: any = multiaddr(`/ip4/${ip}/udp/${bindPort}`)
+  const initMa = multiaddr(`/ip4/${ip}/udp/${bindPort}`)
   enr.setLocationMultiaddr(initMa)
 
   const metrics = setupMetrics()
@@ -222,7 +222,9 @@ const main = async () => {
         }
       },
     })
-    server.http().listen(args.rpcPort ?? 8545, args.rpcAddr ?? '127.0.0.1')
+    const rpcAddr = args.rpcAddr ?? ip
+    const rpcPort = args.rpcPort ?? 8545
+    server.http().listen(rpcPort, rpcAddr)
 
     log(`Started JSON RPC Server address=http://${args.rpcAddr ?? '127.0.0.1'}:${args.rpcPort}`)
 
@@ -246,6 +248,6 @@ const main = async () => {
 }
 
 main().catch((err) => {
-  console.log('Encountered an error', err)
-  console.log('Shutting down...')
+  console.error('Encountered an error', err)
+  console.error('Shutting down...')
 })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -154,6 +154,7 @@ const main = async () => {
 
   portal.enableLog('ultralight,*Portal*')
 
+  const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined
 
   if (args.metrics) {
@@ -161,8 +162,8 @@ const main = async () => {
     Object.entries(metrics).forEach((entry) => {
       register.registerMetric(entry[1])
     })
-    metricsServer?.listen(args.metricsPort)
-    log(`Started Metrics Server address=http://${args.rpcAddr ?? '127.0.0.1'}:${args.metricsPort}`)
+    metricsServer?.listen(args.metricsPort, rpcAddr)
+    log(`Started Metrics Server address=http://${rpcAddr}:${args.metricsPort}`)
   }
 
   process.on('uncaughtException', (err) => {
@@ -222,11 +223,10 @@ const main = async () => {
         }
       },
     })
-    const rpcAddr = args.rpcAddr ?? ip
     const rpcPort = args.rpcPort ?? 8545
     server.http().listen(rpcPort, rpcAddr)
 
-    log(`Started JSON RPC Server address=http://${args.rpcAddr ?? '127.0.0.1'}:${args.rpcPort}`)
+    log(`Started JSON RPC Server address=http://${rpcAddr}:${rpcPort}`)
 
     if (args.trustedBlockRoot !== undefined) {
       const beaconProtocol = portal.protocols.get(


### PR DESCRIPTION
Adds a handler for uncaught exceptions to the global CLI process so the app doesn't crash when discv5 doesn't clean up its errors.