### PR TITLE
Statenetwork-eth-methods

### DIFF
--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -82,6 +82,26 @@ export async function eth_call(
   return undefined
 }
 
-export async function eth_estimateGas(this: StateProtocol, ...args: any) {
+export type TxEstimateObject = {
+  from?: string
+  to?: string
+  gas?: string
+  gasPrice?: string
+  value?: string
+  data?: string
+}
+
+/**
+ * Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain.
+ * @param this state protocol
+ * @param txObject transaction object
+ * @param blockTag integer block number, or the string "latest", "earliest" or "pending"
+ * @returns
+ */
+export async function eth_estimateGas(
+  this: StateProtocol,
+  txObject: TxEstimateObject,
+  blockTag?: string,
+): Promise<string | undefined> {
   return undefined
 }

--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -58,7 +58,27 @@ export async function eth_getCode(this: StateProtocol, address: string, blockTag
   return undefined
 }
 
-export async function eth_call(this: StateProtocol, ...args: any) {
+export type TxCallObject = {
+  from?: string
+  to: string
+  gas?: string
+  gasPrice?: string
+  value?: string
+  data?: string
+}
+
+/**
+ *
+ * @param this state protocol
+ * @param txCallObject transaction call object
+ * @param blockTag integer block number, or the string "latest", "earliest" or "pending"
+ * @returns the return value of the executed contract
+ */
+export async function eth_call(
+  this: StateProtocol,
+  txCallObject: TxCallObject,
+  blockTag?: string,
+): Promise<string | undefined> {
   return undefined
 }
 

--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -1,0 +1,25 @@
+import { StateProtocol } from './state.js'
+
+export async function eth_getBalance(this: StateProtocol, ...args: any) {
+  return undefined
+}
+
+export async function eth_getStorageAt(this: StateProtocol, ...args: any) {
+  return undefined
+}
+
+export async function eth_getTransactionCount(this: StateProtocol, ...args: any) {
+  return undefined
+}
+
+export async function eth_getCode(this: StateProtocol, ...args: any) {
+  return undefined
+}
+
+export async function eth_call(this: StateProtocol, ...args: any) {
+  return undefined
+}
+
+export async function eth_estimateGas(this: StateProtocol, ...args: any) {
+  return undefined
+}

--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -47,7 +47,14 @@ export async function eth_getTransactionCount(
   return undefined
 }
 
-export async function eth_getCode(this: StateProtocol, ...args: any) {
+/**
+ *
+ * @param this state protocol
+ * @param address address
+ * @param blockTag integer block number, or the string "latest", "earliest" or "pending"
+ * @returns code at a given address
+ */
+export async function eth_getCode(this: StateProtocol, address: string, blockTag?: string) {
   return undefined
 }
 

--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -32,7 +32,18 @@ export async function eth_getStorageAt(
   return undefined
 }
 
-export async function eth_getTransactionCount(this: StateProtocol, ...args: any) {
+/**
+ *
+ * @param this state protocol
+ * @param address address
+ * @param blockTag integer block number, or the string "latest", "earliest" or "pending"
+ * @returns
+ */
+export async function eth_getTransactionCount(
+  this: StateProtocol,
+  address: string,
+  blockTag?: string,
+): Promise<number | undefined> {
   return undefined
 }
 

--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -15,7 +15,20 @@ export async function eth_getBalance(
   return undefined
 }
 
-export async function eth_getStorageAt(this: StateProtocol, ...args: any) {
+/**
+ *
+ * @param this StateProtocol
+ * @param address address of the storage
+ * @param slot integer of the position in the storage
+ * @param blockTag integer block number, or the string "latest", "earliest" or "pending"
+ * @returns the value at this storage position
+ */
+export async function eth_getStorageAt(
+  this: StateProtocol,
+  address: string,
+  slot: string,
+  blockTag?: string,
+): Promise<string | undefined> {
   return undefined
 }
 

--- a/packages/portalnetwork/src/subprotocols/state/eth.ts
+++ b/packages/portalnetwork/src/subprotocols/state/eth.ts
@@ -1,6 +1,17 @@
 import { StateProtocol } from './state.js'
 
-export async function eth_getBalance(this: StateProtocol, ...args: any) {
+/**
+ *
+ * @param this StateProtocol
+ * @param address address to check for balance
+ * @param blockTag integer block number, or the string "latest", "earliest" or "pending"
+ * @returns the balance of the account of given address
+ */
+export async function eth_getBalance(
+  this: StateProtocol,
+  address: string,
+  blockTag?: string,
+): Promise<bigint | undefined> {
   return undefined
 }
 

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -16,6 +16,14 @@ import {
 } from '../../wire/types.js'
 import { decodeHistoryNetworkContentKey } from '../history/util.js'
 import { StateNetworkContentType } from './types.js'
+import {
+  eth_getBalance,
+  eth_getCode,
+  eth_getStorageAt,
+  eth_getTransactionCount,
+  eth_call,
+  eth_estimateGas,
+} from './eth.js'
 
 export class StateProtocol extends BaseProtocol {
   protocolId: ProtocolId.StateNetwork
@@ -30,6 +38,13 @@ export class StateProtocol extends BaseProtocol {
       await this.stateStore(toHexString(contentKey), toHexString(content))
     })
   }
+
+  public eth_getBalance = eth_getBalance.bind(this)
+  public eth_getStorageAt = eth_getStorageAt.bind(this)
+  public eth_getTransactionCount = eth_getTransactionCount.bind(this)
+  public eth_getCode = eth_getCode.bind(this)
+  public eth_call = eth_call.bind(this)
+  public eth_estimateGas = eth_estimateGas.bind(this)
 
   /**
    * Send FINDCONTENT request for content corresponding to `key` to peer corresponding to `dstId`

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -39,7 +39,11 @@ export class StateProtocol extends BaseProtocol {
     })
   }
 
+  /**
+   * {@link eth_getBalance}
+   */
   public eth_getBalance = eth_getBalance.bind(this)
+
   public eth_getStorageAt = eth_getStorageAt.bind(this)
   public eth_getTransactionCount = eth_getTransactionCount.bind(this)
   public eth_getCode = eth_getCode.bind(this)

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -48,6 +48,10 @@ export class StateProtocol extends BaseProtocol {
    * {@link eth_getStorageAt}
    */
   public eth_getStorageAt = eth_getStorageAt.bind(this)
+
+  /**
+   * {@link eth_getTransactionCount}
+   */
   public eth_getTransactionCount = eth_getTransactionCount.bind(this)
   public eth_getCode = eth_getCode.bind(this)
   public eth_call = eth_call.bind(this)

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -53,6 +53,10 @@ export class StateProtocol extends BaseProtocol {
    * {@link eth_getTransactionCount}
    */
   public eth_getTransactionCount = eth_getTransactionCount.bind(this)
+
+  /**
+   * {@link eth_getCode}
+   */
   public eth_getCode = eth_getCode.bind(this)
   public eth_call = eth_call.bind(this)
   public eth_estimateGas = eth_estimateGas.bind(this)

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -63,6 +63,10 @@ export class StateProtocol extends BaseProtocol {
    * {@link eth_call}
    */
   public eth_call = eth_call.bind(this)
+
+  /**
+   * {@link eth_estimateGas}
+   */
   public eth_estimateGas = eth_estimateGas.bind(this)
 
   /**

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -58,6 +58,10 @@ export class StateProtocol extends BaseProtocol {
    * {@link eth_getCode}
    */
   public eth_getCode = eth_getCode.bind(this)
+
+  /**
+   * {@link eth_call}
+   */
   public eth_call = eth_call.bind(this)
   public eth_estimateGas = eth_estimateGas.bind(this)
 

--- a/packages/portalnetwork/src/subprotocols/state/state.ts
+++ b/packages/portalnetwork/src/subprotocols/state/state.ts
@@ -44,6 +44,9 @@ export class StateProtocol extends BaseProtocol {
    */
   public eth_getBalance = eth_getBalance.bind(this)
 
+  /**
+   * {@link eth_getStorageAt}
+   */
   public eth_getStorageAt = eth_getStorageAt.bind(this)
   public eth_getTransactionCount = eth_getTransactionCount.bind(this)
   public eth_getCode = eth_getCode.bind(this)


### PR DESCRIPTION
Stubs `eth_`  namespace JSON-RPC methods for StateProtocol class.

`state.eth_getBalance`
`state.eth_getStorageAt`
`state.eth_getTransactionCount`
`state.eth_call`
`state.eth_estimateGas`

Actual implementation to follow in future PR.
This prepares StateProtocol to serve calls from a `Ultralight State Provider`

Currently they will all return `undefined`, 

This should trigger the `Ultralight State Provider` to redirect the request to the fallback.