### PR TITLE
Remove redundant bytes <> hex conversions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.format.enable": true,
   "eslint.workingDirectories": [

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -436,7 +436,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
               // TODO: Figure out how to clear this listener
               this.on('ContentAdded', (contentKey, contentType, value) => {
                 if (contentKey === toHexString(key)) {
-                  resolve({ selector: 0, value: hexToBytes(value) })
+                  resolve({ selector: 0, value })
                 }
               })
               void this.handleNewRequest({
@@ -635,7 +635,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
     this.logger(
       `storing ${BeaconLightClientNetworkContentType[contentType]} content corresponding to ${contentKey}`,
     )
-    this.emit('ContentAdded', contentKey, contentType, toHexString(value))
+    this.emit('ContentAdded', contentKey, contentType, value)
   }
 
   /**

--- a/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
+++ b/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
@@ -258,17 +258,14 @@ export class UltralightTransport implements LightClientTransport {
   onOptimisticUpdate(
     handler: (optimisticUpdate: allForks.LightClientOptimisticUpdate) => void,
   ): void {
-    this.network.on('ContentAdded', (contentKey, contentType, content) => {
+    this.network.on('ContentAdded', (_contentKey, contentType, content: Uint8Array) => {
       if (contentType === BeaconLightClientNetworkContentType.LightClientOptimisticUpdate) {
-        const value = hexToBytes(content)
-        const forkhash = value.slice(0, 4) as Uint8Array
+        const forkhash = content.slice(0, 4)
         const forkname = this.network.beaconConfig.forkDigest2ForkName(
           forkhash,
         ) as LightClientForkName
         try {
-          handler(
-            ssz[forkname].LightClientOptimisticUpdate.deserialize((value as Uint8Array).slice(4)),
-          )
+          handler(ssz[forkname].LightClientOptimisticUpdate.deserialize(content.slice(4)))
         } catch (err) {
           this.logger('something went wrong trying to process Optimistic Update')
           this.logger(err)
@@ -277,17 +274,14 @@ export class UltralightTransport implements LightClientTransport {
     })
   }
   onFinalityUpdate(handler: (finalityUpdate: allForks.LightClientFinalityUpdate) => void): void {
-    this.network.on('ContentAdded', (contentKey, contentType, content) => {
+    this.network.on('ContentAdded', (_contentKey, contentType, content: Uint8Array) => {
       if (contentType === BeaconLightClientNetworkContentType.LightClientFinalityUpdate) {
-        const value = hexToBytes(content)
-        const forkhash = value.slice(0, 4) as Uint8Array
+        const forkhash = content.slice(0, 4)
         const forkname = this.network.beaconConfig.forkDigest2ForkName(
           forkhash,
         ) as LightClientForkName
         try {
-          handler(
-            ssz[forkname].LightClientFinalityUpdate.deserialize((value as Uint8Array).slice(4)),
-          )
+          handler(ssz[forkname].LightClientFinalityUpdate.deserialize(content.slice(4)))
         } catch (err) {
           this.logger('something went wrong trying to process Finality Update')
           this.logger(err)

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -91,7 +91,7 @@ export class ContentLookup {
             const utpDecoder = (
               contentKey: string,
               contentType: HistoryNetworkContentType,
-              content: string,
+              content: Uint8Array,
             ) => {
               this.logger(
                 `this.contentKey: ${contentType} +  ${toHexString(this.contentKey.slice(1))}`,
@@ -102,7 +102,7 @@ export class ContentLookup {
                 contentKey === toHexString(this.contentKey.slice(1))
               ) {
                 this.network.removeListener('ContentAdded', utpDecoder)
-                resolve({ content: hexToBytes(content), utp: true })
+                resolve({ content, utp: true })
               }
             }
             this.network.on('ContentAdded', utpDecoder)

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -255,7 +255,7 @@ export class HistoryNetwork extends BaseNetwork {
     } else {
       this.put(this.networkId, getContentKey(contentType, hexToBytes(hashKey)), toHexString(value))
     }
-    this.emit('ContentAdded', hashKey, contentType, toHexString(value))
+    this.emit('ContentAdded', hashKey, contentType, value)
     if (this.routingTable.values().length > 0) {
       // Gossip new content to network (except header accumulators)
       this.gossipManager.add(hashKey, contentType)

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -159,7 +159,7 @@ export class StateNetwork extends BaseNetwork {
   ) => {
     await this.stateDB.storeContent(contentType, fromHexString(contentKey), content)
     this.logger(`content added for: ${contentKey}`)
-    this.emit('ContentAdded', contentKey, contentType, toHexString(content))
+    this.emit('ContentAdded', contentKey, contentType, content)
   }
 
   public getAccountTrieProof = async (address: Uint8Array, stateRoot: Uint8Array) => {

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -124,9 +124,9 @@ it('gossip test', async () => {
 
   // Fancy workaround to allow us to "await" an event firing as expected following this - https://github.com/ljharb/tape/pull/503#issuecomment-619358911
   const end = new EventEmitter()
-  network2.on('ContentAdded', async (key, contentType, content) => {
+  network2.on('ContentAdded', async (key, contentType, content: Uint8Array) => {
     if (contentType === 0) {
-      const headerWithProof = BlockHeaderWithProof.deserialize(hexToBytes(content))
+      const headerWithProof = BlockHeaderWithProof.deserialize(content)
       const header = BlockHeader.fromRLPSerializedHeader(headerWithProof.header, {
         setHardfork: true,
       })

--- a/packages/ui/src/server/subscriptions.ts
+++ b/packages/ui/src/server/subscriptions.ts
@@ -143,9 +143,9 @@ export const subscriptions = async (
     })
     .subscription(() => {
       return observable((emit) => {
-        const contentAdded = (key: string, contentType: number, content: string) => {
+        const contentAdded = (key: string, contentType: number, content: Uint8Array) => {
           console.groupCollapsed('onContentAdded')
-          console.dir({ key, contentType, content })
+          console.dir({ key, contentType, content: toHexString(content) })
           console.groupEnd()
           emit.next({ key, contentType, content })
         }


### PR DESCRIPTION
Removes redundant `bytesToHex` and `hexToBytes` conversions for the `contentValue` parameter in the `.store` function.