### PR TITLE
CLI: increase request timeout in config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,6 +127,7 @@ const main = async () => {
       enrUpdate: true,
       addrVotesToUpdateEnr: 5,
       allowUnverifiedSessions: true,
+      requestTimeout: 3000,
     },
     bindAddrs: {
       ip4: initMa,
@@ -181,7 +182,7 @@ const main = async () => {
   })
   portal.discv5.enableLogs()
 
-  portal.enableLog('*RPC*,*ultralight*,*Portal*')
+  portal.enableLog('*')
 
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined


### PR DESCRIPTION
Fixes failing portal-hive tests by adding `requestTimout: 3000` to the discv5 config.