### PR TITLE
history: fix bug in gossip.enqueue

### DIFF
--- a/packages/portalnetwork/src/networks/history/gossip.ts
+++ b/packages/portalnetwork/src/networks/history/gossip.ts
@@ -37,7 +37,7 @@ export class GossipManager {
    * @returns the current number of items in a peer's gossip queue
    */
   private enqueue(peer: Peer, key: Uint8Array): number {
-    if (this.gossipQueues[peer] !== undefined) {
+    if (this.gossipQueues[peer] === undefined) {
       this.gossipQueues[peer] = []
     }
     if (!this.history.routingTable.contentKeyKnownToPeer(peer, toHexString(key))) {

--- a/packages/portalnetwork/src/networks/history/gossip.ts
+++ b/packages/portalnetwork/src/networks/history/gossip.ts
@@ -37,12 +37,13 @@ export class GossipManager {
    * @returns the current number of items in a peer's gossip queue
    */
   private enqueue(peer: Peer, key: Uint8Array): number {
-    if (!this.history.routingTable.contentKeyKnownToPeer(peer, toHexString(key))) {
-      this.gossipQueues[peer] !== undefined
-        ? this.gossipQueues[peer].push(key)
-        : (this.gossipQueues[peer] = [key])
+    if (this.gossipQueues[peer] !== undefined) {
+      this.gossipQueues[peer] = []
     }
-    return this.gossipQueues[peer]?.length ?? 0
+    if (!this.history.routingTable.contentKeyKnownToPeer(peer, toHexString(key))) {
+      this.gossipQueues[peer].push(key)
+    }
+    return this.gossipQueues[peer].length
   }
 
   /**

--- a/packages/portalnetwork/src/networks/history/gossip.ts
+++ b/packages/portalnetwork/src/networks/history/gossip.ts
@@ -42,7 +42,7 @@ export class GossipManager {
         ? this.gossipQueues[peer].push(key)
         : (this.gossipQueues[peer] = [key])
     }
-    return this.gossipQueues[peer].length
+    return this.gossipQueues[peer]?.length ?? 0
   }
 
   /**


### PR DESCRIPTION
Fixes error in history gossip manager which causes error to throw when gossip functions are called on peers not yet in the routing table or gossip queue.  This does not happen in normal operation, but is a condition that can be met using direct RPC controls such as in **hive** testing scenarios.  

This moves the conditional that adds an empty array to the gossip queue if the peer is not yet in the queue to the beginning of the function.
