### PR TITLE
state: add address-range utility

### DIFF
--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -223,3 +223,20 @@ export function removeDuplicateSequences(_arr: string[][]): string[][] {
 
   return result
 }
+
+export function calculateAddressRange(
+  address: bigint,
+  radius: bigint,
+): { min: bigint; max: bigint } {
+  // Ensure we're dealing with BigInts representing 32-byte values
+  address = BigInt.asUintN(256, address)
+  radius = BigInt.asUintN(256, radius)
+  // Find the maximum address by OR-ing the address with the radius.
+  // This will set all bits to 1 where the radius has 1s, potentially up to the boundary of the radius.
+  const maxAddress = BigInt.asUintN(256, address | radius)
+  // Find the minimum address by AND-ing the address with the NOT of the radius.
+  // This will clear all bits to 0 wherever the radius has 1s, potentially down to the boundary of the radius.
+  const minAddress = BigInt.asUintN(256, address & ~radius)
+
+  return { min: minAddress, max: maxAddress }
+}

--- a/packages/portalnetwork/test/networks/state/utils.spec.ts
+++ b/packages/portalnetwork/test/networks/state/utils.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/networks/state/types.js'
 import {
   MODULO,
+  calculateAddressRange,
   decodeStateNetworkContentKey,
   distance,
   getStateNetworkContentId,
@@ -183,5 +184,163 @@ describe('Contract Byte Code Key methods', () => {
     const decoded = decodeStateNetworkContentKey(contentKey_CBC) as any
     assert.deepEqual(Object.keys(decoded), ['contentType', 'address', 'codeHash'])
     assert.equal(decoded.contentType, StateNetworkContentType.ContractByteCode)
+  })
+})
+
+const halfRange = (min: bigint, max: bigint, change: 'min' | 'max' = 'max') => {
+  if (change === 'max') {
+    const newMin = min
+    const newMax = min + (max - min) / 2n
+    return [newMin, newMax]
+  } else {
+    const newMin = max - (max - min) / 2n
+    const newMax = max
+    return [newMin, newMax]
+  }
+}
+
+const address = '0x0ac1df79da5c2fa964d224f2545b2cba509d6d76c001a26f6fe3d49ae7dbca19'
+describe('calculateAddressRange: ' + address.slice(0, 18) + '...', () => {
+  //                              0x
+  //               0 1 2 3 4 5 6 7  8 9 a b c d e f
+  //              /                                 \
+  //     [0x00...]                                   [0x0ff...]
+  const [min, max] = [2n ** 0n, 2n ** 256n]
+
+  it('should calculate address range for radius = 2**256 - 1', () => {
+    const range = calculateAddressRange(BigInt(address), 2n ** 256n - 1n)
+    assert.equal(range.min, min - 1n)
+    assert.equal(range.max, max - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0000000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min0, max0] = halfRange(min, max)
+  it('should calculate address range for radius = 2**255 - 1', () => {
+    //                              0x
+    //               0 1 2 3 4 5 6 7  - - - - - - - -
+    //              /               \
+    //   [0x0000...]                 [0x7fff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 255n - 1n)
+    assert.equal(range.min, min0 - 1n)
+    assert.equal(range.max, max0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0000000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min_0, max_0] = halfRange(min0, max0)
+  it('should calculate address range for radius = 2**254 - 1', () => {
+    //                              0x
+    //               0 1 2 3 - - - -  _ _ _ _ _ _ _ _
+    //              /       \
+    //   [0x0000...]         [0x3fff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 254n - 1n)
+    assert.equal(range.min, min_0 - 1n)
+    assert.equal(range.max, max_0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0000000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min__0, max__0] = halfRange(min_0, max_0)
+  it('should calculate address range for radius = 2**253 - 1', () => {
+    //                              0x
+    //               0 1 - - _ _ _ _  _ _ _ _ _ _ _ _
+    //              /   \
+    //   [0x0000...]     [0x1fff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 253n - 1n)
+    assert.equal(range.min, min__0 - 1n)
+    assert.equal(range.max, max__0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0000000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min___0, max___0] = halfRange(min__0, max__0)
+  it('should calculate address range for radius = 2**252 - 1', () => {
+    //                                             0x
+    //                              0 - _ _ _ _ _ _  _ _ _ _ _ _ _ _
+    //               0 1 2 3 4 5 6 7 8 9 a b c d e f
+    //              /                               \
+    //   [0x0000...]                                 [0x0fff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 252n - 1n)
+    assert.equal(range.min, min___0 - 1n)
+    assert.equal(range.max, max___0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0000000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min____0, max____0] = halfRange(min___0, max___0, 'min')
+  it('should calculate address range for radius = 2**251 - 1', () => {
+    //                                     0x
+    //                      0 _ _ _ _ _ _ _  _ _ _ _ _ _ _ _
+    //       - - - - - - - - 8 9 a b c d e f
+    //                      /               \
+    //           [0x0800...]        -        [0x0fff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 251n - 1n)
+    assert.equal(range.min, min____0 - 1n)
+    assert.equal(range.max, max____0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0800000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min_____0, max_____0] = halfRange(min____0, max____0)
+  it('should calculate address range for radius = 2**250 - 1', () => {
+    //                                     0x
+    //                      0 _ _ _ _ _ _ _  _ _ _ _ _ _ _ _
+    //       _ _ _ _ _ _ _ _ 8 9 a b - - - -
+    //                      /       \
+    //           [0x0800...]    -    [0x0bff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 250n - 1n)
+    assert.equal(range.min, min_____0 - 1n)
+    assert.equal(range.max, max_____0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0800000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x0bffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min______0, max______0] = halfRange(min_____0, max_____0, 'min')
+
+  it('should calculate address range for radius = 2**249 - 1', () => {
+    //                                     0x
+    //                      0 _ _ _ _ _ _ _  _ _ _ _ _ _ _ _
+    //      _ _ _ _ _ _ _ _  - - a b _ _ _ _
+    //                          /   \
+    //               [0x0a00...]  -  [0x0bff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 249n - 1n)
+    assert.equal(range.min, min______0 - 1n)
+    assert.equal(range.max, max______0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0a00000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x0bffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
+  })
+
+  const [min_______0, max_______0] = halfRange(min______0, max______0)
+
+  it('should calculate address range for radius = 2**248 - 1', () => {
+    //                                     0x
+    //                      0 _ _ _ _ _ _ _  _ _ _ _ _ _ _ _
+    //       _ _ _ _ _ _ _ _ _ _ a - _ _ _ _
+    //                          / \
+    //               [0x0a00...]   [0x0aff...]
+    const range = calculateAddressRange(BigInt(address), 2n ** 248n - 1n)
+    assert.equal(range.min, min_______0 - 1n)
+    assert.equal(range.max, max_______0 - 1n)
+    assert.deepEqual(range, {
+      min: BigInt('0x0a00000000000000000000000000000000000000000000000000000000000000'),
+      max: BigInt('0x0affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+    })
   })
 })


### PR DESCRIPTION
Adds a utility function: **calculateAddressRange**

Calculates range of addresses in radius of a given address

`calculateAddressRange(address, radius)`
- Params:
  - `address: bigint`
  - `radius: bigint`
- Returns 
  - Object with range of addresses in radius
  - `{ min: bigint; max: bigint }`  

### Demo: 
#### sections of Trie in range of `address` **0x0ac1df79....** as `radius` is halved:

##### address: 0x0ac1df79da5c2fa9...  
#### **0x  0  a  c  1  d  f  7  9  . . .**
##### radius:

* 2^256 - 1 **100%**


                                    0x
                                   /  \
                    0 1 2 3 4 5 6 7    8 9 a b c d e f
                   /                                   \
        [0x0000...]                                     [0xffff...]


* 2^255 - 1 **50%**

                                   0x
                                  /  
                   0 1 2 3 4 5 6 7 _ _ _ _ _ _ _ _
                  /               \
        [0x0000...]                 [0x7fff...]

* 2^254 - 1 **25%**

                           0x
                          /  
                   0 1 2 3 _ _ _ _ 
                  /       \
        [0x0000...]         [0x3fff...]
    
* 2^253 - 1 **12.5%**
    
                        0x
                       /  
                    0 1 _ _
                   /   \
        [0x0000...]     [0x1fff...]

* 2^252 - 1 **6.25%**

                                      0x
                                     /  
                                    0
                                   / \
                    0 1 2 3 4 5 6 7   8 9 a b c d e f
                   /                                 \
        [0x0000...]                                   [0x0fff...]

* 2^251 - 1 **3.125%**

                              0x
                             /  
                            0
                             \
             _ _ _ _ _ _ _ _  8 9 a b c d e f
                             /               \
                  [0x0800...]                 [0x0fff...]


* 2^250 - 1 **1.5625%**

                         0x
                        /  
                       0
                        \
                          8 9 a b _ _ _ _
                        /         \
              [0x0800...]         [0x0bff...]

* 2^249 - 1 **0.78125%**

                        0x
                       /  
                      0
                       \
                    _ _ a b
                       /   \
            [0x0a00...]    [0x0bff...]

* 2^248 - 1 **0.390625%**

                      0x
                   /  
                  0
                    \ 
                      a _   
                     / \
          [0x0a00...]   [0x0aff...]


