### PR TITLE
Only get IP from OS if not available

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -91,8 +91,9 @@ const reportMetrics = async (req: http.IncomingMessage, res: http.ServerResponse
 
 const main = async () => {
   const cmd = 'hostname -I'
-  const pubIp = execSync(cmd).toString().split(' ')
-  const ip = args.bindAddress ? args.bindAddress.split(':')[0] : pubIp[0].trim()
+  const ip = args.bindAddress
+    ? args.bindAddress.split(':')[0]
+    : execSync(cmd).toString().split(' ')[0].trim()
   const bindPort = args.bindAddress ? args.bindAddress.split(':')[1] : 9000 // Default discv5 port
   const log = debug('ultralight')
   let id: PeerId


### PR DESCRIPTION
Adjusts method call within CLI to only call `hostname -I` if no `bindAddress` is provided.  Fixes a bug in `portal-hive` where the docker image can't run because `hostname -I` isn't available as part of the docker image.