### PR TITLE
GetAccount

### DIFF
--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -1,6 +1,6 @@
 import { ENR, distance } from '@chainsafe/discv5'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { BranchNode, Trie, decodeNode } from '@ethereumjs/trie'
+import { BranchNode, ExtensionNode, LeafNode, Trie, decodeNode } from '@ethereumjs/trie'
 import { bytesToHex, bytesToInt, hexToBytes } from '@ethereumjs/util'
 import debug from 'debug'
 
@@ -12,6 +12,7 @@ import {
   MessageCodes,
   PortalWireMessageType,
 } from '../../wire/types.js'
+import { ContentLookup } from '../contentLookup.js'
 import { decodeHistoryNetworkContentKey } from '../history/util.js'
 import { BaseNetwork } from '../network.js'
 import { NetworkId } from '../types.js'
@@ -221,5 +222,75 @@ export class StateNetwork extends BaseNetwork {
       path: tightlyPackNibbles(newpaths as TNibble[]),
     })
     return { content, contentKey }
+  }
+
+  async getAccount(address: string, stateroot: Uint8Array) {
+    const lookupTrie = new Trie({
+      useKeyHashing: true,
+      db: this.stateDB.db,
+    })
+    lookupTrie.root(stateroot)
+    const addressPath = toHexString(lookupTrie['hash'](fromHexString(address)))
+      .slice(2)
+      .split('')
+    const lookupFunction = async (key: Uint8Array) => {
+      const lookup = new ContentLookup(this, key)
+      const request = await lookup.startLookup()
+      const requestContent = request && 'content' in request ? request.content : undefined
+      const keyobj = AccountTrieNodeContentKey.decode(key)
+      if (requestContent === undefined) {
+        throw new Error(
+          `network doesn't have node [${unpackNibbles(
+            keyobj.path.packedNibbles,
+            keyobj.path.isOddLength,
+          )}]${toHexString(keyobj.nodeHash)}`,
+        )
+      }
+      const node = AccountTrieNodeRetrieval.deserialize(requestContent).node
+      return { nodeHash: keyobj.nodeHash, node }
+    }
+    const hasRoot = this.stateDB.db._database.get(toHexString(stateroot).slice(2))
+    if (hasRoot === undefined) {
+      const lookup = new ContentLookup(
+        this,
+        AccountTrieNodeContentKey.encode({
+          path: tightlyPackNibbles([]),
+          nodeHash: stateroot,
+        }),
+      )
+      const request = await lookup.startLookup()
+      const requestContent = request && 'content' in request ? request.content : new Uint8Array()
+      const node = AccountTrieNodeRetrieval.deserialize(requestContent).node
+      this.stateDB.db.temp.set(toHexString(stateroot).slice(2), toHexString(node).slice(2))
+    }
+    let accountPath = await lookupTrie.findPath(lookupTrie['hash'](fromHexString(address)))
+    while (!accountPath.node) {
+      const consumedNibbles = accountPath.stack
+        .slice(1)
+        .map((n) => (n instanceof BranchNode ? 1 : n.keyLength()))
+        .reduce((a, b) => a + b)
+      const nodePath = addressPath.slice(0, consumedNibbles)
+      const current = accountPath.stack[accountPath.stack.length - 1]
+      const nextNodeHash =
+        current instanceof BranchNode
+          ? current.getBranch(parseInt(addressPath[consumedNibbles], 16))
+          : current instanceof ExtensionNode
+            ? current.value()
+            : Uint8Array.from([])
+      if (current instanceof LeafNode) {
+        return current.value()
+      }
+      const nextContentKey = AccountTrieNodeContentKey.encode({
+        path: tightlyPackNibbles(nodePath as TNibble[]),
+        nodeHash: nextNodeHash as Uint8Array,
+      })
+      const found = await lookupFunction(nextContentKey)
+      this.stateDB.db.temp.set(
+        toHexString(found.nodeHash).slice(2),
+        toHexString(found.node).slice(2),
+      )
+      accountPath = await lookupTrie.findPath(lookupTrie['hash'](fromHexString(address)))
+    }
+    return accountPath.node.value()
   }
 }

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -41,7 +41,7 @@ export class StateNetwork extends BaseNetwork {
     this.nodeRadius = nodeRadius ?? 2n ** 253n
     this.networkId = NetworkId.StateNetwork
     this.logger = debug(this.enr.nodeId.slice(0, 5)).extend('Portal').extend('StateNetwork')
-    this.stateDB = new StateDB(client.db.sublevel(NetworkId.StateNetwork))
+    this.stateDB = new StateDB(client.db.db)
     this.routingTable.setLogger(this.logger)
     client.uTP.on(
       NetworkId.StateNetwork,

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -38,6 +38,7 @@ export class StateDB {
   async getContent(contentKey: Uint8Array): Promise<string | undefined> {
     const dbKey = getDatabaseKey(contentKey)
     const dbContent = await this.db.get(dbKey)
+    if (dbContent === undefined) return dbContent
     const content = wrapDBContent(contentKey, dbContent)
     return content
   }

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -1,4 +1,5 @@
 import { Trie, decodeNode } from '@ethereumjs/trie'
+import { bytesToUnprefixedHex } from '@ethereumjs/util'
 import { MemoryLevel } from 'memory-level'
 import { assert, describe, expect, it } from 'vitest'
 
@@ -98,7 +99,7 @@ describe('database key / database contents', async () => {
   })
   const dbKey = getDatabaseKey(fromHexString(sampleKey))
   it('should get dbKey from contentKey', () => {
-    expect(dbKey).toEqual(toHexString(nodeHash))
+    expect(dbKey).toEqual(bytesToUnprefixedHex(nodeHash))
   })
   const dbContent = getDatabaseContent(StateNetworkContentType.AccountTrieNode, contentNodeSample)
   it('should get dbContent from content', () => {
@@ -110,8 +111,8 @@ describe('database key / database contents', async () => {
     assert.equal(retrieved, toHexString(contentNodeSample))
   })
   const trie = new Trie({ useKeyHashing: true, db: stateDB.db })
-  const node = await trie.database().db.get(toHexString(nodeHash))
+  const node = await trie.database().db.get(bytesToUnprefixedHex(nodeHash))
   it('should have trie node in trie', async () => {
-    assert.equal(node, toHexString(nodeSample))
+    assert.equal(node, bytesToUnprefixedHex(nodeSample))
   })
 })


### PR DESCRIPTION
Implements `getAccount` method in state network

### `getAccount(address, stateroot)`

This method returns an RLP serialized account through a combination of local database, and network requests.

The same way an Execution Client would find an account:

1. Initialize a Trie class
2. Set Trie root to target state root
3. Walk the Trie towards hash of target address
  - Path = `toNibbles(hash(address))`
  - Find current node in DB by hash
  - Decode node to find child hashes
  - Find next node in DB by hash
  - Repeat untill LeafNode is reached
  - Return LeafNode.value()

The only difference occurs when a node is not found in the DB.  In a Portal Client, the unsuccessful database call is repackaged as a network request, and redirected outwards as FINDCONENT.

A node which is obtained this way is not automatically stored in the DB, however, unless it happens to fall in the client's radius.  Instead, nodes are stored in a temporary storage cache, and discarded at the end of the `getAccount` method.

This allows a client to navigate state tries using nodes not stored locally, without also loading the local DB with content outside the client's radius.

### getAccount Test

Included is an **Integration Test** for `state.getAccount`

1. Setup
- A network of 5 PortalNetwork clients are created, each with a radius covering 25% of the keyspace.
- The client's exchange PING/PONG messages, forming a completely connected network.

2. Test Data
- Content for the test is 1 serialized AccountTrieNode OFFER and content key.
- ContentKey includes `node_hash` and `path`
- Content is a 6 node proof for a LeafNode from the genesis Trie.

3. Content distribution
- state.receiveAccountTrieOffer()` is called using one of the clients.
- This method stores in-radius content, and gossips forward an OFFER for the proof of the next node.
- The Gossip process comes to a natural conclusion with gossip of the lone state root.
- The result is each Client in the network storing 2-3 nodes (out of 6 total).

4. Get Account
- A client is chosen who neither stores the state root node, nor the target account leaf node.
- state.getAccount is called using the account `address`
- Client uses Trie methods to navigate the state trie towards the adress.
- Nodes that the client does not store locally are requested as needed from the network using node_hash and the known path to the node in the state trie
- Client getAccount method returns correct account information without storing any more nodes.


This represents the first true Proof-Of-Concept for the updated State Network design.