### PR TITLE
Remove permanent PortalTrieDB from StateDB

### DIFF
--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -1,7 +1,7 @@
 import { ENR, distance } from '@chainsafe/discv5'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { BranchNode, ExtensionNode, LeafNode, Trie, decodeNode } from '@ethereumjs/trie'
-import { bytesToHex, bytesToInt, hexToBytes } from '@ethereumjs/util'
+import { BranchNode, LeafNode, Trie, decodeNode } from '@ethereumjs/trie'
+import { bytesToHex, bytesToInt, equalsBytes, hexToBytes } from '@ethereumjs/util'
 import debug from 'debug'
 
 import { shortId } from '../../util/util.js'
@@ -21,6 +21,7 @@ import { StateDB } from './statedb.js'
 import { AccountTrieNodeOffer, AccountTrieNodeRetrieval, StateNetworkContentType } from './types.js'
 import {
   AccountTrieNodeContentKey,
+  PortalTrieDB,
   StateNetworkContentId,
   nextOffer,
   tightlyPackNibbles,
@@ -225,9 +226,10 @@ export class StateNetwork extends BaseNetwork {
   }
 
   async getAccount(address: string, stateroot: Uint8Array) {
+    const stateNetworkDB = new PortalTrieDB(this.stateDB._db)
     const lookupTrie = new Trie({
       useKeyHashing: true,
-      db: this.stateDB.db,
+      db: stateNetworkDB,
     })
     lookupTrie.root(stateroot)
     const addressPath = toHexString(lookupTrie['hash'](fromHexString(address)))
@@ -249,7 +251,7 @@ export class StateNetwork extends BaseNetwork {
       const node = AccountTrieNodeRetrieval.deserialize(requestContent).node
       return { nodeHash: keyobj.nodeHash, node }
     }
-    const hasRoot = this.stateDB.db._database.get(toHexString(stateroot).slice(2))
+    const hasRoot = stateNetworkDB._database.get(toHexString(stateroot).slice(2))
     if (hasRoot === undefined) {
       const lookup = new ContentLookup(
         this,
@@ -261,7 +263,7 @@ export class StateNetwork extends BaseNetwork {
       const request = await lookup.startLookup()
       const requestContent = request && 'content' in request ? request.content : new Uint8Array()
       const node = AccountTrieNodeRetrieval.deserialize(requestContent).node
-      this.stateDB.db.temp.set(toHexString(stateroot).slice(2), toHexString(node).slice(2))
+      stateNetworkDB.temp.set(toHexString(stateroot).slice(2), toHexString(node).slice(2))
     }
     let accountPath = await lookupTrie.findPath(lookupTrie['hash'](fromHexString(address)))
     while (!accountPath.node) {
@@ -274,9 +276,7 @@ export class StateNetwork extends BaseNetwork {
       const nextNodeHash =
         current instanceof BranchNode
           ? current.getBranch(parseInt(addressPath[consumedNibbles], 16))
-          : current instanceof ExtensionNode
-            ? current.value()
-            : Uint8Array.from([])
+          : current.value()
       if (current instanceof LeafNode) {
         return current.value()
       }
@@ -285,12 +285,18 @@ export class StateNetwork extends BaseNetwork {
         nodeHash: nextNodeHash as Uint8Array,
       })
       const found = await lookupFunction(nextContentKey)
-      this.stateDB.db.temp.set(
+      if (found.node instanceof LeafNode) {
+        return found.node.value()
+      }
+      stateNetworkDB.temp.set(
         toHexString(found.nodeHash).slice(2),
         toHexString(found.node).slice(2),
       )
       accountPath = await lookupTrie.findPath(lookupTrie['hash'](fromHexString(address)))
+      const next = accountPath.stack[accountPath.stack.length - 1]
+      if (equalsBytes(current.serialize(), next.serialize())) {
+        return undefined
+      }
     }
-    return accountPath.node.value()
   }
 }

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -1,17 +1,17 @@
 import debug from 'debug'
 
-import { PortalTrieDB, getDatabaseContent, getDatabaseKey, keyType, wrapDBContent } from './util.js'
+import { getDatabaseContent, getDatabaseKey, keyType, wrapDBContent } from './util.js'
 
 import type { AbstractLevel } from 'abstract-level'
 import type { Debugger } from 'debug'
 
 export class StateDB {
-  db: PortalTrieDB
+  _db: AbstractLevel<string, string, string>
   logger: Debugger | undefined
   blocks: Map<number, string>
   stateRoots: Map<string, string>
   constructor(db: AbstractLevel<string, string, string>, logger?: Debugger) {
-    this.db = new PortalTrieDB(db)
+    this._db = db
     this.logger = logger ? logger.extend('StateDB') : debug('StateDB')
     this.stateRoots = new Map()
     this.blocks = new Map()
@@ -26,7 +26,7 @@ export class StateDB {
   async storeContent(contentKey: Uint8Array, content: Uint8Array) {
     const dbKey = getDatabaseKey(contentKey)
     const dbContent = getDatabaseContent(keyType(contentKey), content)
-    await this.db.put(dbKey, dbContent)
+    await this._db.put(dbKey, dbContent)
     return true
   }
 
@@ -37,7 +37,7 @@ export class StateDB {
    */
   async getContent(contentKey: Uint8Array): Promise<string | undefined> {
     const dbKey = getDatabaseKey(contentKey)
-    const dbContent = await this.db.get(dbKey)
+    const dbContent = await this._db.get(dbKey)
     if (dbContent === undefined) return dbContent
     const content = wrapDBContent(contentKey, dbContent)
     return content

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -218,18 +218,4 @@ describe('getAccount via network', async () => {
   it('should find account data', async () => {
     assert.deepEqual(foundAccount.balance, BigInt('0x152d02c7e14af6800000'), 'account data found')
   })
-
-  const temp = [...testClient.stateDB.db.temp.keys()]
-  const perm: string[] = []
-  for await (const key of testClient.stateDB.db.db.keys()) {
-    perm.push(key)
-  }
-  it('should have all nodes in temp or permanent db', () => {
-    expect(temp.length + perm.length).toEqual(uniqueStored.length)
-  })
-  it('should not have temp entries also in permanent db', () => {
-    for (const key of temp) {
-      expect(perm.includes(key)).toBeFalsy()
-    }
-  })
 })

--- a/packages/portalnetwork/test/networks/state/stateDB.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateDB.spec.ts
@@ -80,7 +80,7 @@ describe('database key / database contents', async () => {
       createIfMissing: true,
     }) as AbstractLevel<string, string, string>,
   )
-  await stateDB.db.open()
+  await stateDB._db.open()
   const [sampleKey, sampleContent] = testdata[0] as [string, object]
   const sampleContentKey = StateNetworkContentKey.decode(fromHexString(sampleKey))
   const sampleContentBytes = Uint8Array.from(Object.values(sampleContent))
@@ -110,7 +110,8 @@ describe('database key / database contents', async () => {
   it('should put and get node using AccountTrieNode Content and Key', () => {
     assert.equal(retrieved, toHexString(contentNodeSample))
   })
-  const trie = new Trie({ useKeyHashing: true, db: stateDB.db })
+  const db = new PortalTrieDB(stateDB._db)
+  const trie = new Trie({ useKeyHashing: true, db })
   const node = await trie.database().db.get(bytesToUnprefixedHex(nodeHash))
   it('should have trie node in trie', async () => {
     assert.equal(node, bytesToUnprefixedHex(nodeSample))

--- a/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
@@ -25,7 +25,7 @@ describe('StateNetwork', async () => {
   })
   it('should instantiate StateDB', () => {
     expect((stateNetwork as StateNetwork).stateDB).exist
-    expect((stateNetwork as StateNetwork).stateDB.db).exist
+    expect((stateNetwork as StateNetwork).stateDB._db).exist
   })
   it('should connect client db to stateDB', async () => {
     ultralight.db.put(NetworkId.StateNetwork, '0x1234', 'testvalue')


### PR DESCRIPTION
Previously the `StateDB` class would instantiate a permanent `PortalTrieDB` class, which all external methods would share.  

In the previous PR, a temporary map of nodes was added to the `PortalTrieDB` class, which held on to TrieNodes involved in an active lookup, without storing them permanently in the database.

When multiple lookups happen simultaneously, however, cleanup becomes impossible, as there is no way to differentiate nodes being temporarily stored for different lookups.

Since `PortalTrieDB` is not itself the main database, but simply contains a reference to it, this permanent, shared instance contained in `StateDB` is unnecessary.  The same functionality can be achieved by instantiating a `PortalTrieDB` instance inside of each method which uses it.  Without losing any functionality, we gain the ability to remove the temporary node cache at the end of each lookup without affecting other lookups.

Tests were updated/modified/deleted accordingly.