### PR TITLE
Update Node version for cli package and workflows from version 18 to 20

### DIFF
--- a/.github/workflows/build-android-app.yml
+++ b/.github/workflows/build-android-app.yml
@@ -20,10 +20,10 @@ jobs:
     - name: checkout code
       uses: actions/checkout@v2
 
-    - name: Use Node.js 18
+    - name: Use Node.js 20
       uses: actions/setup-node@v2
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
     - run: npm i
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/devnet-run.yml
+++ b/.github/workflows/devnet-run.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/portalnetwork-build.yml
+++ b/.github/workflows/portalnetwork-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": "^18"
+    "node": "^20"
   },
   "devDependencies": {
     "@lodestar/api": "^1.12.0",


### PR DESCRIPTION
This is to break my resilience to do PRs towards and Ultralight repo and maybe it is even doing something useful. 😂

(Node 18 is in maintenance mode https://nodejs.org/en/about/previous-releases and so it is likely time to upgrade, I personally stumbled upon this during installation)

<img width="603" alt="grafik" src="https://github.com/ethereumjs/ultralight/assets/931137/e6938e31-8de9-4192-9671-2455a677e2ff">