### PR TITLE
uTP: SYN-ACK fix

### DIFF
--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -23,6 +23,7 @@ import {
   UtpSocketKey,
   decodeHistoryNetworkContentKey,
   BeaconLightClientNetworkContentType,
+  ConnectionState,
 } from '../../../index.js'
 import { EventEmitter } from 'events'
 
@@ -190,7 +191,7 @@ export class PortalNetworkUTP extends EventEmitter {
   async _handleStatePacket(request: ContentRequest, packet: StatePacket): Promise<void> {
     switch (request.requestCode) {
       case RequestCode.FINDCONTENT_READ: {
-        if (packet.header.seqNr === request.socket.getSeqNr() - 1) {
+        if (request.socket.state === ConnectionState.SynSent) {
           request.socket.setAckNr(packet.header.seqNr)
           break
         } else {


### PR DESCRIPTION
READ sockets will only receive STATE packets in the form of SYN-ACK during a FINDCONTENT request.
This updates the handler to only expect STATE packet while in connection state: SYN-SENT, rather than comparing the sequence number and ack number.