### PR TITLE
Interop-bugs

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -526,9 +526,11 @@ export class portal {
     this.logger(`Received stateLocalContent request for ${contentKey}`)
 
     const res = await this._state.findContentLocally(fromHexString(contentKey))
-    this.logger.extend(`stateLocalContent`)(`request returned ${res.length} bytes`)
-    this.logger.extend(`stateLocalContent`)(`${toHexString(res)}`)
-    if (res.length === 0) {
+    this.logger.extend(`stateLocalContent`)(`request returned ${res?.length} bytes`)
+    this.logger.extend(`stateLocalContent`)(
+      `${res !== undefined ? toHexString(res) : 'content not found'}`,
+    )
+    if (res === undefined) {
       throw new Error('No content found')
     }
     return toHexString(res)

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -62,6 +62,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         allowUnverifiedSessions: true,
         requestTimeout: 3000,
         sessionEstablishTimeout: 3000,
+        lookupTimeout: 3000,
+        sessionTimeout: 3000,
+        requestRetries: 2,
       },
     }
     const config = { ...defaultConfig, ...opts.config }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -369,7 +369,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       return
     }
 
-    network.handle(message, src)
+    await network.handle(message, src)
   }
 
   private onTalkResp = (src: INodeAddress, sourceId: ENR | null, message: ITalkRespMessage) => {

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -1,5 +1,5 @@
 import { distance } from '@chainsafe/discv5'
-import { bigIntToHex, hexToBytes } from '@ethereumjs/util'
+import { bigIntToHex, hexToBytes, padToEven } from '@ethereumjs/util'
 import { MemoryLevel } from 'memory-level'
 
 import { fromHexString, serializedContentKeyToContentId } from '../index.js'
@@ -40,7 +40,9 @@ export class DBManager {
     const databaseKey = this.databaseKey(key)
     const val = await db.get(databaseKey)
     this.logger(
-      `Got ${key} from DB with key: ${databaseKey}.  Size=${fromHexString(val).length} bytes`,
+      `Got ${key} from DB with key: ${databaseKey}.  Size=${
+        fromHexString(padToEven(val)).length
+      } bytes`,
     )
     return val
   }
@@ -51,7 +53,9 @@ export class DBManager {
     db.put(databaseKey, val, (err: any) => {
       if (err !== undefined) this.logger(`Error putting content in history DB: ${err.toString()}`)
     })
-    this.logger(`Put ${key} in DB as ${databaseKey}.  Size=${fromHexString(val).length} bytes`)
+    this.logger(
+      `Put ${key} in DB as ${databaseKey}.  Size=${fromHexString(padToEven(val)).length} bytes`,
+    )
   }
 
   async storeBlockIndex(blockIndex: Map<string, string>) {

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -2,7 +2,7 @@ import { distance } from '@chainsafe/discv5'
 import { bigIntToHex, hexToBytes } from '@ethereumjs/util'
 import { MemoryLevel } from 'memory-level'
 
-import { serializedContentKeyToContentId } from '../index.js'
+import { fromHexString, serializedContentKeyToContentId } from '../index.js'
 
 import type { NetworkId } from '../index.js'
 import type { NodeId } from '@chainsafe/enr'
@@ -35,18 +35,23 @@ export class DBManager {
     }
   }
 
-  get(network: NetworkId, key: string) {
+  async get(network: NetworkId, key: string) {
     const db = this.sublevel(network)
     const databaseKey = this.databaseKey(key)
-    return db.get(databaseKey)
+    const val = await db.get(databaseKey)
+    this.logger(
+      `Got ${key} from DB with key: ${databaseKey}.  Size=${fromHexString(val).length} bytes`,
+    )
+    return val
   }
 
   put(network: NetworkId, key: string, val: string) {
     const db = this.sublevel(network)
     const databaseKey = this.databaseKey(key)
-    return db.put(databaseKey, val, (err: any) => {
+    db.put(databaseKey, val, (err: any) => {
       if (err !== undefined) this.logger(`Error putting content in history DB: ${err.toString()}`)
     })
+    this.logger(`Put ${key} in DB as ${databaseKey}.  Size=${fromHexString(val).length} bytes`)
   }
 
   async storeBlockIndex(blockIndex: Map<string, string>) {

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -75,7 +75,8 @@ export class ContentLookup {
       }
       this.contacted.push(nearestPeer.nodeId)
       const res = await this.network.sendFindContent(nearestPeer.nodeId, this.contentKey)
-      if (!res || res.value.length < 1) {
+      if (!res) {
+        this.logger(`No response to findContent from ${shortId(nearestPeer.nodeId)}`)
         continue
       }
       switch (res.selector) {

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -65,9 +65,9 @@ export class HistoryNetwork extends BaseNetwork {
    * @param decodedContentMessage content key to be found
    * @returns content if available locally
    */
-  public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array> => {
+  public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array | undefined> => {
     const value = await this.retrieve(toHexString(contentKey))
-    return value !== undefined ? hexToBytes(value) : hexToBytes('0x')
+    return value !== undefined ? hexToBytes(value) : undefined
   }
 
   public indexBlockhash = async (number: bigint, blockHash: string) => {
@@ -182,9 +182,6 @@ export class HistoryNetwork extends BaseNetwork {
     })
     this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr)}`)
     const res = await this.sendMessage(enr, payload, this.networkId)
-    if (res.length === 0) {
-      return undefined
-    }
 
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -519,6 +519,7 @@ export abstract class BaseNetwork extends EventEmitter {
     )
 
     const lookupKey = serializedContentKeyToContentId(decodedContentMessage.contentKey)
+    await new Promise((resolve) => setTimeout(resolve, 1000))
     const value = await this.findContentLocally(decodedContentMessage.contentKey)
     if (!value) {
       // Discv5 calls for maximum of 16 nodes per NODES message

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -520,7 +520,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
     const lookupKey = serializedContentKeyToContentId(decodedContentMessage.contentKey)
     const value = await this.findContentLocally(decodedContentMessage.contentKey)
-    if (!value || value.length === 0) {
+    if (!value) {
       // Discv5 calls for maximum of 16 nodes per NODES message
       const ENRs = this.routingTable.nearest(lookupKey, 16)
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -93,7 +93,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   abstract store(contentType: any, hashKey: string, value: Uint8Array): Promise<void>
 
-  public handle(message: ITalkReqMessage, src: INodeAddress) {
+  public async handle(message: ITalkReqMessage, src: INodeAddress) {
     const id = message.id
     const network = message.protocol
     const request = message.request
@@ -114,18 +114,18 @@ export abstract class BaseNetwork extends EventEmitter {
     )
     switch (messageType) {
       case MessageCodes.PING:
-        void this.handlePing(src, id, decoded as PingMessage)
+        await this.handlePing(src, id, decoded as PingMessage)
         break
       case MessageCodes.PONG:
         this.logger(`PONG message not expected in TALKREQ`)
         break
       case MessageCodes.FINDNODES:
         this.metrics?.findNodesMessagesReceived.inc()
-        void this.handleFindNodes(src, id, decoded as FindNodesMessage)
+        await this.handleFindNodes(src, id, decoded as FindNodesMessage)
         break
       case MessageCodes.FINDCONTENT:
         this.metrics?.findContentMessagesReceived.inc()
-        void this.handleFindContent(src, id, network, decoded as FindContentMessage)
+        await this.handleFindContent(src, id, network, decoded as FindContentMessage)
         break
       case MessageCodes.OFFER:
         this.metrics?.offerMessagesReceived.inc()

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -4,7 +4,7 @@ import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { BranchNode, LeafNode, Trie, decodeNode } from '@ethereumjs/trie'
-import { bytesToInt, bytesToUnprefixedHex, hexToBytes } from '@ethereumjs/util'
+import { bytesToInt, bytesToUnprefixedHex } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
 import debug from 'debug'
 
@@ -127,9 +127,9 @@ export class StateNetwork extends BaseNetwork {
     }
   }
 
-  public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array> => {
+  public findContentLocally = async (contentKey: Uint8Array): Promise<Uint8Array | undefined> => {
     const value = await this.stateDB.getContent(contentKey)
-    return value !== undefined ? fromHexString(value) : hexToBytes('0x')
+    return value !== undefined ? fromHexString(value) : undefined
   }
 
   public routingTableInfo = async () => {

--- a/packages/portalnetwork/src/networks/state/statedb.ts
+++ b/packages/portalnetwork/src/networks/state/statedb.ts
@@ -13,9 +13,17 @@ export class StateDB {
   stateRoots: Map<string, string>
   constructor(db: AbstractLevel<string, string, string>, logger?: Debugger) {
     this.db = new PortalTrieDB(db)
-    this.logger = logger ? logger.extend('StateDB') : debug('StateDB')
+    this.logger = logger
+      ? logger.extend('StateNetwork').extend('StateDB')
+      : debug('StateNetwork').extend('StateDB')
     this.stateRoots = new Map()
     this.blocks = new Map()
+  }
+
+  async keys() {
+    const keys = await this.db.keys()
+    this.logger(`keys: ${keys.length}`)
+    return keys
   }
 
   /**
@@ -28,6 +36,11 @@ export class StateDB {
     const dbKey = getDatabaseKey(contentKey)
     const dbContent = getDatabaseContent(keyType(contentKey), content)
     await this.db.put(dbKey, dbContent)
+    this.logger(
+      `storeContent (${content.length}) bytes: \ncontentKey: ${toHexString(
+        contentKey,
+      )}\ndbKey: 0x${dbKey}\ndbSize: ${(await this.keys()).length}`,
+    )
     return true
   }
 

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -153,7 +153,7 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
     this.temp = new Map()
   }
   async put(key: string, value: string) {
-    return this.db.put(key, value)
+    await this.db.put(key, value)
   }
   async get(key: string, _opts?: EncodingOpts) {
     try {
@@ -166,6 +166,13 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
   }
   async del(key: string) {
     await this.db.del(key)
+  }
+  async keys() {
+    const keys = await this.db.keys().all()
+    return keys
+  }
+  tempKeys() {
+    return this.temp.keys()
   }
 }
 export function getDatabaseKey(contentKey: Uint8Array) {

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -52,7 +52,6 @@ export class ContentRequest {
   }
 
   close(): void {
-    this.content = Uint8Array.from([])
     this.socket.close()
   }
 

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -280,11 +280,18 @@ export class PortalNetworkUTP extends EventEmitter {
   async _handleFinPacket(request: ContentRequest, packet: FinPacket) {
     const keys = request.contentKeys
     const content = await request.socket.handleFinPacket(packet)
+    if (!content) {
+      request.close()
+      this.openContentRequest.delete(request.socketKey)
+      return
+    }
     let contents = [content]
     if (request.requestCode === RequestCode.ACCEPT_READ) {
       contents = dropPrefixes(content)
     }
     await this.returnContent(request.networkId, contents, keys)
+    request.close()
+    this.openContentRequest.delete(request.socketKey)
   }
   async returnContent(network: NetworkId, contents: Uint8Array[], keys: Uint8Array[]) {
     this.logger(`Decompressing stream into ${keys.length} pieces of content`)
@@ -298,7 +305,7 @@ export class PortalNetworkUTP extends EventEmitter {
               HistoryNetworkContentType[k[0]]
             } to database`,
           )
-            this.emit(NetworkId.HistoryNetwork, k[0], decodedContentKey.blockHash, _content)
+          this.emit(NetworkId.HistoryNetwork, k[0], decodedContentKey.blockHash, _content)
         }
         break
       case NetworkId.BeaconLightClientNetwork:

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -298,12 +298,7 @@ export class PortalNetworkUTP extends EventEmitter {
               HistoryNetworkContentType[k[0]]
             } to database`,
           )
-          if (_content.length === 0) {
-            this.logger.extend(`FINISHED`)(`Missing content...`)
-            continue
-          } else {
             this.emit(NetworkId.HistoryNetwork, k[0], decodedContentKey.blockHash, _content)
-          }
         }
         break
       case NetworkId.BeaconLightClientNetwork:

--- a/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
@@ -3,6 +3,7 @@ import debug from 'debug'
 import type { StatePacket } from '../index.js'
 import type { Debugger } from 'debug'
 export class ContentReader {
+  bytesReceived: number
   packets: StatePacket[]
   inOrder: StatePacket[]
   reading: boolean
@@ -11,6 +12,7 @@ export class ContentReader {
   lastDataNr: number | undefined
   logger: Debugger
   constructor(startingDataNr: number) {
+    this.bytesReceived = 0
     this.packets = new Array<StatePacket>()
     this.inOrder = new Array<StatePacket>()
     this.reading = true
@@ -23,6 +25,7 @@ export class ContentReader {
 
   async addPacket(packet: StatePacket): Promise<boolean | number> {
     this.packets.push(packet)
+    this.bytesReceived += packet.payload!.length
     if (packet.header.seqNr === this.nextDataNr) {
       this.nextDataNr++
       return this.inOrder.push(packet)

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -220,15 +220,10 @@ describe('getAccount via network', async () => {
     assert.deepEqual(foundAccount.balance, BigInt('0x3636cd06e2db3a8000'), 'account data found')
   })
 
-  const temp = [...testClient.stateDB.db.temp.keys()]
-  const perm: string[] = []
-  for await (const key of testClient.stateDB.db.db.keys()) {
-    perm.push(key)
-  }
-  it('should have all nodes in temp or permanent db', () => {
+  const temp = [...testClient.stateDB.db.tempKeys()]
+  const perm: string[] = await testClient.stateDB.keys()
+  it('should have all nodes in temp or permanent db', async () => {
     expect(temp.length + perm.length).toEqual(uniqueStored.length)
-  })
-  it('should not have temp entries also in permanent db', () => {
     for (const key of temp) {
       expect(perm.includes(key)).toBeFalsy()
     }


### PR DESCRIPTION
Small fixes that address **portal-hive** test failures.

- uTP
  - `FIN` packet handling
  - socket closing
  - handling of `length=0` content
  - log bytes received progress during read stream

- RPC
  - send `PING` during `addEnr` method

- network
  - differentiate content not found and content=`0x` 
  - return `undefined` if not found
  - make `handle` method async

- DB Manager
  - Log during put/get methods

- Discv5
  - tweak timeout settings
