### PR TITLE
uTP: fix FIN bug

### DIFF
--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -280,9 +280,11 @@ export class PortalNetworkUTP extends EventEmitter {
   async _handleFinPacket(request: ContentRequest, packet: FinPacket) {
     const keys = request.contentKeys
     const content = await request.socket.handleFinPacket(packet)
-    if (!content) {
+    if (request.socket.type === UtpSocketType.WRITE) {
       request.close()
       this.openContentRequest.delete(request.socketKey)
+    }
+    if (!content || content.length === 0) {
       return
     }
     let contents = [content]
@@ -290,6 +292,7 @@ export class PortalNetworkUTP extends EventEmitter {
       contents = dropPrefixes(content)
     }
     await this.returnContent(request.networkId, contents, keys)
+    request.socket.close()
     request.close()
     this.openContentRequest.delete(request.socketKey)
   }


### PR DESCRIPTION
Addresses 2 bugs in FIN packet handling.

Per specs: a READ socket **MAY** send a FIN if it can determine that it has reached the end of the stream.

Ultralight was not prepared for these FIN packets, and would attempt to handle like a READ socket.  This updates WRITE socket FIN handler to close request if it receives a FIN.

Unknown bug causes READ socket to process FIN packets multiple times, sometimes resulting in overwriting content in the DB with an empty Uint8Array.

While this does not directly address the (unknown) cause of this bug, we update the FIN packet handler to check if content is 0 bytes before processing.  

Content that is supposed to by 0 bytes will still be processed, because this check happens before the `dropPrefixes` call, and therefore should never be 0 bytes.

This PR fixes several failing Portal Hive interop tests.