### PR TITLE
Fix npm scripts in cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,8 +57,8 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "devnet": "tsx scripts/devnet.ts ",
-    "dev": "tsx watch src/index.ts -- --bindAddress=127.0.0.1:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data'",
-    "dev-testnet": "tsx watch src/index.ts -- --bindAddress=0.0.0.0:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data' --bootnodeList=./bootnodes.txt",
+    "dev": "tsx watch src/index.ts --bindAddress=127.0.0.1:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data'",
+    "dev-testnet": "tsx watch src/index.ts --bindAddress=0.0.0.0:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data' --bootnodeList=./bootnodes.txt",
     "build": "tsc && cp bootnodes.txt ./dist",
     "test": "npx vitest run test/* -c=./vitest.config.unit.ts",
     "lint": "../../config/cli/lint.sh",


### PR DESCRIPTION
Removes now unnecessary `--` in `cli` npm scripts that was necessary before we switched to `tsx`