### PR TITLE
Add `LightClientForkName` enum

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -162,7 +162,9 @@ const main = async () => {
   })
   portal.discv5.enableLogs()
 
-  portal.enableLog('ultralight,*Portal*')
+  portal.enableLog(
+    'ultralight,-uTP,-FINDNODES,*LightClient:DEBUG,*LightClient:INFO,*BeaconLightClientProtocol',
+  )
 
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined

--- a/packages/portalnetwork/src/subprotocols/beacon/types.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/types.ts
@@ -14,11 +14,7 @@ export enum BeaconLightClientNetworkContentType {
   LightClientUpdate = 4, // Added for convenience, not part of the Portal Network Spec
 }
 
-export enum Forks {
-  altair = ForkName.altair,
-  capella = ForkName.capella,
-  deneb = ForkName.deneb,
-}
+export type LightClientForkName = Exclude<ForkName, 'phase0' | 'bellatrix'> // ForkName subset that excludes forks that have no light client changes
 
 // TODO - figure out what a theoretical maximum byte size for a LightClientUpdate is (the `ByteListType`) in the below ssz list
 export const LightClientUpdatesByRange = new ListCompositeType(new ByteListType(2 ** 18), 128)

--- a/packages/portalnetwork/src/subprotocols/beacon/ultralightTransport.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/ultralightTransport.ts
@@ -7,6 +7,7 @@ import {
   BeaconLightClientNetworkContentType,
   LightClientBootstrapKey,
   LightClientFinalityUpdateKey,
+  LightClientForkName,
   LightClientOptimisticUpdateKey,
   LightClientUpdatesByRange,
   LightClientUpdatesByRangeKey,
@@ -54,10 +55,12 @@ export class UltralightTransport implements LightClientTransport {
         const updateRange = LightClientUpdatesByRange.deserialize(decoded as Uint8Array)
         for (const update of updateRange) {
           const forkhash = update.slice(0, 4)
-          const forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as any
+          const forkname = this.protocol.beaconConfig.forkDigest2ForkName(
+            forkhash,
+          ) as LightClientForkName
           range.push({
             version: forkname as ForkName,
-            data: (ssz as any)[forkname].LightClientUpdate.deserialize(update.slice(4)),
+            data: ssz[forkname].LightClientUpdate.deserialize(update.slice(4)),
           })
         }
         return range
@@ -89,8 +92,8 @@ export class UltralightTransport implements LightClientTransport {
     )
     if (decoded !== undefined) {
       const forkhash = decoded.value.slice(0, 4) as Uint8Array
-      forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as ForkName
-      optimisticUpdate = (ssz as any)[forkname].LightClientOptimisticUpdate.deserialize(
+      forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
+      optimisticUpdate = ssz[forkname].LightClientOptimisticUpdate.deserialize(
         (decoded.value as Uint8Array).slice(4),
       )
 
@@ -124,8 +127,8 @@ export class UltralightTransport implements LightClientTransport {
     )
     if (decoded !== undefined) {
       const forkhash = decoded.value.slice(0, 4) as Uint8Array
-      forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as ForkName
-      finalityUpdate = (ssz as any)[forkname].LightClientfinalityUpdate.deserialize(
+      forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
+      finalityUpdate = ssz[forkname].LightClientFinalityUpdate.deserialize(
         (decoded.value as Uint8Array).slice(4),
       )
 
@@ -152,8 +155,10 @@ export class UltralightTransport implements LightClientTransport {
     if (localBootstrap !== undefined && localBootstrap.length !== 0) {
       this.logger('Found LightClientBootstrap locally.  Initializing light client...')
       try {
-        forkname = this.protocol.beaconConfig.forkDigest2ForkName(localBootstrap.slice(0, 4))
-        bootstrap = (ssz as any)[forkname].LightClientBootstrap.deserialize(localBootstrap.slice(4))
+        forkname = this.protocol.beaconConfig.forkDigest2ForkName(
+          localBootstrap.slice(0, 4),
+        ) as LightClientForkName
+        bootstrap = ssz[forkname].LightClientBootstrap.deserialize(localBootstrap.slice(4))
       } catch (err) {
         this.logger('Error loading local bootstrap error')
         this.logger(err)
@@ -175,8 +180,8 @@ export class UltralightTransport implements LightClientTransport {
         )
         if (decoded !== undefined) {
           const forkhash = decoded.value.slice(0, 4) as Uint8Array
-          forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as any
-          bootstrap = (ssz as any)[forkname].LightClientBootstrap.deserialize(
+          forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
+          bootstrap = ssz[forkname].LightClientBootstrap.deserialize(
             (decoded.value as Uint8Array).slice(4),
           )
           break
@@ -201,11 +206,11 @@ export class UltralightTransport implements LightClientTransport {
       if (contentType === BeaconLightClientNetworkContentType.LightClientOptimisticUpdate) {
         const value = hexToBytes(content)
         const forkhash = value.slice(0, 4) as Uint8Array
-        const forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as any
+        const forkname = this.protocol.beaconConfig.forkDigest2ForkName(
+          forkhash,
+        ) as LightClientForkName
         handler(
-          (ssz as any)[forkname].LightClientOptimisticUpdate.deserialize(
-            (value as Uint8Array).slice(4),
-          ),
+          ssz[forkname].LightClientOptimisticUpdate.deserialize((value as Uint8Array).slice(4)),
         )
       }
     })
@@ -215,12 +220,10 @@ export class UltralightTransport implements LightClientTransport {
       if (contentType === BeaconLightClientNetworkContentType.LightClientFinalityUpdate) {
         const value = hexToBytes(content)
         const forkhash = value.slice(0, 4) as Uint8Array
-        const forkname = this.protocol.beaconConfig.forkDigest2ForkName(forkhash) as any
-        handler(
-          (ssz as any)[forkname].LightClientFinalityUpdate.deserialize(
-            (value as Uint8Array).slice(4),
-          ),
-        )
+        const forkname = this.protocol.beaconConfig.forkDigest2ForkName(
+          forkhash,
+        ) as LightClientForkName
+        handler(ssz[forkname].LightClientFinalityUpdate.deserialize((value as Uint8Array).slice(4)))
       }
     })
   }


### PR DESCRIPTION
Partially solves the typing issue related to accessing the `lodestar/types` types specific to Light Client data structures by adding a new `LightClientForkName` enum that can be used to index the `ssz` namespace without having to cast `ForkName` to `any`.