### PR TITLE
RPC: wrap PING in try/catch during addENR

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -313,9 +313,6 @@ export class portal {
       }
       this._client.discv5.addEnr(enr)
       this._history.routingTable.insertOrUpdate(encodedENR, EntryStatus.Connected)
-      try {
-        await this._history.sendPing(enr)
-      } catch {}
       return true
     } catch {
       return false

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -313,7 +313,9 @@ export class portal {
       }
       this._client.discv5.addEnr(enr)
       this._history.routingTable.insertOrUpdate(encodedENR, EntryStatus.Connected)
-      await this._history.sendPing(enr)
+      try {
+        await this._history.sendPing(enr)
+      } catch {}
       return true
     } catch {
       return false


### PR DESCRIPTION
The design of `portal-hive` tests causes an error.

`RPC-compat` expects to test `addEnr`, `getEnr`, `deleteEnr` endpoints without actually having an active node with the tested ENR.  So if we try to PING during `addEnr`, we will meet an error.

This PR removes the PING from `addEnr`

This will likely cause errors in other `interop` tests in hive which will need to be addressed separately.  