### PR TITLE
AccountTrieNode Gossip

### DIFF
--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -135,6 +135,15 @@ export class StateNetwork extends BaseNetwork {
     this.logger(`content added for: ${contentKey}`)
     this.emit('ContentAdded', contentKey, contentType, content)
   }
+  async receiveAccountTrieNodeOffer(contentKey: Uint8Array, content: Uint8Array) {
+    const { path } = AccountTrieNodeContentKey.decode(contentKey)
+    const { blockHash, proof } = AccountTrieNodeOffer.deserialize(content)
+
+    const gossipContents = await this.forwardAccountTrieOffer(path, proof, blockHash)
+
+    return gossipContents
+  }
+
   async forwardAccountTrieOffer(path: TNibbles, proof: Uint8Array[], blockHash: Uint8Array) {
     const nibbles = unpackNibbles(path.packedNibbles, path.isOddLength)
     const newpaths = [...nibbles]

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -195,5 +195,21 @@ export class StateNetwork extends BaseNetwork {
     return { interested, notInterested }
   }
 
+  async forwardAccountTrieOffer(
+    path: TNibbles,
+    proof: Uint8Array[],
+    blockHash: Uint8Array,
+  ): Promise<{
+    content: Uint8Array
+    contentKey: Uint8Array
+  }> {
+    const { curRlp, nodes, newpaths } = await nextOffer(path, proof)
+    const content = AccountTrieNodeOffer.serialize({ blockHash, proof: nodes })
+    const nodeHash = new Trie({ useKeyHashing: true })['hash'](curRlp)
+    const contentKey = AccountTrieNodeContentKey.encode({
+      nodeHash,
+      path: tightlyPackNibbles(newpaths as TNibble[]),
+    })
+    return { content, contentKey }
   }
 }

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -131,7 +131,12 @@ export class StateNetwork extends BaseNetwork {
     contentKey: string,
     content: Uint8Array,
   ) => {
-    await this.stateDB.storeContent(fromHexString(contentKey), content)
+    const fullkey = Uint8Array.from([contentType, ...fromHexString(contentKey)])
+    if (contentType === StateNetworkContentType.AccountTrieNode) {
+      await this.receiveAccountTrieNodeOffer(fullkey, content)
+    } else {
+      await this.stateDB.storeContent(fullkey, content)
+    }
     this.logger(`content added for: ${contentKey}`)
     this.emit('ContentAdded', contentKey, contentType, content)
   }

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -1,6 +1,6 @@
 import debug from 'debug'
 
-import { PortalTrieDB, getDatabaseContent, getDatabaseKey, keyType } from './util.js'
+import { PortalTrieDB, getDatabaseContent, getDatabaseKey, keyType, wrapDBContent } from './util.js'
 
 import type { AbstractLevel } from 'abstract-level'
 import type { Debugger } from 'debug'
@@ -38,6 +38,7 @@ export class StateDB {
   async getContent(contentKey: Uint8Array): Promise<string | undefined> {
     const dbKey = getDatabaseKey(contentKey)
     const dbContent = await this.db.get(dbKey)
-    return dbContent
+    const content = wrapDBContent(contentKey, dbContent)
+    return content
   }
 }

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -1,6 +1,7 @@
 import { digest as sha256 } from '@chainsafe/as-sha256'
 import { distance } from '@chainsafe/discv5'
-import { toHexString } from '@chainsafe/ssz'
+import { fromHexString, toHexString } from '@chainsafe/ssz'
+import { BranchNode, ExtensionNode, decodeNode } from '@ethereumjs/trie'
 import { MapDB, equalsBytes, padToEven } from '@ethereumjs/util'
 
 import {
@@ -98,6 +99,24 @@ export class StateNetworkContentId {
   static fromBytes(key: Uint8Array): Uint8Array {
     return sha256(key)
   }
+}
+
+export function wrapDBContent(contentKey: Uint8Array, dbContent: string) {
+  const keytype = keyType(contentKey)
+  const dbBytes = fromHexString(dbContent)
+  const wrapped =
+    keytype === StateNetworkContentType.AccountTrieNode
+      ? AccountTrieNodeRetrieval.serialize({
+          node: dbBytes,
+        })
+      : keytype === StateNetworkContentType.ContractTrieNode
+        ? StorageTrieNodeRetrieval.serialize({
+            node: dbBytes,
+          })
+        : ContractRetrieval.serialize({
+            code: dbBytes,
+          })
+  return toHexString(wrapped)
 }
 
 export function calculateAddressRange(

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -227,9 +227,12 @@ export function getDatabaseContent(type: StateNetworkContentType, content: Uint8
 }
 
 export async function nextOffer(path: TNibbles, proof: Uint8Array[]) {
+  if (proof.length === 1) {
+    return { curRlp: proof[0], nodes: proof, newpaths: [] }
+  }
   const nibbles = unpackNibbles(path.packedNibbles, path.isOddLength)
   const nodes = proof.slice(0, -1)
-  const curRlp = nodes.slice(-1)[0]
+  const curRlp = nodes[nodes.length - 1]
   const curNode = decodeNode(curRlp)
   const newpaths = nibbles.slice(
     0,

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -206,3 +206,19 @@ export function getDatabaseContent(type: StateNetworkContentType, content: Uint8
   }
   return toHexString(dbContent)
 }
+
+export async function nextOffer(path: TNibbles, proof: Uint8Array[]) {
+  const nibbles = unpackNibbles(path.packedNibbles, path.isOddLength)
+  const nodes = proof.slice(0, -1)
+  const curRlp = nodes.slice(-1)[0]
+  const curNode = decodeNode(curRlp)
+  const newpaths = nibbles.slice(
+    0,
+    curNode instanceof BranchNode ? 1 : curNode instanceof ExtensionNode ? curNode.key().length : 0,
+  )
+  return {
+    curRlp,
+    nodes,
+    newpaths,
+  }
+}

--- a/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
+++ b/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
@@ -1,0 +1,88 @@
+import { KeypairType, SignableENR, createKeypair } from '@chainsafe/discv5'
+import { bytesToHex } from '@ethereumjs/util'
+import { peerIdFromString } from '@libp2p/peer-id'
+import { describe, expect, it } from 'vitest'
+
+import {
+  AccountTrieNodeContentKey,
+  AccountTrieNodeOffer,
+  NetworkId,
+  PortalNetwork,
+  StateNetworkContentId,
+  distance,
+  fromHexString,
+  nextOffer,
+  toHexString,
+  unpackNibbles,
+} from '../../../src/index.js'
+
+import samples from './testdata/accountNodeSamples.json'
+
+import type { StateNetwork } from '../../../src/index.js'
+
+const keypair = createKeypair(
+  KeypairType.Secp256k1,
+  Buffer.from('0ec9a107bcf64e1213128fe9ede9a148ccf77c6e952ab87eed845df9091207f3', 'hex'),
+  Buffer.from('03f4b147e6934b23fae52ecb4f2e33d6eaa6a99e774b6184a5d2ce62413993d736', 'hex'),
+)
+const config = {
+  keypair,
+  enr: SignableENR.decodeTxt(
+    'enr:-IS4QIlbUdmqYYXh1Ga17owfX75adT0wftLk9iQNkpftJg9yDjTa4p9mGNmNSYyxIgrWPLg8gNUoSDCZPE3TSOT6SLsDgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQP0sUfmk0sj-uUuy08uM9bqpqmed0thhKXSzmJBOZPXNoN1ZHCCE4g',
+    keypair,
+  ),
+  peerId: peerIdFromString('16Uiu2HAmV8Acjks2Y9wQ4nXFRsMMaZQ4r4i7dzKcnurYrwtg35zV'),
+  r: 254,
+}
+describe('StateNetwork AccountTrieNode Gossip', async () => {
+  const client = await PortalNetwork.create({
+    supportedNetworks: [NetworkId.StateNetwork],
+    radius: BigInt(2 ** config.r),
+    config: {
+      enr: config.enr,
+      peerId: config.peerId,
+    },
+  })
+  const state = client.networks.get(NetworkId.StateNetwork) as StateNetwork
+  const sample = samples.slice(-1)[0]
+  const [key, value] = sample as [string, object]
+  const contentBytes = Uint8Array.from(Object.values(value))
+  const contentKeyBytes = fromHexString(key)
+  const contentKey = AccountTrieNodeContentKey.decode(contentKeyBytes)
+  const content = AccountTrieNodeOffer.deserialize(contentBytes)
+  const { path } = contentKey
+  const unpacked = unpackNibbles(path.packedNibbles, path.isOddLength)
+  const { proof, blockHash } = content
+  const { interested, notInterested } = await state.storeInterestedNodes(path, proof)
+  it('Should store interested content', async () => {
+    expect(interested.length).toBeGreaterThan(0)
+    expect(proof.length - interested.length).toEqual(notInterested.length)
+    for (const { contentKey } of interested) {
+      const id = StateNetworkContentId.fromBytes(contentKey)
+      const dist = distance(client.discv5.enr.nodeId, bytesToHex(id).slice(2))
+      expect(dist).toBeLessThan(state.nodeRadius)
+    }
+    for (const { contentKey } of notInterested) {
+      const id = StateNetworkContentId.fromBytes(contentKey)
+      const dist = distance(client.discv5.enr.nodeId, bytesToHex(id).slice(2))
+      expect(dist).toBeGreaterThan(state.nodeRadius)
+    }
+  })
+  it(`should find (${interested.length}) interested contents in db`, async () => {
+    for (const { contentKey, dbContent } of interested) {
+      const content = await state.stateDB.getContent(contentKey)
+      expect(content).toBeDefined()
+      expect(content).toEqual(toHexString(dbContent))
+    }
+  })
+  it(`should create higher level offer`, async () => {
+    const next = await nextOffer(path, proof)
+    expect(next.nodes.length).toEqual(proof.length - 1)
+    expect(next.newpaths.length).toBeLessThan(unpacked.length)
+  })
+  it(`should package forward offer for gossip`, async () => {
+    const forwardOffer = await state.forwardAccountTrieOffer(path, proof, blockHash)
+    const decoded = AccountTrieNodeContentKey.decode(forwardOffer.contentKey)
+    expect(decoded.path.packedNibbles.length).toBeLessThanOrEqual(path.packedNibbles.length)
+  })
+})

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -107,7 +107,7 @@ describe('database key / database contents', async () => {
   await stateDB.storeContent(fromHexString(sampleKey), contentNodeSample)
   const retrieved = await stateDB.getContent(fromHexString(sampleKey))
   it('should put and get node using AccountTrieNode Content and Key', () => {
-    assert.equal(retrieved, toHexString(nodeSample))
+    assert.equal(retrieved, toHexString(contentNodeSample))
   })
   const trie = new Trie({ useKeyHashing: true, db: stateDB.db })
   const node = await trie.database().db.get(toHexString(nodeHash))


### PR DESCRIPTION
Implements custom protocol for `AccountTrieNode` **gossip** (OFFER)

summary: 
- A **proof** is an array of serialized trie nodes
- StateNetwork clients will only OFFER nodes with proofs.
- When a StateNetwork client receives a proof in an OFFER
  - 1. Calculate the content key for each individual node+path
  - 2. Store nodes based on distance to the hashed content keys of each node
  - 3. Forward gossip proof for **parent node** of current target node
    * pop last element off of proof
    * determine node path in trie
    * recalculate contentKey
    * gossip new proof with new content key

1. [ root_node, trie_nodeA, trie_nodeB, leaf_node ]
2. [ root_node, trie_nodeA, trie_nodeB ]
3. [ root_node, trie_nodeA ]
4. [ root_node ]

- For each new block:
    - A bridge node will GOSSIP full proofs for all new leaf nodes
    - The nodes which receive these proofs will forward the "parent proofs"
    - This process will cascade towards gossip of the new state root node
    - The gossip process will reach a natural conclusion with gossip of the state root node



Utility function: 
- nextOffer()
  - generates forwarding gossip content

StateNetwork methods:
- `forwardAccountTrieOffer()`
  - calls `nextOffer()` on received content
  - serializes and packages forwarding proof as content and contentKey
- `storeInterestedNodes()`
  - generates individual contentKeys for nodes in proof
  - calculates contentId of contentKeys
  - compares distance from node to each contentId
  - stores node with contentId in radius
  - returns sorted contents by interested / not interested
- `receiveAccountTrieNodeOffer`
  - decodes ContentKey
  - deserializes OFFER content
  - calls `forwardAccountTrieNodeOffer()`
  - calls `storeInterestedNodes()`
  - calls `gossipContent()` on forwarding proof
  - returns results of internal methods 


Also included => unit tests and integration tests for functions/methods