### PR TITLE
chore: add province false to docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           push: ${{ github.event.name == 'schedule' }}
           tags: ghcr.io/${{ github.repository_owner }}/ultralight:latest
-  
+          provenance: false


### PR DESCRIPTION
Province is currently on and this is causing
```nim
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 2201,
         "digest": "sha256:dc619ad32dd5ac9afee36495d5f4fa683e3af6af26c0288cc52bcf347ce160e0",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:e31579f8e5e6e75cbafbbd1e339c77235d04ecc4adbd4b3ee28c8eab2560847d",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}

```

"unknown" to be added

Which is apparently causing
``{"errors":[{"code":"MANIFEST_UNKNOWN","message":"OCI index found, but Accept header does not support OCI indexes"}]}``


I found a proposed solution here
https://github.com/docker/buildx/issues/1509#issuecomment-1378454396

Which is what I added