### PR TITLE
chore: mark autogenerated docs as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packages/portalnetwork/docs/ linguist-vendored


### PR DESCRIPTION
This excludes the autogenerated HTML docs from GitHub's language % calculations