### PR TITLE
RPC: Throw errors when content not found

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -681,12 +681,15 @@ export class portal {
     this.logger.extend('stateRecursiveFindContent')(`request returned ${JSON.stringify(res)}`)
     if (!res) {
       this.logger.extend('stateRecursiveFindContent')(`request returned { enrs: [] }`)
-      return { content: '0x', utpTransfer: false }
+      throw new Error('No content found')
     }
     if ('enrs' in res) {
       this.logger.extend('stateRecursiveFindContent')(
         `request returned { enrs: [{${{ enrs: res.enrs.map(toHexString) }}}] }`,
       )
+      if (res.enrs.length === 0) {
+        throw new Error('No content found')
+      }
       return { enrs: res.enrs.map(toHexString) }
     } else {
       this.logger.extend('stateRecursiveFindContent')(

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -511,7 +511,10 @@ export class portal {
     const res = await this._history.findContentLocally(fromHexString(contentKey))
     this.logger.extend(`historyLocalContent`)(`request returned ${res.length} bytes`)
     this.logger.extend(`historyLocalContent`)(`${toHexString(res)}`)
-    return res.length > 0 ? toHexString(res) : '0x'
+    if (res.length === 0) {
+      throw new Error('No content found')
+    }
+    return toHexString(res)
   }
   async stateLocalContent(params: [string]): Promise<string | undefined> {
     const [contentKey] = params

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -523,7 +523,10 @@ export class portal {
     const res = await this._state.findContentLocally(fromHexString(contentKey))
     this.logger.extend(`stateLocalContent`)(`request returned ${res.length} bytes`)
     this.logger.extend(`stateLocalContent`)(`${toHexString(res)}`)
-    return res.length > 0 ? toHexString(res) : '0x'
+    if (res.length === 0) {
+      throw new Error('No content found')
+    }
+    return toHexString(res)
   }
   async historyFindContent(params: [string, string]) {
     const [enr, contentKey] = params

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -647,12 +647,15 @@ export class portal {
     this.logger.extend('historyRecursiveFindContent')(`request returned ${JSON.stringify(res)}`)
     if (!res) {
       this.logger.extend('historyRecursiveFindContent')(`request returned { enrs: [] }`)
-      return { content: '0x', utpTransfer: false }
+      throw new Error('No content found')
     }
     if ('enrs' in res) {
       this.logger.extend('historyRecursiveFindContent')(
         `request returned { enrs: [{${{ enrs: res.enrs.map(toHexString) }}}] }`,
       )
+      if (res.enrs.length === 0) {
+        throw new Error('No content found')
+      }
       return { enrs: res.enrs.map(toHexString) }
     } else {
       this.logger.extend('historyRecursiveFindContent')(

--- a/packages/portalnetwork/src/networks/state/types.ts
+++ b/packages/portalnetwork/src/networks/state/types.ts
@@ -3,7 +3,11 @@ import {
   ByteVectorType,
   ContainerType,
   ListCompositeType,
+  NoneType,
   UintBigintType,
+  UnionType,
+  VectorBasicType,
+  VectorCompositeType,
 } from '@chainsafe/ssz'
 
 export enum StateNetworkContentType {
@@ -146,3 +150,24 @@ export type StorageTrieProofKey = {
   stateRoot: StateRoot
 }
 export type CodeHash = Bytes32
+
+type BlockNumber = number
+
+const MAX_LENGTH = 2 ** 32 - 1
+
+// MAX  number of storage changes in 1 ERA file
+const MAX_STORAGE_CHANGES = 2 ** 32 - 1
+
+const AccountBalance = new UintBigintType(16)
+
+const BalanceChange = new VectorBasicType(new UintBigintType(16), 2)
+const NonceChange = new VectorBasicType(new UintBigintType(16), 2)
+const StorageChange = new VectorBasicType(new UintBigintType(32), 2)
+
+const StorageChangeList = new ListCompositeType(StorageChange, MAX_STORAGE_CHANGES)
+
+const AccountChange = new UnionType([BalanceChange, NonceChange])
+
+const AccountChangeList = new ListCompositeType(AccountChange, 2)
+
+new ListCompositeType(AccountChange, 2)

--- a/packages/portalnetwork/src/networks/state/types.ts
+++ b/packages/portalnetwork/src/networks/state/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   ByteListType,
   ByteVectorType,


### PR DESCRIPTION
Updates RPC responses in
-historyLocalContent
-historyRecursiveFindContent
-stateLocalContent
-stateRecursiveFindContent

Per the spec: Methods should return ERROR if content not found.