### PR TITLE
Logging cleanup

### DIFF
--- a/packages/cli/scripts/beaconBridge.ts
+++ b/packages/cli/scripts/beaconBridge.ts
@@ -14,7 +14,7 @@ const { Client } = jayson
 const main = async () => {
     const beaconConfig = createBeaconConfig(defaultChainConfig, hexToBytes(genesisData.mainnet.genesisValidatorsRoot))
     const capellaForkDigest = beaconConfig.forkName2ForkDigest(ForkName.capella)
-    const beaconNode = 'https://lodestar-mainnet.chainsafe.io/'
+    const beaconNode = 'http://testing.mainnet.beacon-api.nimbus.team/'
     const ultralight = Client.http({ host: '127.0.0.1', port: 8545 })
 
     console.log('Retrieving bootstrap and updates from Beacon node...')

--- a/packages/portalnetwork/src/subprotocols/beacon/beacon.ts
+++ b/packages/portalnetwork/src/subprotocols/beacon/beacon.ts
@@ -363,6 +363,13 @@ export class BeaconLightClientNetwork extends BaseProtocol {
         break
       case BeaconLightClientNetworkContentType.LightClientFinalityUpdate:
         key = LightClientFinalityUpdateKey.deserialize(contentKey.slice(1))
+        this.logger.extend('FINDLOCALLY')(
+          `looking for finality update for slot - ${
+            key.finalitySlot
+          } and local finalized update is for slot - ${
+            this.lightClient?.getFinalized().beacon.slot ?? 'unavailable'
+          }`,
+        )
         if (
           this.lightClient !== undefined &&
           key.finalitySlot <= BigInt(this.lightClient.getFinalized().beacon.slot)

--- a/packages/portalnetwork/src/subprotocols/history/history.ts
+++ b/packages/portalnetwork/src/subprotocols/history/history.ts
@@ -116,7 +116,7 @@ export class HistoryProtocol extends BaseProtocol {
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })
-    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(dstId)}`)
+    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr)}`)
     const res = await this.sendMessage(enr, payload, this.protocolId)
     if (res.length === 0) {
       return undefined
@@ -125,7 +125,7 @@ export class HistoryProtocol extends BaseProtocol {
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
         this.metrics?.contentMessagesReceived.inc()
-        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(dstId)}`)
+        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         const contentKey = decodeHistoryNetworkContentKey(toHexString(key))
         const contentHash = contentKey.blockHash
@@ -163,7 +163,7 @@ export class HistoryProtocol extends BaseProtocol {
         return decoded
       }
     } catch (err: any) {
-      this.logger(`Error sending FINDCONTENT to ${shortId(dstId)} - ${err.message}`)
+      this.logger(`Error sending FINDCONTENT to ${shortId(enr)} - ${err.message}`)
     }
   }
 

--- a/packages/portalnetwork/src/subprotocols/nodeLookup.ts
+++ b/packages/portalnetwork/src/subprotocols/nodeLookup.ts
@@ -76,9 +76,10 @@ export class NodeLookup {
     }
     newPeers.length > 0 &&
       this.log(
-        `finished node lookup for ${shortId(this.nodeSought)} and found ${
-          newPeers.length
-        } new peers`,
+        `finished node lookup for ${shortId(
+          this.nodeSought,
+          this.protocol.routingTable,
+        )} and found ${newPeers.length} new peers`,
       )
     for await (const enr of newPeers) {
       // Add all newly found peers to the subprotocol routing table

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -53,7 +53,7 @@ export class StateProtocol extends BaseProtocol {
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })
-    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(dstId)}`)
+    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr)}`)
     const res = await this.sendMessage(enr, payload, this.protocolId)
     if (res.length === 0) {
       return undefined
@@ -62,7 +62,7 @@ export class StateProtocol extends BaseProtocol {
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
         this.metrics?.contentMessagesReceived.inc()
-        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(dstId)}`)
+        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         const contentKey = decodeHistoryNetworkContentKey(toHexString(key))
         const contentHash = contentKey.blockHash
@@ -100,7 +100,7 @@ export class StateProtocol extends BaseProtocol {
         return decoded
       }
     } catch (err: any) {
-      this.logger(`Error sending FINDCONTENT to ${shortId(dstId)} - ${err.message}`)
+      this.logger(`Error sending FINDCONTENT to ${shortId(enr)} - ${err.message}`)
     }
   }
 

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -6,24 +6,27 @@ import { toBigIntBE, toBufferBE } from 'bigint-buffer'
 import { promises as fs } from 'fs'
 
 import * as path from 'path'
+import { PortalNetworkRoutingTable } from '../client'
 
 export const MEGABYTE = 1048576
 
 /**
  *  Shortens a Node ID to a readable length
  */
-export const shortId = (nodeId: string | ENR) => {
-  if (typeof nodeId === 'string')
-    return nodeId.slice(0, 5) + '...' + nodeId.slice(nodeId.length - 5)
-  const nodeType = nodeId.kvs.get('c')
+export const shortId = (nodeId: string | ENR, routingTable?: PortalNetworkRoutingTable) => {
+  let enr
+  if (typeof nodeId === 'string') {
+    enr = routingTable?.getWithPending(nodeId)
+    if (enr === undefined) return nodeId.slice(0, 5) + '...' + nodeId.slice(nodeId.length - 5)
+    enr = enr.value
+  } else {
+    enr = nodeId
+  }
+
+  const nodeType = enr.kvs.get('c')
   const nodeTypeString =
     nodeType !== undefined && nodeType.length > 0 ? `${bytesToUtf8(nodeType)}:` : ''
-  return (
-    nodeTypeString +
-    nodeId.nodeId.slice(0, 5) +
-    '...' +
-    nodeId.nodeId.slice(nodeId.nodeId.length - 5)
-  )
+  return nodeTypeString + enr.nodeId.slice(0, 5) + '...' + enr.nodeId.slice(enr.nodeId.length - 5)
 }
 
 /**


### PR DESCRIPTION
Begins work on #490 
- Adds `routingTable` as optional parameter to `shortId`
- Updates all current calls to `shortId` to use the routing table where applicable
- Adds some additional logging in `BeaconLightClientNetwork` when doing different things