### PR TITLE
chore: update Dockerfile to create 3 layers instead of 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,11 @@ RUN npm i --omit-dev
 
 LABEL org.opencontainers.image.source=https://github.com/acolytec3/ultralight
 
-FROM node:18-alpine
-WORKDIR /ultralight
-RUN apk update && apk add --no-cache bash && rm -rf /var/cache/apk/*
-COPY --from=BUILD_IMAGE /ultralight/node_modules ./node_modules
-COPY --from=BUILD_IMAGE /ultralight/packages/portalnetwork ./packages/portalnetwork
-COPY --from=BUILD_IMAGE /ultralight/packages/cli ./packages/cli
-COPY --from=BUILD_IMAGE /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+FROM ubuntu:23.04
+RUN apt update && apt-get install nodejs musl-dev -y && ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
+COPY --from=BUILD_IMAGE ./ultralight ./ultralight
 ENV BINDADDRESS=
 ENV RPCPORT=
 ENV PK=
 
-ENTRYPOINT node packages/cli/dist/index.js --bindAddress=BINDADDRESS --rpcPort=RPCPORT
+ENTRYPOINT node ultralight/packages/cli/dist/index.js --bindAddress=BINDADDRESS --rpcPort=RPCPORT


### PR DESCRIPTION
![image](https://github.com/ethereumjs/ultralight/assets/31669092/32741109-dfaf-4880-8489-68f12099af69)
How it was before ^

![image](https://github.com/ethereumjs/ultralight/assets/31669092/dc84b72d-8fa2-43da-a74f-5b3845b4bafa)
How it was after ^

I am trying to extract ultralight from the docker image to use in portal-testground a testing framework we are trying out. Currently the ultralight docker image has 10 layers which makes it fairly difficult to get the files I want. Consolidating the layers will make this a lot easier