### PR TITLE
Make nodeRadius public

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -45,7 +45,7 @@ import type { Debugger } from 'debug'
 export abstract class BaseNetwork extends EventEmitter {
   public routingTable: PortalNetworkRoutingTable | StateNetworkRoutingTable
   public metrics: PortalNetworkMetrics | undefined
-  private nodeRadius: bigint
+  public nodeRadius: bigint
   private checkIndex: number
   abstract logger: Debugger
   abstract networkId: NetworkId


### PR DESCRIPTION
This pull request updates the `BaseNetwork` class to make the `nodeRadius` property public instead of private. This change allows external access to the `nodeRadius` property, which was previously restricted.