### PR TITLE
Remove-libp2p-interface-dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10955,7 +10955,6 @@
         "@ethereumjs/tx": "^5.3.0",
         "@ethereumjs/util": "^9.0.3",
         "@ethereumjs/vm": "^8.0.0",
-        "@libp2p/interface": "^1.1.1",
         "@libp2p/peer-id": "^4.0.4",
         "@libp2p/peer-id-factory": "^4.0.3",
         "@lodestar/config": "^1.17.0",
@@ -10986,7 +10985,7 @@
         "vitest": "^1.2.2"
       },
       "engines": {
-        "node": "^18"
+        "node": "^20"
       },
       "peerDependencies": {
         "alchemy-sdk": "^3.0.0-beta.3"
@@ -11016,7 +11015,6 @@
         "@ethereumjs/util": "^9.0.3",
         "@ethereumjs/vm": "^8.0.0",
         "@frontall/capacitor-udp": "^0.3.4",
-        "@libp2p/interface": "^1.1.1",
         "@libp2p/peer-id": "^4.0.4",
         "@libp2p/peer-id-factory": "^4.0.3",
         "@lodestar/config": "^1.17.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,6 @@
     "@ethereumjs/tx": "^5.3.0",
     "@ethereumjs/util": "^9.0.3",
     "@ethereumjs/vm": "^8.0.0",
-    "@libp2p/interface": "^1.1.1",
     "@libp2p/peer-id": "^4.0.4",
     "@libp2p/peer-id-factory": "^4.0.3",
     "@lodestar/config": "^1.17.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,6 @@ import { RPCManager } from './rpc/rpc.js'
 
 import type { Enr } from './rpc/schema/types.js'
 import type { ClientOpts } from './types.js'
-import type { PeerId } from '@libp2p/interface'
 
 const args: ClientOpts = yargs(hideBin(process.argv))
   .parserConfiguration({
@@ -104,7 +103,7 @@ const main = async () => {
       : execSync(cmd).toString().split(' ')[0].trim()
   const bindPort = args.bindAddress !== undefined ? args.bindAddress.split(':')[1] : 9000 // Default discv5 port
   const log = debug('ultralight')
-  let id: PeerId
+  let id: any
   let web3: jayson.Client | undefined
   if (args.pk === undefined) {
     id = await createSecp256k1PeerId()

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -37,7 +37,6 @@
     "@ethereumjs/util": "^9.0.3",
     "@ethereumjs/vm": "^8.0.0",
     "@frontall/capacitor-udp": "^0.3.4",
-    "@libp2p/interface": "^1.1.1",
     "@libp2p/peer-id": "^4.0.4",
     "@libp2p/peer-id-factory": "^4.0.3",
     "@lodestar/config": "^1.17.0",

--- a/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
+++ b/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
@@ -1,6 +1,5 @@
 import { SignableENR, createPeerIdFromPrivateKey } from '@chainsafe/enr'
 import { bytesToUnprefixedHex, hexToBytes } from '@ethereumjs/util'
-import { secp256k1 } from '@libp2p/interface'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -54,7 +53,7 @@ describe('StateNetwork AccountTrieNode Gossip', async () => {
       'enr:-IS4QIlbUdmqYYXh1Ga17owfX75adT0wftLk9iQNkpftJg9yDjTa4p9mGNmNSYyxIgrWPLg8gNUoSDCZPE3TSOT6SLsDgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQP0sUfmk0sj-uUuy08uM9bqpqmed0thhKXSzmJBOZPXNoN1ZHCCE4g',
       privateKey,
     ),
-    peerId: await createPeerIdFromPrivateKey(secp256k1, privateKey),
+    peerId: await createPeerIdFromPrivateKey('secp256k1', privateKey),
     r: 254,
   }
   const client = await PortalNetwork.create({


### PR DESCRIPTION
package: `@libp2p/interface` seems to be a blocker for EthJS Client integration.

This PR removes `@libp2p/interface` as a dependency.  This package was mostly used to declare types for the PeerId and Sepk256 variables during ENR creation, which can be achieved just as easily by declaring those variables as `any`.

We also adjust the client constructor to store the keypair itself instead of the `PeerId`, since accessing the keypair was the only use of the `PeerId` attribute beyond the constructor.