### PR TITLE
Remove restriction on ENRs

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -543,13 +543,18 @@ export class portal {
           })
     this.logger.extend('findContent')(`request returned ${content.length} bytes`)
     res.selector === FoundContent.UTP && this.logger.extend('findContent')('utp')
-    this.logger.extend('findContent')(content)
-    return res.selector === FoundContent.ENRS
-      ? { enrs: content }
-      : {
-          content: content.length > 0 ? toHexString(content as Uint8Array) : '',
-          utpTransfer: res.selector === FoundContent.UTP,
-        }
+    const returnVal =
+      res.selector === FoundContent.ENRS
+        ? { enrs: (<Uint8Array[]>content).map((v) => ENR.decode(v).encodeTxt()) }
+        : {
+            content: content.length > 0 ? toHexString(content as Uint8Array) : '',
+            utpTransfer: res.selector === FoundContent.UTP,
+          }
+    this.logger.extend('findContent')({
+      selector: FoundContent[res.selector],
+      value: returnVal,
+    })
+    return returnVal
   }
   async stateFindContent(params: [string, string]) {
     const [enr, contentKey] = params


### PR DESCRIPTION
- Clients respond to FINDCONTENT requests with an array of ENRs if the target content is not stored locally.

Here, to align with with updates to the portal network wire spec, and other portal clients:

* We remove the conditional in which the client filters the ENR array, only sending nodes **closer to the target than itself**
* Instead Ultralight client will respond an array of ENRs closest to the target content_ID **regardless** of relative distance.

**RPC**

* Also modified the RPC return value for FINDCONTENT.
  * ENRs response updated to return enr strings instead of Uint8Arrays
* Fixes **portal-hive** "portal-mesh" tests