### PR TITLE
history.addBlockBody  -- disable automatic receipt building

### DIFF
--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -228,9 +228,11 @@ export class HistoryProtocol extends BaseProtocol {
     const bodyContentKey = getContentKey(HistoryNetworkContentType.BlockBody, hexToBytes(hashKey))
     if (block instanceof Block) {
       this.put(this.protocolId, bodyContentKey, toHexString(value))
-      if (block.transactions.length > 0) {
-        await this.saveReceipts(block)
-      }
+      // TODO: Decide when and if to build and store receipts.
+      //       Doing this here caused a bottleneck when same receipt is gossiped via uTP at the same time.
+      // if (block.transactions.length > 0) {
+      //   await this.saveReceipts(block)
+      // }
     } else {
       this.logger(`Could not verify block content`)
       this.logger(`Adding anyway for testing...`)


### PR DESCRIPTION
Ultralight currently creates a receipt whenever it receives a new block body.  

```ts
      if (block.transactions.length > 0) {
         await this.saveReceipts(block)
       }
```


This becomes problematic when the same receipt is simultaneously being received via network gossip.

Quick fix:  
  - Building receipts is not essential portal client behavior, and can be skipped entirely.
  - Maybe something that only happens on command when needed.
  - This may be a task that only bridge nodes need to perform.