### PR TITLE
Various updates

### DIFF
--- a/packages/browser-client/src/Components/ContentManager.tsx
+++ b/packages/browser-client/src/Components/ContentManager.tsx
@@ -22,7 +22,7 @@ export default function ContentManager() {
           dispatch({
             type: StateChange.SETBLOCK,
             payload: await ethJsBlockToEthersBlockWithTxs(
-              Block.fromRLPSerializedBlock(Buffer.from(fromHexString(last[1].rlp)), {
+              Block.fromRLPSerializedBlock(fromHexString(last[1].rlp), {
                 setHardfork: true,
               }),
             ),

--- a/packages/browser-client/src/Components/DisplayBlock.tsx
+++ b/packages/browser-client/src/Components/DisplayBlock.tsx
@@ -27,6 +27,7 @@ import {
 import React, { useContext, useEffect, useState } from 'react'
 import { AppContext, AppContextType, StateChange } from '../globalReducer'
 import SelectTx from './SelectTx'
+import { bytesToBigInt } from '@ethereumjs/util'
 
 const DisplayBlock = () => {
   const { state, dispatch } = useContext(AppContext as React.Context<AppContextType>)
@@ -98,7 +99,7 @@ const DisplayBlock = () => {
               ) : k === 'extraData' ? (
                 <HStack width="100%">
                   <Text paddingY={0} fontSize={'x-small'} width="50%">
-                    {Buffer.from(fromHexString(v)).toString()}
+                    {v}
                   </Text>
                   <Text paddingY={0} fontSize={'x-small'}>
                     {v}
@@ -181,13 +182,13 @@ const DisplayBlock = () => {
                       ? 'Undefineded for unknown reasons'
                       : typeof value
                     : key === 'coinbase'
-                    ? toHexString((value as any).buf as Buffer)
+                    ? toHexString((value as any).buf as Uint8Array)
                     : typeof value === 'string'
                     ? value
                     : typeof value === 'bigint'
                     ? value
                     : key === 'nonce'
-                    ? BigInt('0x' + (value as Buffer).toString('hex'))
+                    ? bytesToBigInt(value as Uint8Array)
                     : '0x' + (value as any).toString('hex')
                 return key === 'cache' ? (
                   <Box key={key}></Box>
@@ -220,12 +221,10 @@ const DisplayBlock = () => {
   async function init() {
     try {
       const receipts = decodeReceipts(
-        Buffer.from(
-          fromHexString(
-            await state.provider!.historyProtocol.get(
-              ProtocolId.HistoryNetwork,
-              getContentKey(HistoryNetworkContentType.Receipt, fromHexString(state.block!.hash)),
-            ),
+        fromHexString(
+          await state.provider!.historyProtocol.get(
+            ProtocolId.HistoryNetwork,
+            getContentKey(HistoryNetworkContentType.Receipt, fromHexString(state.block!.hash)),
           ),
         ),
       )
@@ -245,15 +244,9 @@ const DisplayBlock = () => {
       typeof (state.block as any).hash === 'string'
         ? (state.block as any).hash
         : toHexString((state.block as any).hash())
-    const header = getContentKey(
-      HistoryNetworkContentType.BlockHeader,
-      Buffer.from(fromHexString(hash)),
-    )
+    const header = getContentKey(HistoryNetworkContentType.BlockHeader, fromHexString(hash))
 
-    const body = getContentKey(
-      HistoryNetworkContentType.BlockBody,
-      Buffer.from(fromHexString(hash)),
-    )
+    const body = getContentKey(HistoryNetworkContentType.BlockBody, fromHexString(hash))
     setKeys({
       header,
       body,

--- a/packages/browser-client/src/Components/Layout.tsx
+++ b/packages/browser-client/src/Components/Layout.tsx
@@ -25,7 +25,7 @@ export default function Layout() {
   }
   async function setSample() {
     const sampleBlock = await ethJsBlockToEthersBlockWithTxs(
-      Block.fromRLPSerializedBlock(Buffer.from(fromHexString(bigblock[0].rlp)), {
+      Block.fromRLPSerializedBlock(fromHexString(bigblock[0].rlp), {
         setHardfork: true,
       }),
     )

--- a/packages/browser-client/src/Components/PortalButtons.tsx
+++ b/packages/browser-client/src/Components/PortalButtons.tsx
@@ -69,7 +69,7 @@ export function PortalButton(props: IPortalButton) {
   }, [blockHash])
 
   const addToOffer = async (type: HistoryNetworkContentType) => {
-    const contentKey = getContentKey(type, Buffer.from(fromHexString(blockHash)))
+    const contentKey = getContentKey(type, fromHexString(blockHash))
     const contentId = getContentId(type, blockHash)
     if (await state.provider?.historyProtocol.get(ProtocolId.HistoryNetwork, contentKey)) {
       setOffer([...offer, contentId])

--- a/packages/browser-client/src/portalClient.ts
+++ b/packages/browser-client/src/portalClient.ts
@@ -8,6 +8,7 @@ import {
   fromHexString,
   TransportLayer,
   UltralightProvider,
+  ProtocolId,
 } from 'portalnetwork'
 import { AppState } from './globalReducer'
 import bns from './bootnodes.json'
@@ -64,16 +65,18 @@ export const startUp = async (provider: UltralightProvider) => {
 }
 export async function createNodeFromScratch(state: AppState): Promise<UltralightProvider> {
   const provider = Capacitor.isNativePlatform()
-    ? await UltralightProvider.create(new ethers.providers.CloudflareProvider(), 1, {
+    ? await UltralightProvider.create('', 1, {
         bootnodes: bns,
         db: state.LDB as any,
         transport: TransportLayer.MOBILE,
+        supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.BeaconLightClientNetwork],
       })
-    : await UltralightProvider.create(new ethers.providers.CloudflareProvider(), 1, {
+    : await UltralightProvider.create('', 1, {
         proxyAddress: state.proxy,
         bootnodes: bns,
         db: state.LDB as any,
         transport: TransportLayer.WEB,
+        supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.BeaconLightClientNetwork],
       })
   await startUp(provider)
   return provider
@@ -81,18 +84,20 @@ export async function createNodeFromScratch(state: AppState): Promise<Ultralight
 
 export async function createNodeFromStorage(state: AppState): Promise<UltralightProvider> {
   const provider = Capacitor.isNativePlatform()
-    ? await UltralightProvider.create(new ethers.providers.CloudflareProvider(), 1, {
+    ? await UltralightProvider.create('', 1, {
         bootnodes: bns,
         db: state.LDB as any,
         rebuildFromMemory: true,
         transport: TransportLayer.MOBILE,
+        supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.BeaconLightClientNetwork],
       })
-    : await UltralightProvider.create(new ethers.providers.CloudflareProvider(), 1, {
+    : await UltralightProvider.create('', 1, {
         proxyAddress: state.proxy,
         bootnodes: bns,
         db: state.LDB as any,
         rebuildFromMemory: true,
         transport: TransportLayer.WEB,
+        supportedProtocols: [ProtocolId.HistoryNetwork, ProtocolId.BeaconLightClientNetwork],
       })
   await startUp(provider)
   return provider

--- a/packages/browser-client/src/portalClient.ts
+++ b/packages/browser-client/src/portalClient.ts
@@ -1,5 +1,4 @@
 import { Capacitor } from '@capacitor/core'
-import { ethers } from 'ethers'
 import {
   ENR,
   log2Distance,

--- a/packages/browser-client/webpack.config.js
+++ b/packages/browser-client/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     },
   },
   module: {
+    exprContextCritical: false,
     rules: [
       {
         test: /\.m?js/,


### PR DESCRIPTION
Grab-bag PR with several cleanup items:
- Removes several unnecessary `Buffer` references in the `browser-client`
- Removes the fallback provider which masks `findContent` failures
- Suppress warning about `blst` dynamic dependency that doesn't apply to browser context
- Updates `beacon` subnetwork to use `signature_slot` when requesting optimistic updates