### PR TITLE
OFFER rpc method

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -10,7 +10,6 @@ import {
   NodeLookup,
   PingPongCustomDataType,
   PortalWireMessageType,
-  decodeHistoryNetworkContentKey,
   fromHexString,
   shortId,
   toHexString,
@@ -789,19 +788,17 @@ export class portal {
   async historyOffer(params: [string, string, string]) {
     const [enrHex, contentKeyHex, contentValueHex] = params
     const enr = ENR.decodeTxt(enrHex)
-    const contentKey = decodeHistoryNetworkContentKey(contentKeyHex)
     if (this._history.routingTable.getWithPending(enr.nodeId)?.value === undefined) {
       const res = await this._history.sendPing(enr)
       if (res === undefined) {
         return '0x'
       }
     }
-    await this._history.store(
-      contentKey.contentType,
-      contentKey.blockHash,
-      fromHexString(contentValueHex),
+    const res = await this._history.sendOffer(
+      enr.nodeId,
+      [fromHexString(contentKeyHex)],
+      [fromHexString(contentValueHex)],
     )
-    const res = await this._history.sendOffer(enr.nodeId, [fromHexString(contentKeyHex)])
     return res
   }
   async historySendOffer(params: [string, string[]]) {

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -820,9 +820,11 @@ export class portal {
         return '0x'
       }
     }
-    const contentKey = fromHexString(contentKeyHex)
-    await this._state.store(contentKey[0], contentKeyHex, fromHexString(contentValueHex))
-    const res = await this._state.sendOffer(enr.nodeId, [fromHexString(contentKeyHex)])
+    const res = await this._state.sendOffer(
+      enr.nodeId,
+      [fromHexString(contentKeyHex)],
+      [fromHexString(contentValueHex)],
+    )
     return res
   }
   async stateSendOffer(params: [string, string[]]) {


### PR DESCRIPTION
RPC method portal_historyOffer and portal_stateOffer take the actual `content` as a parameter.  

Ultralight had no direct method of offering this content without storing first, so included an extra step of storing the content first before offering.  

Not only was this unnecessary processing, it became a problem with the new `state` network design, in which OFFERs contain a proof that does not get fully stored by the client.

This adds an optional parameter to `network.sendOffer` for the list of content.  If provided, the method bypasses the DB call and simply forwards the OFFER to the intended peer.

This fixes OFFER related `portal-hive` tests in the `state-interop` suite.