### PR TITLE
Various fixes

### DIFF
--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -62,12 +62,12 @@ const main = async () => {
   const pubIp = execSync(cmd).toString().split(' ')
   const ip = args.ip ?? pubIp[0]
   const children: ChildProcessByStdio<any, any, null>[] = []
-  const file = require.resolve(process.cwd() + '/dist/index.js')
+  const file = require.resolve('../src/index.js')
   if (args.pks !== undefined) {
     const pks = fs.readFileSync(args.pks, { encoding: 'utf8' }).split('\n')
     for (let idx = 0; idx < pks.length; idx++) {
       const child = spawn(
-        process.execPath,
+        'tsx',
         [
           file,
           `--rpc`,
@@ -86,7 +86,7 @@ const main = async () => {
   } else if (args.numNodes !== undefined) {
     for (let x = 0; x < args.numNodes; x++) {
       const child = spawn(
-        process.execPath,
+        'tsx',
         [
           file,
           `--rpcAddr=${ip}`,
@@ -124,7 +124,7 @@ const main = async () => {
   }
 
   // Connect nodes to other nodes in the network via `addBootNode`
-  if (args.connectNodes !== undefined) {
+  if (args.connectNodes !== false) {
     console.log('connecting nodes')
     const ultralights: jayson.HttpClient[] = []
     for (let x = 0; x < 10; x++) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,6 +127,7 @@ const main = async () => {
       enrUpdate: true,
       addrVotesToUpdateEnr: 5,
       allowUnverifiedSessions: true,
+      requestTimeout: 3000,
     },
     bindAddrs: {
       ip4: initMa,
@@ -181,7 +182,7 @@ const main = async () => {
   })
   portal.discv5.enableLogs()
 
-  portal.enableLog('*RPC*,*ultralight*,*Portal*')
+  portal.enableLog('*')
 
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined

--- a/packages/portalnetwork/src/networks/history/eth_module.ts
+++ b/packages/portalnetwork/src/networks/history/eth_module.ts
@@ -44,7 +44,9 @@ export class ETH {
     try {
       let lookup = new ContentLookup(this.network, headerContentKey)
       lookupResponse = await lookup.startLookup()
-      this.network.logger.extend('getBlockByHash')(`Looking for ${blockHash} on the network`)
+      this.network.logger.extend('getBlockByHash')(
+        `Looking for BlockHeader for ${blockHash} on the network`,
+      )
       this.network.logger.extend('getBlockByHash')(lookupResponse)
       if (!lookupResponse || !('content' in lookupResponse)) {
         return undefined
@@ -58,6 +60,10 @@ export class ETH {
       } else {
         lookup = new ContentLookup(this.network, bodyContentKey!)
         lookupResponse = await lookup.startLookup()
+        this.network.logger.extend('getBlockByHash')(
+          `Looking for BlockBody for ${blockHash} on the network`,
+        )
+        this.network.logger.extend('getBlockByHash')(lookupResponse)
         if (!lookupResponse || !('content' in lookupResponse)) {
           block = reassembleBlock(header)
         } else {

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -248,6 +248,12 @@ export class HistoryNetwork extends BaseNetwork {
         await this.validateHeader(value, hashKey)
       } catch (err) {
         this.logger(`Error validating header: ${(err as any).message}`)
+        // Putting anyway for now since we don't store epochs locally
+        this.put(
+          this.networkId,
+          getContentKey(contentType, hexToBytes(hashKey)),
+          toHexString(value),
+        )
       }
     } else {
       this.put(this.networkId, getContentKey(contentType, hexToBytes(hashKey)), toHexString(value))
@@ -268,7 +274,6 @@ export class HistoryNetwork extends BaseNetwork {
   }
 
   public async addBlockBody(value: Uint8Array, hashKey: string, header?: Uint8Array) {
-    const _bodyKey = getContentKey(HistoryNetworkContentType.BlockBody, hexToBytes(hashKey))
     if (value.length === 0) {
       // Occurs when `getBlockByHash` called `includeTransactions` === false
       return


### PR DESCRIPTION
- Updates the `devnet.ts` script to use `tsx` so we don't have to recompile the code to see changes we've made to source code in `cli`
- Adds some additional logging in `getBlockByHash`
- Relaxes the requirement to have a header proof when adding a block from an RPC call