### PR TITLE
Portal Trie DB

### DIFF
--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -116,7 +116,7 @@ export class StateNetwork extends BaseNetwork {
 
   public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array> => {
     const value = await this.stateDB.getContent(contentKey)
-    return value ?? hexToBytes('0x')
+    return value !== undefined ? fromHexString(value) : hexToBytes('0x')
   }
 
   public routingTableInfo = async () => {

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -31,7 +31,7 @@ export class StateNetwork extends BaseNetwork {
     super(client, nodeRadius)
     this.networkId = NetworkId.StateNetwork
     this.logger = debug(this.enr.nodeId.slice(0, 5)).extend('Portal').extend('StateNetwork')
-    this.stateDB = new StateDB(this)
+    this.stateDB = new StateDB(client.db.sublevel(NetworkId.StateNetwork))
     this.routingTable.setLogger(this.logger)
     client.uTP.on(
       NetworkId.StateNetwork,

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -1,7 +1,6 @@
-import { toHexString } from '@chainsafe/ssz'
 import debug from 'debug'
 
-import { PortalTrieDB } from './util.js'
+import { PortalTrieDB, getDatabaseContent, getDatabaseKey, keyType } from './util.js'
 
 import type { AbstractLevel } from 'abstract-level'
 import type { Debugger } from 'debug'
@@ -20,21 +19,25 @@ export class StateDB {
 
   /**
    * Store content by content key
-   * @param contentKey
-   * @param content
+   * @param contentKey serialized state network content key
+   * @param content serialized state network content type
    * @returns true if content is stored successfully
    */
   async storeContent(contentKey: Uint8Array, content: Uint8Array) {
-    await this.db.put(toHexString(contentKey), content)
+    const dbKey = getDatabaseKey(contentKey)
+    const dbContent = getDatabaseContent(keyType(contentKey), content)
+    await this.db.put(dbKey, dbContent)
     return true
   }
 
   /**
-   * Get content by content key
-   * @param contentKey
-   * @returns stored content or undefined
+   * Get database content by content key
+   * @param contentKey serialized state network content key
+   * @returns stored content (node or code) or undefined
    */
   async getContent(contentKey: Uint8Array): Promise<string | undefined> {
     const dbKey = getDatabaseKey(contentKey)
+    const dbContent = await this.db.get(dbKey)
+    return dbContent
   }
 }

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -1,22 +1,19 @@
 import { toHexString } from '@chainsafe/ssz'
-import { MemoryLevel } from 'memory-level'
+import debug from 'debug'
 
-import type { StateNetwork } from './state.js'
+import { PortalTrieDB } from './util.js'
+
 import type { Debugger } from 'debug'
+import type { MemoryLevel } from 'memory-level'
 
 export class StateDB {
-  db: MemoryLevel<string, Uint8Array>
+  db: PortalTrieDB
   logger: Debugger | undefined
-  state?: StateNetwork
   blocks: Map<number, string>
   stateRoots: Map<string, string>
-  constructor(state?: StateNetwork) {
-    this.db = new MemoryLevel({
-      createIfMissing: true,
-      valueEncoding: 'view',
-    })
-    this.state = state
-    this.logger = state?.logger.extend('StateDB')
+  constructor(db: MemoryLevel<string, Uint8Array>, logger?: Debugger) {
+    this.db = new PortalTrieDB(db)
+    this.logger = logger ? logger.extend('StateDB') : debug('StateDB')
     this.stateRoots = new Map()
     this.blocks = new Map()
   }

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -3,15 +3,15 @@ import debug from 'debug'
 
 import { PortalTrieDB } from './util.js'
 
+import type { AbstractLevel } from 'abstract-level'
 import type { Debugger } from 'debug'
-import type { MemoryLevel } from 'memory-level'
 
 export class StateDB {
   db: PortalTrieDB
   logger: Debugger | undefined
   blocks: Map<number, string>
   stateRoots: Map<string, string>
-  constructor(db: MemoryLevel<string, Uint8Array>, logger?: Debugger) {
+  constructor(db: AbstractLevel<string, string, string>, logger?: Debugger) {
     this.db = new PortalTrieDB(db)
     this.logger = logger ? logger.extend('StateDB') : debug('StateDB')
     this.stateRoots = new Map()
@@ -34,7 +34,7 @@ export class StateDB {
    * @param contentKey
    * @returns stored content or undefined
    */
-  async getContent(contentKey: Uint8Array): Promise<Uint8Array | undefined> {
-    return this.db.get(toHexString(contentKey))
+  async getContent(contentKey: Uint8Array): Promise<string | undefined> {
+    const dbKey = getDatabaseKey(contentKey)
   }
 }

--- a/packages/portalnetwork/src/networks/state/types.ts
+++ b/packages/portalnetwork/src/networks/state/types.ts
@@ -8,9 +8,9 @@ import {
 } from '@chainsafe/ssz'
 
 export enum StateNetworkContentType {
-  AccountTrieNode = 16, // 0x20
-  ContractTrieNode = 17, // 0x21
-  ContractByteCode = 18, // 0x22
+  AccountTrieNode = 0x20,
+  ContractTrieNode = 0x21,
+  ContractByteCode = 0x22,
 }
 
 /* ----------------- Ping.custom_data & Pong.custom_data ----------- */

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -22,7 +22,7 @@ import type {
   TStorageTrieNodeKey,
 } from './types.js'
 import type { BatchDBOp, DB } from '@ethereumjs/util'
-import type { MemoryLevel } from 'memory-level'
+import type { AbstractLevel } from 'abstract-level'
 
 /* ContentKeys */
 
@@ -147,22 +147,22 @@ export const compareDistance = (nodeId: string, nodeA: Uint8Array, nodeB: Uint8A
   return distanceA < distanceB ? nodeA : nodeB
 }
 
-export class PortalTrieDB extends MapDB<string, Uint8Array> implements DB<string, Uint8Array> {
-  db: MemoryLevel<string, Uint8Array>
-  constructor(db: MemoryLevel<string, Uint8Array>) {
+export class PortalTrieDB extends MapDB<string, string> implements DB<string, string> {
+  db: AbstractLevel<string, string, string>
+  constructor(db: AbstractLevel<string, string, string>) {
     super()
     this.db = db
   }
   async get(key: string) {
     return this.db.get(key)
   }
-  async put(key: string, value: Uint8Array) {
+  async put(key: string, value: string) {
     return this.db.put(key, value)
   }
   async del(key: string) {
     return this.db.del(key)
   }
-  async batch(opStack: BatchDBOp<string, Uint8Array>[]): Promise<void> {
+  async batch(opStack: BatchDBOp<string, string>[]): Promise<void> {
     for (const op of opStack) {
       if (op.type === 'del') {
         await this.del(op.key)

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -153,6 +153,9 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
     super()
     this.db = db
   }
+  async put(key: string, value: string) {
+    return this.db.put(key, value)
+  }
   async get(key: string) {
     // TODO: Retrieve from network if not found locally
     return this.db.get(key)

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -5,10 +5,13 @@ import { MapDB, equalsBytes } from '@ethereumjs/util'
 
 import {
   AccountTrieNodeKey,
+  AccountTrieNodeRetrieval,
   ContractCodeKey,
+  ContractRetrieval,
   Nibble,
   StateNetworkContentType,
   StorageTrieNodeKey,
+  StorageTrieNodeRetrieval,
 } from './types.js'
 
 import type {
@@ -188,4 +191,20 @@ export function getDatabaseKey(contentKey: Uint8Array) {
       break
   }
   return toHexString(dbKey)
+}
+
+export function getDatabaseContent(type: StateNetworkContentType, content: Uint8Array) {
+  let dbContent = new Uint8Array()
+  switch (type) {
+    case StateNetworkContentType.AccountTrieNode:
+      dbContent = AccountTrieNodeRetrieval.deserialize(content).node
+      break
+    case StateNetworkContentType.ContractTrieNode:
+      dbContent = StorageTrieNodeRetrieval.deserialize(content).node
+      break
+    case StateNetworkContentType.ContractByteCode:
+      dbContent = ContractRetrieval.deserialize(content).code
+      break
+  }
+  return toHexString(dbContent)
 }

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -1,5 +1,6 @@
 import { digest as sha256 } from '@chainsafe/as-sha256'
 import { distance } from '@chainsafe/discv5'
+import { toHexString } from '@chainsafe/ssz'
 import { MapDB, equalsBytes } from '@ethereumjs/util'
 
 import {
@@ -169,4 +170,22 @@ export class PortalTrieDB extends MapDB<string, Uint8Array> implements DB<string
       }
     }
   }
+}
+export function getDatabaseKey(contentKey: Uint8Array) {
+  const type = keyType(contentKey)
+  let dbKey = contentKey
+  switch (type) {
+    case StateNetworkContentType.AccountTrieNode:
+      dbKey = AccountTrieNodeContentKey.decode(contentKey).nodeHash
+      break
+    case StateNetworkContentType.ContractTrieNode:
+      dbKey = StorageTrieNodeContentKey.decode(contentKey).nodeHash
+      break
+    case StateNetworkContentType.ContractByteCode:
+      dbKey = ContractCodeContentKey.decode(contentKey).codeHash
+      break
+    default:
+      break
+  }
+  return toHexString(dbKey)
 }

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -28,11 +28,11 @@ import type { AbstractLevel } from 'abstract-level'
 
 export const keyType = (contentKey: Uint8Array): StateNetworkContentType => {
   switch (contentKey[0]) {
-    case 16:
+    case 32:
       return StateNetworkContentType.AccountTrieNode
-    case 17:
+    case 33:
       return StateNetworkContentType.ContractTrieNode
-    case 18:
+    case 34:
       return StateNetworkContentType.ContractByteCode
     default:
       throw new Error(`Invalid content key type: ${contentKey[0]}`)

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -21,7 +21,7 @@ import type {
   TNibbles,
   TStorageTrieNodeKey,
 } from './types.js'
-import type { BatchDBOp, DB } from '@ethereumjs/util'
+import type { DB } from '@ethereumjs/util'
 import type { AbstractLevel } from 'abstract-level'
 
 /* ContentKeys */
@@ -154,24 +154,8 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
     this.db = db
   }
   async get(key: string) {
+    // TODO: Retrieve from network if not found locally
     return this.db.get(key)
-  }
-  async put(key: string, value: string) {
-    return this.db.put(key, value)
-  }
-  async del(key: string) {
-    return this.db.del(key)
-  }
-  async batch(opStack: BatchDBOp<string, string>[]): Promise<void> {
-    for (const op of opStack) {
-      if (op.type === 'del') {
-        await this.del(op.key)
-      }
-
-      if (op.type === 'put') {
-        await this.put(op.key, op.value)
-      }
-    }
   }
 }
 export function getDatabaseKey(contentKey: Uint8Array) {

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -160,6 +160,9 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
     // TODO: Retrieve from network if not found locally
     return this.db.get(key)
   }
+  async del(key: string) {
+    await this.db.del(key)
+  }
 }
 export function getDatabaseKey(contentKey: Uint8Array) {
   const type = keyType(contentKey)

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -2,10 +2,15 @@ import { MemoryLevel } from 'memory-level'
 import { describe, expect, it } from 'vitest'
 
 import { PortalTrieDB } from '../../../src/index.js'
+import { StateDB } from '../../../src/networks/state/statedb.js'
 
-describe('PortalTrieDB', async () => {
+describe('StateDB', async () => {
   it('should create PortalTrieDB from constructor', () => {
     const portalTrieDB = new PortalTrieDB(new MemoryLevel() as any)
     expect(portalTrieDB).exist
+  })
+  it('should create StateDB from constructor', () => {
+    const stateDB = new StateDB(new MemoryLevel() as any)
+    expect(stateDB).exist
   })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -22,7 +22,7 @@ describe('StateDB components', async () => {
     expect(portalTrieDB).exist
   })
 
-  const trie = new Trie({ useKeyHashing: true, db: portalTrieDB })
+  const trie = new Trie({ useKeyHashing: true, db: portalTrieDB, useNodePruning: true })
   it('should be able to instantiate Trie from StateDB', () => {
     expect(trie).exist
   })
@@ -36,12 +36,22 @@ describe('StateDB components', async () => {
   it('should put and get trie value', async () => {
     assert.deepEqual(value, fromHexString('0x1234'), 'should find trie node in StateDB')
   })
-
-  const tNode = await portalTrieDB.get(toHexString(trie.root()).slice(2))
+  const rootHex = toHexString(trie.root()).slice(2)
+  const tNode = await portalTrieDB.get(rootHex)
   const node = decodeNode(fromHexString(tNode!))
 
   it('should find trie node in db', () => {
     assert.deepEqual(node.value(), value, 'should find trie node in StateDB')
     assert.deepEqual(node.value(), fromHexString('0x1234'), 'should find trie node in StateDB')
+  })
+
+  it('should delete node from trie database', async () => {
+    await portalTrieDB.del(rootHex)
+    try {
+      await trie.get(fromHexString(tKey), true)
+      assert.fail('value should be deleted from trie')
+    } catch {
+      assert.ok('deleted value deleted')
+    }
   })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -1,21 +1,44 @@
-import { Trie } from '@ethereumjs/trie'
+import { Trie, decodeNode } from '@ethereumjs/trie'
 import { MemoryLevel } from 'memory-level'
-import { describe, expect, it } from 'vitest'
+import { assert, describe, expect, it } from 'vitest'
 
-import { PortalTrieDB } from '../../../src/index.js'
+import { PortalTrieDB, fromHexString, toHexString } from '../../../src/index.js'
 import { StateDB } from '../../../src/networks/state/statedb.js'
 
+import type { AbstractLevel } from 'abstract-level'
+
 describe('StateDB components', async () => {
-  const portalTrieDB = new PortalTrieDB(new MemoryLevel() as any)
-  it('should create PortalTrieDB from constructor', () => {
-    expect(portalTrieDB).exist
-  })
   const stateDB = new StateDB(new MemoryLevel() as any)
   it('should create StateDB from constructor', () => {
     expect(stateDB).exist
   })
-  const trie = new Trie({ useKeyHashing: true, db: stateDB.db })
+  const portalTrieDB = new PortalTrieDB(
+    new MemoryLevel({
+      createIfMissing: true,
+    }) as AbstractLevel<string, string, string>,
+  )
+  it('should create PortalTrieDB from constructor', () => {
+    expect(portalTrieDB).exist
+  })
+  await portalTrieDB.open()
+  const trie = new Trie({ useKeyHashing: true, db: portalTrieDB })
   it('should be able to instantiate Trie from StateDB', () => {
     expect(trie).exist
+  })
+  const tKey = '0xabcd'
+  const tVal = '0x1234'
+  const prevRoot = trie.root()
+  await trie.put(fromHexString(tKey), fromHexString(tVal))
+  const value = await trie.get(fromHexString(tKey))
+  it('should put and get trie value', async () => {
+    const curRoot = trie.root()
+    assert.notDeepEqual(prevRoot, curRoot, 'trie root should change')
+    assert.deepEqual(value, fromHexString('0x1234'), 'should find trie node in StateDB')
+  })
+  const tNode = await portalTrieDB.get(toHexString(trie.root()).slice(2))
+  const node = decodeNode(fromHexString(tNode!))
+  it('should find trie node in db', () => {
+    assert.deepEqual(node.value(), value, 'should find trie node in StateDB')
+    assert.deepEqual(node.value(), fromHexString('0x1234'), 'should find trie node in StateDB')
   })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -79,6 +79,7 @@ describe('database key / database contents', async () => {
       createIfMissing: true,
     }) as AbstractLevel<string, string, string>,
   )
+  await stateDB.db.open()
   const [sampleKey, sampleContent] = testdata[0] as [string, object]
   const sampleContentKey = StateNetworkContentKey.decode(fromHexString(sampleKey))
   const sampleContentBytes = Uint8Array.from(Object.values(sampleContent))
@@ -87,6 +88,9 @@ describe('database key / database contents', async () => {
   const { blockHash, proof } = content
   const nodeSample = proof.slice(-1)[0]
   const contentNodeSample = AccountTrieNodeRetrieval.serialize({ node: nodeSample })
+  const contentNodeSamples = proof.map((node) => {
+    AccountTrieNodeRetrieval.serialize({ node })
+  })
   it('should correctly decode sample', () => {
     expect(sampleContentKey).exist
     expect(content).exist
@@ -107,5 +111,10 @@ describe('database key / database contents', async () => {
   const retrieved = await stateDB.getContent(fromHexString(sampleKey))
   it('should put and get node using AccountTrieNode Content and Key', () => {
     assert.equal(retrieved, toHexString(nodeSample))
+  })
+  const trie = new Trie({ useKeyHashing: true, db: stateDB.db })
+  const node = await trie.database().db.get(toHexString(nodeHash))
+  it('should have trie node in trie', async () => {
+    assert.equal(node, toHexString(nodeSample))
   })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -1,0 +1,11 @@
+import { MemoryLevel } from 'memory-level'
+import { describe, expect, it } from 'vitest'
+
+import { PortalTrieDB } from '../../../src/index.js'
+
+describe('PortalTrieDB', async () => {
+  it('should create PortalTrieDB from constructor', () => {
+    const portalTrieDB = new PortalTrieDB(new MemoryLevel() as any)
+    expect(portalTrieDB).exist
+  })
+})

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -2,14 +2,31 @@ import { Trie, decodeNode } from '@ethereumjs/trie'
 import { MemoryLevel } from 'memory-level'
 import { assert, describe, expect, it } from 'vitest'
 
-import { PortalTrieDB, fromHexString, toHexString } from '../../../src/index.js'
+import {
+  AccountTrieNodeOffer,
+  AccountTrieNodeRetrieval,
+  PortalTrieDB,
+  StateNetworkContentKey,
+  StateNetworkContentType,
+  fromHexString,
+  getDatabaseContent,
+  getDatabaseKey,
+  toHexString,
+} from '../../../src/index.js'
 import { StateDB } from '../../../src/networks/state/statedb.js'
 
+import testdata from './testdata/accountNodeSamples.json'
+
+import type { TAccountTrieNodeKey } from '../../../src/index.js'
 import type { AbstractLevel } from 'abstract-level'
 
 describe('StateDB components', async () => {
   it('should create StateDB from constructor', () => {
-    const stateDB = new StateDB(new MemoryLevel() as any)
+    const stateDB = new StateDB(
+      new MemoryLevel({
+        createIfMissing: true,
+      }) as AbstractLevel<string, string, string>,
+    )
     expect(stateDB).exist
   })
   const portalTrieDB = new PortalTrieDB(
@@ -53,5 +70,42 @@ describe('StateDB components', async () => {
     } catch {
       assert.ok('deleted value deleted')
     }
+  })
+})
+
+describe('database key / database contents', async () => {
+  const stateDB = new StateDB(
+    new MemoryLevel({
+      createIfMissing: true,
+    }) as AbstractLevel<string, string, string>,
+  )
+  const [sampleKey, sampleContent] = testdata[0] as [string, object]
+  const sampleContentKey = StateNetworkContentKey.decode(fromHexString(sampleKey))
+  const sampleContentBytes = Uint8Array.from(Object.values(sampleContent))
+  const content = AccountTrieNodeOffer.deserialize(sampleContentBytes)
+  const { nodeHash, path } = sampleContentKey as TAccountTrieNodeKey
+  const { blockHash, proof } = content
+  const nodeSample = proof.slice(-1)[0]
+  const contentNodeSample = AccountTrieNodeRetrieval.serialize({ node: nodeSample })
+  it('should correctly decode sample', () => {
+    expect(sampleContentKey).exist
+    expect(content).exist
+    expect(nodeHash).exist
+    expect(path).exist
+    expect(blockHash).exist
+    expect(proof).exist
+  })
+  const dbKey = getDatabaseKey(fromHexString(sampleKey))
+  it('should get dbKey from contentKey', () => {
+    expect(dbKey).toEqual(toHexString(nodeHash))
+  })
+  const dbContent = getDatabaseContent(StateNetworkContentType.AccountTrieNode, contentNodeSample)
+  it('should get dbContent from content', () => {
+    assert.deepEqual(fromHexString(dbContent), nodeSample)
+  })
+  await stateDB.storeContent(fromHexString(sampleKey), contentNodeSample)
+  const retrieved = await stateDB.getContent(fromHexString(sampleKey))
+  it('should put and get node using AccountTrieNode Content and Key', () => {
+    assert.equal(retrieved, toHexString(nodeSample))
   })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -8,8 +8,8 @@ import { StateDB } from '../../../src/networks/state/statedb.js'
 import type { AbstractLevel } from 'abstract-level'
 
 describe('StateDB components', async () => {
-  const stateDB = new StateDB(new MemoryLevel() as any)
   it('should create StateDB from constructor', () => {
+    const stateDB = new StateDB(new MemoryLevel() as any)
     expect(stateDB).exist
   })
   const portalTrieDB = new PortalTrieDB(
@@ -17,26 +17,29 @@ describe('StateDB components', async () => {
       createIfMissing: true,
     }) as AbstractLevel<string, string, string>,
   )
+  await portalTrieDB.open()
   it('should create PortalTrieDB from constructor', () => {
     expect(portalTrieDB).exist
   })
-  await portalTrieDB.open()
+
   const trie = new Trie({ useKeyHashing: true, db: portalTrieDB })
   it('should be able to instantiate Trie from StateDB', () => {
     expect(trie).exist
   })
+
   const tKey = '0xabcd'
   const tVal = '0x1234'
-  const prevRoot = trie.root()
+
   await trie.put(fromHexString(tKey), fromHexString(tVal))
   const value = await trie.get(fromHexString(tKey))
+
   it('should put and get trie value', async () => {
-    const curRoot = trie.root()
-    assert.notDeepEqual(prevRoot, curRoot, 'trie root should change')
     assert.deepEqual(value, fromHexString('0x1234'), 'should find trie node in StateDB')
   })
+
   const tNode = await portalTrieDB.get(toHexString(trie.root()).slice(2))
   const node = decodeNode(fromHexString(tNode!))
+
   it('should find trie node in db', () => {
     assert.deepEqual(node.value(), value, 'should find trie node in StateDB')
     assert.deepEqual(node.value(), fromHexString('0x1234'), 'should find trie node in StateDB')

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -1,16 +1,21 @@
+import { Trie } from '@ethereumjs/trie'
 import { MemoryLevel } from 'memory-level'
 import { describe, expect, it } from 'vitest'
 
 import { PortalTrieDB } from '../../../src/index.js'
 import { StateDB } from '../../../src/networks/state/statedb.js'
 
-describe('StateDB', async () => {
+describe('StateDB components', async () => {
+  const portalTrieDB = new PortalTrieDB(new MemoryLevel() as any)
   it('should create PortalTrieDB from constructor', () => {
-    const portalTrieDB = new PortalTrieDB(new MemoryLevel() as any)
     expect(portalTrieDB).exist
   })
+  const stateDB = new StateDB(new MemoryLevel() as any)
   it('should create StateDB from constructor', () => {
-    const stateDB = new StateDB(new MemoryLevel() as any)
     expect(stateDB).exist
+  })
+  const trie = new Trie({ useKeyHashing: true, db: stateDB.db })
+  it('should be able to instantiate Trie from StateDB', () => {
+    expect(trie).exist
   })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -88,9 +88,6 @@ describe('database key / database contents', async () => {
   const { blockHash, proof } = content
   const nodeSample = proof.slice(-1)[0]
   const contentNodeSample = AccountTrieNodeRetrieval.serialize({ node: nodeSample })
-  const contentNodeSamples = proof.map((node) => {
-    AccountTrieNodeRetrieval.serialize({ node })
-  })
   it('should correctly decode sample', () => {
     expect(sampleContentKey).exist
     expect(content).exist

--- a/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from 'vitest'
 
 import { NetworkId, PortalNetwork } from '../../../src/index.js'
 
-describe.skip('StateNetwork', async () => {
+import type { StateNetwork } from '../../../src/index.js'
+
+describe('StateNetwork', async () => {
   const pk = await createSecp256k1PeerId()
   const enr1 = SignableENR.createFromPeerId(pk)
   const r = 4n
@@ -20,5 +22,17 @@ describe.skip('StateNetwork', async () => {
   const stateNetwork = ultralight.networks.get(NetworkId.StateNetwork)
   it('should start with state network', () => {
     expect(stateNetwork).toBeDefined()
+  })
+  it('should instantiate StateDB', () => {
+    expect((stateNetwork as StateNetwork).stateDB).exist
+    expect((stateNetwork as StateNetwork).stateDB.db).exist
+  })
+  it('should connect client db to stateDB', async () => {
+    ultralight.db.put(NetworkId.StateNetwork, '0x1234', 'testvalue')
+    const value = await stateNetwork!.get(NetworkId.StateNetwork, '0x1234')
+    expect(value).toEqual('testvalue')
+    stateNetwork!.put(NetworkId.StateNetwork, '0xabcd', 'testvalue2')
+    const value2 = await ultralight.db.get(NetworkId.StateNetwork, '0xabcd')
+    expect(value2).toEqual('testvalue2')
   })
 })

--- a/packages/portalnetwork/test/networks/state/utils.spec.ts
+++ b/packages/portalnetwork/test/networks/state/utils.spec.ts
@@ -22,17 +22,17 @@ describe('distance()', () => {
 describe('keyType', () => {
   const randHash = randomBytes(32)
   it('should indentify AccountTrieProof contentKey', () => {
-    const contentKey = Uint8Array.from([0x10, ...randHash])
+    const contentKey = Uint8Array.from([0x20, ...randHash])
     const type = keyType(contentKey)
     assert.equal(type, StateNetworkContentType.AccountTrieNode)
   })
   it('should indentify ContractStorageTrieProof contentKey', () => {
-    const contentKey = Uint8Array.from([0x11, ...randHash])
+    const contentKey = Uint8Array.from([0x21, ...randHash])
     const type = keyType(contentKey)
     assert.equal(type, StateNetworkContentType.ContractTrieNode)
   })
   it('should indentify ContractByteCode contentKey', () => {
-    const contentKey = Uint8Array.from([0x12, ...randHash])
+    const contentKey = Uint8Array.from([0x22, ...randHash])
     const type = keyType(contentKey)
     assert.equal(type, StateNetworkContentType.ContractByteCode)
   })


### PR DESCRIPTION
Implements a custom Portal Trie DB class.  PortalTrieDB implements the `DB` interface used in the EthJS Trie contstructor.  This will allow a Trie instance to access the main state network database as well as network retrieval methods during a lookup.

The Trie instance can proceed normally with lookup operations, and use network retrieval methods when nodes are unavailable in the local database.