### PR TITLE
State-network-methods

### DIFF
--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -34,7 +34,7 @@ const args: any = yargs(hideBin(process.argv))
   }).option('networks', {
     describe: 'supported subnetworks',
     array: true,
-    default: ['history', 'beacon'],
+    default: ['history', 'beacon', 'state'],
     optional: true
   }).option('connectNodes', {
     describe: 'connet all nodes on network start',

--- a/packages/cli/scripts/statenetworkTest.ts
+++ b/packages/cli/scripts/statenetworkTest.ts
@@ -1,0 +1,67 @@
+import { execSync } from 'child_process'
+import jayson, { HttpClient } from 'jayson/promise/index.js'
+
+const { Client } = jayson
+
+const contentKey =
+  '0xb8ffc3cd6e7cf5a098a1c92f48009765b24088dcad272b45f9bf4e9ff2aa9832cdcf51288571ee0ca3bcbd041a73e61adeb2b2547ba205cbc5c4dcd6c48c7613e78d97637a082197a0829b7e8fc5d0b05a0b7471'
+
+const content =
+  '0x2400000017144556fd3424edc8fc8a4c940b2d04936d17eb0000000000000000000000000c00000080010000f3010000f9017180a0ff159d1e61f5242a84d88017baf33f1666fb372b097c3f5e68c231dec1a34af2a016d5a4dd80706fd859f90ad638ed136b441af8c4af767ad65d511c8778225dc18080a0165c9b93ace495cb76b9081facacc75c12aa05d2341a7731fc45834d744a8821a0f507e0c0d8e5c0c9b1c096288ad5ab9ee8c959dc3f04aa54d3ced6e4d056a3dda066281fb0cb9f8e39d501b372d6e24d079f99f7b79863827dc388e1245d806d87a0692c066ea2f71bee3d24a093c3f2f4deabcec5310d7fef0241bff7ed2052fd2ea0c42ea48381de9c57199a8cd341c9261f3674c67eaf7ed794f3e840a56864c571a091c281f6d9094f4245271a459f7ff9ca3d0526e7e2ab23b670b6d7c1f8a03025a0f49ab5e02ef9fd3b5b8a26ddb56a54efd8a59b59772a3760cb00203485289e6da0bc59f1e7f4f14a8f089b79d091dec5b44ceae5d84a4a66406457f654877ccf8c80a004ef8086c3f830c351ffad0ab6021cf7200933f102c86111189dc24d61b36eb28080f8718080808080a0ffbb1115c71eaf3e19e1362f958db465ccd49dbef8bc3aa3d5b6ed262ec3849da0fb4aeed8b91d4ad9a4dbf05e6cedd3940cb0ec9ea42d3196b1c9a70201ccaaa980808080a0db8149f325d7a80b38cdd58c81db5c6288a908f7d9686e06e855b93725679c488080808080f7a0208b532707259da8a2ff648515124a594268fff6ef66e594ea1261396db28767959417144556fd3424edc8fc8a4c940b2d04936d17eb'
+
+const test = async () => {
+  const cmd = 'hostname -I'
+  const pubIp = execSync(cmd).toString().split(' ')
+  const ip = pubIp[0]
+  const ultralights: HttpClient[] = []
+  const enrs: string[] = []
+  const nodeIds: string[] = []
+  for (let i = 0; i < 2; i++) {
+    const ultralight = Client.http({ host: ip, port: 8545 + i })
+    const ultralightENR = await ultralight.request('discv5_nodeInfo', [])
+    ultralights.push(ultralight)
+    enrs.push(ultralightENR.result.enr)
+    nodeIds.push(ultralightENR.result.nodeId)
+  }
+
+  const stored = await ultralights[0].request('portal_stateStore', [contentKey, content])
+  console.log({ stored })
+
+  const retrieved = await ultralights[0].request('portal_stateLocalContent', [contentKey])
+  console.log({ retrieved })
+
+  const ping = await ultralights[0].request('portal_statePing', [enrs[1]])
+  console.log({ ping })
+  if (ping.result) {
+    const peers = await ultralights[0].request('portal_stateRoutingTableInfo', [])
+    console.log(
+      'Enr Added: ',
+      peers.result.buckets.flat().includes(nodeIds[1].slice(2))
+        ? 'pass'
+        : { expected: nodeIds[1], peers: peers.result.buckets.flat() }
+    )
+  }
+
+    const findContent = await ultralights[1].request('portal_stateFindContent', [enrs[0], contentKey])
+    console.log({ findContent })
+
+//   const offerContent = await ultralights[0].request('portal_stateOffer', [
+//     enrs[1],
+//     contentKey,
+//     content,
+//   ])
+
+//   console.log({ offerContent })
+
+  await new Promise((res) => {
+    console.log('wait')
+    setTimeout(() => {
+        console.log('waited')
+      res(undefined)
+    }, 1000)
+  })
+
+  const received = await ultralights[1].request('portal_stateLocalContent', [contentKey])
+  console.log({ received })
+}
+test()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -149,6 +149,9 @@ const main = async () => {
         case 'beacon':
           networks.push(ProtocolId.BeaconLightClientNetwork)
           break
+        case 'state':
+          networks.push(ProtocolId.StateNetwork)
+          break
       }
     }
   } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -176,7 +176,7 @@ const main = async () => {
   // portal.enableLog(
   //  'ultralight,-FINDNODES,*LightClient:DEBUG,*LightClient:INFO,*BeaconLightClientNetwork,*BOOTSTRAP,*OFFER,*ACCEPT,*FINDCONTENT,*FOUNDCONTENT,*uTP:FINISHED',
   //  )
-  portal.enableLog('*Portal*,uTP*,ultralight')
+  portal.enableLog('*RPC*, *ultralight*, *Portal*')
 
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined
@@ -236,7 +236,11 @@ const main = async () => {
             else return res.error
           })
         } else {
-          log(`Received ${method} with params: ${JSON.stringify(params)}`)
+          log(
+            `Received ${method} with params: ${(params as any[]).map((p, idx) => {
+              return `${idx}: ${p.toString().slice(0, 64)}${p.toString().length > 64 ? '...' : ''}`
+            })}`,
+          )
           return this.getMethod(method)
         }
       },

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -22,6 +22,7 @@ import {
   FoundContent,
   BeaconLightClientNetwork,
   BeaconLightClientNetworkContentType,
+  StateProtocol,
 } from 'portalnetwork'
 import { GetEnrResult } from '../schema/types.js'
 import { isValidId } from '../util.js'
@@ -69,6 +70,7 @@ export class portal {
   private _client: PortalNetwork
   private _history: HistoryProtocol
   private _beacon: BeaconLightClientNetwork
+  private _state: StateProtocol
   private logger: Debugger
 
   constructor(client: PortalNetwork, logger: Debugger) {
@@ -77,6 +79,7 @@ export class portal {
     this._beacon = this._client.protocols.get(
       ProtocolId.BeaconLightClientNetwork,
     ) as BeaconLightClientNetwork
+    this._state = this._client.protocols.get(ProtocolId.StateNetwork) as StateProtocol
     this.logger = logger
     this.methods = middleware(this.methods.bind(this), 0, [])
     this.historyNodeInfo = middleware(this.historyNodeInfo.bind(this), 0, [])

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -30,6 +30,7 @@ import { middleware, validators } from '../validators.js'
 import { Multiaddr } from '@multiformats/multiaddr'
 
 const methods = [
+  'portal_stateRoutingTableInfo',
   'portal_stateStore',
   // history
   'portal_historyRoutingTableInfo',
@@ -83,6 +84,7 @@ export class portal {
     this.logger = logger
     this.methods = middleware(this.methods.bind(this), 0, [])
     this.historyNodeInfo = middleware(this.historyNodeInfo.bind(this), 0, [])
+    this.stateRoutingTableInfo = middleware(this.stateRoutingTableInfo.bind(this), 0, [])
     this.historyRoutingTableInfo = middleware(this.historyRoutingTableInfo.bind(this), 0, [])
     this.historyLookupEnr = middleware(this.historyLookupEnr.bind(this), 1, [[validators.dstId]])
     this.historyAddBootNode = middleware(this.historyAddBootNode.bind(this), 1, [[validators.enr]])
@@ -275,6 +277,24 @@ export class portal {
     let localNodeId = ''
     let buckets: string[][] = []
     const table = this._history.routingTable
+    try {
+      localNodeId = table.localId
+      buckets = table.buckets
+        .map((bucket) => bucket.values().map((value) => value.nodeId))
+        .reverse()
+    } catch (err) {
+      localNodeId = (err as any).message
+    }
+    return {
+      localNodeId: localNodeId,
+      buckets: buckets,
+    }
+  }
+  async stateRoutingTableInfo(_params: []): Promise<any> {
+    this.logger(`portal_stateRoutingTableInfo request received.`)
+    let localNodeId = ''
+    let buckets: string[][] = []
+    const table = this._state.routingTable
     try {
       localNodeId = table.localId
       buckets = table.buckets

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -33,6 +33,7 @@ const methods = [
   'portal_stateRoutingTableInfo',
   'portal_stateStore',
   'portal_stateLocalContent',
+  'portal_stateGossip',
   // history
   'portal_historyRoutingTableInfo',
   'portal_historyAddEnr',
@@ -156,6 +157,10 @@ export class portal {
     ])
     this.historyGossip = middleware(this.historyGossip.bind(this), 2, [
       [validators.contentKey],
+      [validators.hex],
+    ])
+    this.stateGossip = middleware(this.stateGossip.bind(this), 2, [
+      [validators.hex],
       [validators.hex],
     ])
     this.beaconSendFindContent = middleware(this.beaconSendFindContent.bind(this), 2, [
@@ -603,6 +608,12 @@ export class portal {
     const [contentKey, content] = params
     this.logger(`historyGossip request received for ${contentKey}`)
     const res = await this._history.gossipContent(fromHexString(contentKey), fromHexString(content))
+    return res
+  }
+  async stateGossip(params: [string, string]) {
+    const [contentKey, content] = params
+    this.logger(`stateGossip request received for ${contentKey}`)
+    const res = await this._state.gossipContent(fromHexString(contentKey), fromHexString(content))
     return res
   }
   async historyStore(params: [string, string]) {

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -32,6 +32,7 @@ import { Multiaddr } from '@multiformats/multiaddr'
 const methods = [
   'portal_stateRoutingTableInfo',
   'portal_stateStore',
+  'portal_stateLocalContent',
   // history
   'portal_historyRoutingTableInfo',
   'portal_historyAddEnr',
@@ -123,6 +124,7 @@ export class portal {
     this.historyLocalContent = middleware(this.historyLocalContent.bind(this), 1, [
       [validators.hex],
     ])
+    this.stateLocalContent = middleware(this.stateLocalContent.bind(this), 1, [[validators.hex]])
     this.historyStore = middleware(this.historyStore.bind(this), 2, [
       [validators.contentKey],
       [validators.hex],
@@ -439,6 +441,15 @@ export class portal {
     const res = await this._history.findContentLocally(fromHexString(contentKey))
     this.logger.extend(`historyLocalContent`)(`request returned ${res.length} bytes`)
     this.logger.extend(`historyLocalContent`)(`${toHexString(res)}`)
+    return res.length > 0 ? toHexString(res) : '0x'
+  }
+  async stateLocalContent(params: [string]): Promise<string | undefined> {
+    const [contentKey] = params
+    this.logger(`Received stateLocalContent request for ${contentKey}`)
+
+    const res = await this._state.findContentLocally(fromHexString(contentKey))
+    this.logger.extend(`stateLocalContent`)(`request returned ${res.length} bytes`)
+    this.logger.extend(`stateLocalContent`)(`${toHexString(res)}`)
     return res.length > 0 ? toHexString(res) : '0x'
   }
   async historyFindContent(params: [string, string]) {

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -29,6 +29,8 @@ import { middleware, validators } from '../validators.js'
 import { Multiaddr } from '@multiformats/multiaddr'
 
 const methods = [
+  'portal_stateStore',
+  // history
   'portal_historyRoutingTableInfo',
   'portal_historyAddEnr',
   'portal_historyGetEnr',
@@ -118,6 +120,10 @@ export class portal {
     ])
     this.historyStore = middleware(this.historyStore.bind(this), 2, [
       [validators.contentKey],
+      [validators.hex],
+    ])
+    this.stateStore = middleware(this.stateStore.bind(this), 2, [
+      [validators.hex],
       [validators.hex],
     ])
     this.historyFindContent = middleware(this.historyFindContent.bind(this), 2, [
@@ -575,6 +581,17 @@ export class portal {
       )
       return true
     } catch {
+      return false
+    }
+  }
+  async stateStore(params: [string, string]) {
+    const [contentKey, content] = params
+    try {
+      await this._state.stateStore(contentKey, content)
+      this.logger(`stored ${contentKey} in state network db`)
+      return true
+    } catch {
+      this.logger(`stateStore failed for ${contentKey}`)
       return false
     }
   }

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -2,6 +2,8 @@ import debug, { Debugger } from 'debug'
 import { PortalNetwork } from '../../client/client.js'
 import { BaseProtocol } from '../protocol.js'
 import { ProtocolId } from '../types.js'
+import { toHexString } from '@chainsafe/ssz'
+import { hexToBytes } from '@ethereumjs/util'
 
 export class StateProtocol extends BaseProtocol {
   protocolId: ProtocolId.StateNetwork
@@ -18,6 +20,10 @@ export class StateProtocol extends BaseProtocol {
     return undefined
   }
 
+  public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array> => {
+    const value = await this.retrieve(toHexString(contentKey))
+    return value ? hexToBytes(value) : hexToBytes('0x')
+  }
 
   public routingTableInfo = async () => {
     return {

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -3,7 +3,19 @@ import { PortalNetwork } from '../../client/client.js'
 import { BaseProtocol } from '../protocol.js'
 import { ProtocolId } from '../types.js'
 import { toHexString } from '@chainsafe/ssz'
-import { hexToBytes } from '@ethereumjs/util'
+import { bytesToInt, hexToBytes } from '@ethereumjs/util'
+import { ENR } from '@chainsafe/discv5'
+import { shortId } from '../../util/util.js'
+import { RequestCode } from '../../wire/index.js'
+import {
+  FindContentMessage,
+  PortalWireMessageType,
+  MessageCodes,
+  ContentMessageType,
+  FoundContent,
+} from '../../wire/types.js'
+import { decodeHistoryNetworkContentKey } from '../history/util.js'
+import { StateNetworkContentType } from './types.js'
 
 export class StateProtocol extends BaseProtocol {
   protocolId: ProtocolId.StateNetwork
@@ -14,10 +26,82 @@ export class StateProtocol extends BaseProtocol {
     this.protocolId = ProtocolId.StateNetwork
     this.logger = debug(this.enr.nodeId.slice(0, 5)).extend('Portal').extend('StateNetwork')
     this.routingTable.setLogger(this.logger)
+    client.uTP.on(ProtocolId.StateNetwork, async (contentKey: Uint8Array, content: Uint8Array) => {
+      await this.stateStore(toHexString(contentKey), toHexString(content))
+    })
   }
 
-  public sendFindContent = async (_dstId: string, _key: Uint8Array) => {
-    return undefined
+  /**
+   * Send FINDCONTENT request for content corresponding to `key` to peer corresponding to `dstId`
+   * @param dstId node id of peer
+   * @param key content key defined by the subprotocol spec
+   * @returns the value of the FOUNDCONTENT response or undefined
+   */
+  public sendFindContent = async (dstId: string, key: Uint8Array) => {
+    const enr = dstId.startsWith('enr:')
+      ? ENR.decodeTxt(dstId)
+      : this.routingTable.getWithPending(dstId)?.value
+      ? this.routingTable.getWithPending(dstId)?.value
+      : this.routingTable.getWithPending(dstId.slice(2))?.value
+    if (!enr) {
+      this.logger(`No ENR found for ${shortId(dstId)}.  FINDCONTENT aborted.`)
+      return
+    }
+    this.metrics?.findContentMessagesSent.inc()
+    const findContentMsg: FindContentMessage = { contentKey: key }
+    const payload = PortalWireMessageType.serialize({
+      selector: MessageCodes.FINDCONTENT,
+      value: findContentMsg,
+    })
+    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(dstId)}`)
+    const res = await this.sendMessage(enr, payload, this.protocolId)
+    if (res.length === 0) {
+      return undefined
+    }
+
+    try {
+      if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
+        this.metrics?.contentMessagesReceived.inc()
+        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(dstId)}`)
+        const decoded = ContentMessageType.deserialize(res.subarray(1))
+        const contentKey = decodeHistoryNetworkContentKey(toHexString(key))
+        const contentHash = contentKey.blockHash
+        const contentType = contentKey.contentType
+
+        switch (decoded.selector) {
+          case FoundContent.UTP: {
+            const id = new DataView((decoded.value as Uint8Array).buffer).getUint16(0, false)
+            this.logger.extend('FOUNDCONTENT')(`received uTP Connection ID ${id}`)
+            await this.handleNewRequest({
+              protocolId: this.protocolId,
+              contentKeys: [key],
+              peerId: dstId,
+              connectionId: id,
+              requestCode: RequestCode.FINDCONTENT_READ,
+              contents: [],
+            })
+            break
+          }
+          case FoundContent.CONTENT:
+            this.logger(
+              `received ${StateNetworkContentType[contentType]} content corresponding to ${contentHash}`,
+            )
+            try {
+              await this.stateStore(toHexString(key), toHexString(decoded.value as Uint8Array))
+            } catch {
+              this.logger('Error adding content to DB')
+            }
+            break
+          case FoundContent.ENRS: {
+            this.logger(`received ${decoded.value.length} ENRs`)
+            break
+          }
+        }
+        return decoded
+      }
+    } catch (err: any) {
+      this.logger(`Error sending FINDCONTENT to ${shortId(dstId)} - ${err.message}`)
+    }
   }
 
   public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array> => {
@@ -28,7 +112,7 @@ export class StateProtocol extends BaseProtocol {
   public routingTableInfo = async () => {
     return {
       nodeId: this.enr.nodeId,
-      buckets: [['']],
+      buckets: this.routingTable.buckets.map((bucket) => bucket.values().map((enr) => enr.nodeId)),
     }
   }
 

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -18,8 +18,9 @@ export class StateProtocol extends BaseProtocol {
     return undefined
   }
 
-  public findContentLocally = async (_contentKey: Uint8Array): Promise<Uint8Array | undefined> => {
-    return undefined
+  public stateStore = async (contentKey: string, content: string) => {
+    this.put(ProtocolId.StateNetwork, contentKey, content)
+    this.logger(`content added for: ${contentKey}`)
   }
 
   public store = async () => {}

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -18,6 +18,14 @@ export class StateProtocol extends BaseProtocol {
     return undefined
   }
 
+
+  public routingTableInfo = async () => {
+    return {
+      nodeId: this.enr.nodeId,
+      buckets: [['']],
+    }
+  }
+
   public stateStore = async (contentKey: string, content: string) => {
     this.put(ProtocolId.StateNetwork, contentKey, content)
     this.logger(`content added for: ${contentKey}`)

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -24,6 +24,7 @@ import {
   decodeHistoryNetworkContentKey,
   BeaconLightClientNetworkContentType,
   ConnectionState,
+  StateNetworkContentType,
 } from '../../../index.js'
 import { EventEmitter } from 'events'
 
@@ -314,6 +315,22 @@ export class PortalNetworkUTP extends EventEmitter {
             continue
           } else {
             this.emit(ProtocolId.BeaconLightClientNetwork, k[0], toHexString(k), _content)
+          }
+        }
+        break
+      case ProtocolId.StateNetwork:
+        for (const [idx, k] of keys.entries()) {
+          const _content = contents[idx]
+          this.logger.extend(`FINISHED`)(
+            `${idx + 1}/${keys.length} -- (${_content.length} bytes) sending ${
+              StateNetworkContentType[k[0]]
+            } to database`,
+          )
+          if (_content.length === 0) {
+            this.logger.extend(`FINISHED`)(`Missing content...`)
+            continue
+          } else {
+            this.emit(ProtocolId.StateNetwork, k, _content)
           }
         }
         break


### PR DESCRIPTION
Implements naive solutions to state network rpc methods.  Implementing without any State Network specific designs.  Just naively activating methods for a StateNetwork client to behave like a HistoryNetwork client, storing and gossiping raw data.

This set of portal_state endpoints should be enough to build upon:

- [x] portal_statePing 
- [x] portal_stateRoutingTableInfo
- [x] portal_stateStore
- [x] portal_stateLocalContent
- [x] portal_stateGossip
- [x] portal_stateFindContent
- [x] portal_stateRecursiveFindContent
- [x] portal_stateOffer
- [x] portal_stateSendOffer
