### PR TITLE
uTP: fix syn id bug

### DIFF
--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -54,11 +54,7 @@ export class ContentRequest {
   }
 
   async sendSyn(): Promise<void> {
-    await this.socket.sendSynPacket(
-      this.requestCode === RequestCode.OFFER_WRITE
-        ? this.socket.sndConnectionId
-        : this.socket.rcvConnectionId,
-    )
+    await this.socket.sendSynPacket(this.socket.sndConnectionId)
     this.socket.state = ConnectionState.SynSent
   }
 }


### PR DESCRIPTION
Reverts change from recent PR.
uTP packet ID numbers were altered in response to hive test failures.
This turned out to be a bug in trin and not actually in ultralight.
This reverts uTP back to spec.