### PR TITLE
Add trustedBlockRoot sync strategy

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -114,6 +114,13 @@ const main = async () => {
   const initMa = multiaddr(`/ip4/${ip}/udp/${bindPort}`)
   enr.setLocationMultiaddr(initMa)
 
+  process.on('uncaughtException', (err) => {
+    // Hack to catch uncaught exceptions that are thrown in async events/functions and aren't caught in
+    // main process (notably a seeming new discv5 bug where certain RPC failures aren't properly handled)
+    log(`Uncaught error: ${err.message}`)
+    log(err)
+  })
+
   const metrics = setupMetrics()
   let db
   if (args.dataDir) {
@@ -163,9 +170,8 @@ const main = async () => {
   portal.discv5.enableLogs()
 
   portal.enableLog(
-    'ultralight,-uTP,-FINDNODES,*LightClient:DEBUG,*LightClient:INFO,*BeaconLightClientProtocol',
+    'ultralight,-uTP,-FINDNODES,*LightClient:DEBUG,*LightClient:INFO,*BeaconLightClientNetwork',
   )
-
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined
 
@@ -178,12 +184,6 @@ const main = async () => {
     log(`Started Metrics Server address=http://${rpcAddr}:${args.metricsPort}`)
   }
 
-  process.on('uncaughtException', (err) => {
-    // Hack to catch uncaught exceptions that are thrown in async events/functions and aren't caught in
-    // main process (notably a seeming new discv5 bug where certain RPC failures aren't properly handled)
-    log(`Uncaught error: ${err.message}`)
-    log(err)
-  })
   await portal.start()
 
   const bootnodes: Array<Enr> = []

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs'
-import { BeaconLightClientNetwork, PortalNetwork, ProtocolId, fromHexString } from 'portalnetwork'
+import { PortalNetwork, ProtocolId, fromHexString } from 'portalnetwork'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import yargs from 'yargs/yargs'
@@ -166,12 +166,14 @@ const main = async () => {
     metrics,
     supportedProtocols: networks,
     dataDir: args.dataDir,
+    trustedBlockRoot: args.trustedBlockRoot,
   })
   portal.discv5.enableLogs()
 
   portal.enableLog(
     'ultralight,-uTP,-FINDNODES,*LightClient:DEBUG,*LightClient:INFO,*BeaconLightClientNetwork',
   )
+
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined
 
@@ -238,14 +240,6 @@ const main = async () => {
     server.http().listen(args.rpcPort, rpcAddr)
 
     log(`Started JSON RPC Server address=http://${rpcAddr}:${args.rpcPort}`)
-
-    if (args.trustedBlockRoot !== undefined) {
-      const beaconProtocol = portal.protocols.get(
-        ProtocolId.BeaconLightClientNetwork,
-      ) as BeaconLightClientNetwork
-      await beaconProtocol.initializeLightClient(args.trustedBlockRoot)
-      beaconProtocol.lightClient?.start()
-    }
   }
 
   process.on('SIGINT', async () => {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -148,6 +148,12 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       const beacon = portal.protocols.get(
         ProtocolId.BeaconLightClientNetwork,
       ) as BeaconLightClientNetwork
+      if (beacon === undefined) {
+        portal.protocols.set(
+          ProtocolId.BeaconLightClientNetwork,
+          new BeaconLightClientNetwork(portal),
+        )
+      }
       await beacon.initializeLightClient(opts.trustedBlockRoot)
     }
 

--- a/packages/portalnetwork/src/subprotocols/beacon/beacon.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/beacon.ts
@@ -17,6 +17,7 @@ import {
   LightClientUpdatesByRange,
   LightClientUpdatesByRangeKey,
   MIN_BOOTSTRAP_VOTES,
+  SyncStrategy,
 } from './types.js'
 import {
   AcceptMessage,
@@ -58,7 +59,14 @@ export class BeaconLightClientNetwork extends BaseProtocol {
   logger: Debugger
   lightClient: Lightclient | undefined
   bootstrapFinder: Map<NodeId, string[] | {}>
-  constructor(client: PortalNetwork, nodeRadius?: bigint) {
+  syncStrategy: SyncStrategy
+  trustedBlockRoot: string | undefined
+  constructor(
+    client: PortalNetwork,
+    nodeRadius?: bigint,
+    trustedBlockRoot?: string,
+    sync?: SyncStrategy,
+  ) {
     super(client, nodeRadius)
     // This config is used to identify the Beacon Chain fork any given light client update is from
     const genesisRoot = hexToBytes(genesisData.mainnet.genesisValidatorsRoot)
@@ -88,13 +96,71 @@ export class BeaconLightClientNetwork extends BaseProtocol {
       }
     })
 
-    this.bootstrapFinder = new Map()
-    this.portal.on('NodeAdded', this.getBootStrapVote)
+    // If a sync strategy is not provided, determine sync strategy based on existence of trusted block root
+    this.syncStrategy =
+      sync ?? trustedBlockRoot ? SyncStrategy.TrustedBlockRoot : SyncStrategy.PollNetwork
+    switch (this.syncStrategy) {
+      case SyncStrategy.PollNetwork:
+        this.bootstrapFinder = new Map()
+        this.portal.on('NodeAdded', this.getBootStrapVote)
+        break
+      case SyncStrategy.TrustedBlockRoot:
+        if (trustedBlockRoot === undefined)
+          throw new Error('must provided trusted block root with SyncStrategy.TrustedBlockRoot')
+        this.bootstrapFinder = new Map()
+        this.trustedBlockRoot = trustedBlockRoot
+        this.portal.on('NodeAdded', this.getBootstrap)
+        break
+    }
   }
 
+  /**
+   * This is the private method employed by the sync strategy whereby we try to find
+   * the `LightClientBootstrap` corresponding to the `trustedBlockRoot` provided when the
+   * BeaconLightClientNetwork was instantiated
+   * @param nodeId NodeId for a peer that was just discovered by the Portal Network `client`
+   * @param protocol the protocol ID for the node just discovered
+   */
+  private getBootstrap = async (nodeId: string, protocol: ProtocolId) => {
+    // We check the protocol ID because NodeAdded is emitted regardless of protocol
+    if (protocol !== ProtocolId.BeaconLightClientNetwork) return
+    const decoded = await this.sendFindContent(
+      nodeId,
+      concatBytes(
+        new Uint8Array([BeaconLightClientNetworkContentType.LightClientBootstrap]),
+        LightClientBootstrapKey.serialize({ blockHash: hexToBytes(this.trustedBlockRoot!) }),
+      ),
+    )
+    if (decoded !== undefined) {
+      const forkhash = decoded.value.slice(0, 4) as Uint8Array
+      const forkname = this.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
+      const bootstrap = ssz[forkname].LightClientBootstrap.deserialize(
+        (decoded.value as Uint8Array).slice(4),
+      )
+      const headerHash = bytesToHex(
+        ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
+      )
+      if (headerHash === this.trustedBlockRoot) {
+        void this.initializeLightClient(headerHash)
+        this.portal.removeListener('NodeAdded', this.getBootstrap)
+      }
+    }
+  }
+
+  /**
+   * This is the private method employed by the sync strategy whereby we try to identify a
+   * reliable starting point for starting our CL Light Client sync by polling newly found
+   * Portal Network nodes for their last three Light Client updates (corresponding to the
+   * 3 most recent sync periods).  Once we reach a minimum number of acceptable of votes, we
+   * determine a trusted block root based on the finalized header root with the most "votes"
+   * (i.e. appearances in peer responses) and try to start our sync from that point.
+   * @param nodeId NodeId for a peer that was just discovered by the Portal Network `client`
+   * @param protocol the protocol ID for the node just discovered
+   */
   private getBootStrapVote = async (nodeId: string, protocol: ProtocolId) => {
     try {
       if (protocol === ProtocolId.BeaconLightClientNetwork) {
+        // We check the protocol ID because NodeAdded is emitted regardless of protocol
         if (this.bootstrapFinder.has(nodeId)) {
           return
         }

--- a/packages/portalnetwork/src/subprotocols/beacon/types.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/types.ts
@@ -33,3 +33,8 @@ export const LightClientFinalityUpdateKey = new ContainerType({
 export const LightClientOptimisticUpdateKey = new ContainerType({
   optimisticSlot: new UintBigintType(8),
 })
+
+export enum SyncStrategy {
+  TrustedBlockRoot,
+  PollNetwork,
+}


### PR DESCRIPTION
Adds a new light client syncing strategy that used a `trustedBlockRoot` provided at protocol instantiation 