### PR TITLE
Individual Network Config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -83,6 +83,21 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     array: true,
     optional: true,
   })
+  .option('radiusHistory', {
+    describe: `2^r radius for history network client`,
+    number: true,
+    default: 0,
+  })
+  .option('radiusBeacon', {
+    describe: `2^r radius for beacon network client`,
+    number: true,
+    default: 0,
+  })
+  .option('radiusState', {
+    describe: `2^r radius for state network client`,
+    number: true,
+    default: 0,
+  })
   .option('trustedBlockRoot', {
     describe: 'a trusted blockroot to start light client syncing of the beacon chain',
     string: true,
@@ -140,13 +155,22 @@ const main = async () => {
     for (const network of args.networks) {
       switch (network) {
         case 'history':
-          networks.push({ networkId: NetworkId.HistoryNetwork, radius: 1n })
+          networks.push({
+            networkId: NetworkId.HistoryNetwork,
+            radius: 2n ** BigInt(args.radiusHistory) - 1n,
+          })
           break
         case 'beacon':
-          networks.push({ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n })
+          networks.push({
+            networkId: NetworkId.BeaconLightClientNetwork,
+            radius: 2n ** BigInt(args.radiusBeacon) - 1n,
+          })
           break
         case 'state':
-          networks.push({ networkId: NetworkId.StateNetwork, radius: 1n })
+          networks.push({
+            networkId: NetworkId.StateNetwork,
+            radius: 2n ** BigInt(args.radiusState) - 1n,
+          })
           break
       }
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import { RPCManager } from './rpc/rpc.js'
 import type { Enr } from './rpc/schema/types.js'
 import type { ClientOpts } from './types.js'
 import type { PeerId } from '@libp2p/interface'
+import type { NetworkConfig } from 'portalnetwork'
 
 const args: ClientOpts = yargs(hideBin(process.argv))
   .parserConfiguration({
@@ -134,27 +135,27 @@ const main = async () => {
     },
     trustedBlockRoot: args.trustedBlockRoot,
   } as any
-  let networks: NetworkId[] = []
+  let networks: NetworkConfig[] = []
   if (args.networks) {
     for (const network of args.networks) {
       switch (network) {
         case 'history':
-          networks.push(NetworkId.HistoryNetwork)
+          networks.push({ networkId: NetworkId.HistoryNetwork, radius: 1n })
           break
         case 'beacon':
-          networks.push(NetworkId.BeaconLightClientNetwork)
+          networks.push({ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n })
           break
         case 'state':
-          networks.push(NetworkId.StateNetwork)
+          networks.push({ networkId: NetworkId.StateNetwork, radius: 1n })
           break
       }
     }
   } else {
-    networks = [NetworkId.HistoryNetwork]
+    networks = [{ networkId: NetworkId.HistoryNetwork, radius: 1n }]
   }
 
   if (args.trustedBlockRoot !== undefined) {
-    networks.push(NetworkId.BeaconLightClientNetwork)
+    networks.push({ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n })
   }
 
   const bootnodes: Array<Enr> = []
@@ -171,7 +172,6 @@ const main = async () => {
 
   const portal = await PortalNetwork.create({
     config,
-    radius: 2n ** 256n - 1n,
     //@ts-ignore Because level doesn't know how to get along with itself
     db,
     metrics,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -277,6 +277,9 @@ export interface ClientOpts {
   dataDir?: string
   web3?: string
   networks?: (string | number)[]
+  radiusHistory: number
+  radiusBeacon: number
+  radiusState: number
   trustedBlockRoot?: string
 }
 

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -21,9 +21,13 @@ export enum TransportLayer {
   MOBILE = 'mobile',
 }
 
+export interface NetworkConfig {
+  networkId: NetworkId
+  radius: bigint
+}
+
 export interface PortalNetworkOpts {
-  supportedNetworks?: NetworkId[]
-  radius?: bigint
+  supportedNetworks?: NetworkConfig[]
   bootnodes?: string[]
   db?: AbstractLevel<string, string> | undefined
   metrics?: PortalNetworkMetrics

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -6,7 +6,7 @@ describe('Client unit tests', () => {
     const node = await PortalNetwork.create({
       bindAddress: '192.168.0.1',
       transport: TransportLayer.WEB,
-      supportedNetworks: [NetworkId.HistoryNetwork],
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
     })
     assert.equal(
       node.discv5.enr.getLocationMultiaddr('udp')!.toOptions().host,

--- a/packages/portalnetwork/test/client/eth/eth.spec.ts
+++ b/packages/portalnetwork/test/client/eth/eth.spec.ts
@@ -8,7 +8,10 @@ import type { StateNetwork } from '../../../src/networks/state/state.js'
 
 describe('ETH class base level API checks', async () => {
   const ultralight = await PortalNetwork.create({
-    supportedNetworks: [NetworkId.HistoryNetwork, NetworkId.StateNetwork],
+    supportedNetworks: [
+      { networkId: NetworkId.HistoryNetwork, radius: 1n },
+      { networkId: NetworkId.StateNetwork, radius: 1n },
+    ],
   })
   const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const state = ultralight.networks.get(NetworkId.StateNetwork) as StateNetwork

--- a/packages/portalnetwork/test/client/provider.spec.ts
+++ b/packages/portalnetwork/test/client/provider.spec.ts
@@ -24,7 +24,7 @@ it('Test provider functionality', async () => {
       enr,
       peerId,
     },
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
 
   const block = await provider.getBlock(5000)

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -45,7 +45,9 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -56,7 +58,9 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -116,7 +120,9 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -127,7 +133,9 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -222,7 +230,9 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -233,7 +243,9 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -299,7 +311,9 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -310,7 +324,9 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -419,7 +435,9 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -430,7 +448,9 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -518,7 +538,9 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -529,7 +551,9 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -601,7 +625,9 @@ describe('beacon light client sync tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -612,7 +638,9 @@ describe('beacon light client sync tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -732,7 +760,9 @@ describe('beacon light client sync tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -743,7 +773,9 @@ describe('beacon light client sync tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [
+        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+      ],
       config: {
         enr: enr2,
         bindAddrs: {

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -57,7 +57,7 @@ it('gossip test', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -68,7 +68,7 @@ it('gossip test', async () => {
   })
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -158,7 +158,7 @@ it('FindContent', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -170,7 +170,7 @@ it('FindContent', async () => {
 
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -226,7 +226,7 @@ it('eth_getBlockByHash', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -238,7 +238,7 @@ it('eth_getBlockByHash', async () => {
 
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
     config: {
       enr: enr2,
       bindAddrs: {

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -44,7 +44,7 @@ describe('AccountTrieNode Gossip / Request', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.StateNetwork],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: 2n ** 254n }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -52,11 +52,10 @@ describe('AccountTrieNode Gossip / Request', async () => {
       },
       peerId: id1,
     },
-    radius: 2n ** 254n,
   })
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.StateNetwork],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: 2n ** 254n }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -64,7 +63,6 @@ describe('AccountTrieNode Gossip / Request', async () => {
       },
       peerId: id2,
     },
-    radius: 2n ** 254n,
   })
   await node1.start()
   await node2.start()
@@ -143,7 +141,7 @@ describe('getAccount via network', async () => {
       enr.setLocationMultiaddr(initMa)
       const node = await PortalNetwork.create({
         transport: TransportLayer.NODE,
-        supportedNetworks: [NetworkId.StateNetwork],
+        supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: 2n ** 255n }],
         config: {
           enr,
           bindAddrs: {
@@ -151,7 +149,6 @@ describe('getAccount via network', async () => {
           },
           peerId,
         },
-        radius: 2n ** 255n,
       })
       await node.start()
       return node

--- a/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
@@ -140,7 +140,7 @@ describe('API tests', async () => {
 
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+    supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -293,7 +293,7 @@ describe('constructor/initialization tests', async () => {
   it('starts the bootstrap finder mechanism when no trusted block root is provided', async () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -313,7 +313,7 @@ describe('constructor/initialization tests', async () => {
   it('starts with a sync strategy of `trustedBootStrap` when a trusted block root is provided', async () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -349,7 +349,7 @@ describe('constructor/initialization tests', async () => {
     const trustedBlockRoot = '0x8e4fc820d749f9cf352d074f784071f65483ea673d8e9b8188870e950125a582'
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork],
+      supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
       config: {
         enr: enr1,
         bindAddrs: {

--- a/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
+++ b/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
@@ -12,7 +12,7 @@ const headerWithProofkey = '0x0088e96d4537bea4d9c05d12549907b32561d3bf31f45aae73
 
 describe('BlockIndex', async () => {
   const ultralight = await PortalNetwork.create({
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
   const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   await history.store(HistoryNetworkContentType.BlockHeader, hash, fromHexString(headerWithProof))
@@ -34,7 +34,7 @@ describe('BlockIndex', async () => {
   })
 
   const ultralight2 = await PortalNetwork.create({
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
     db: ultralight.db.db,
   })
   const history2 = ultralight2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork

--- a/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
@@ -35,7 +35,7 @@ describe('history Network FINDCONTENT/FOUNDCONTENT message handlers', async () =
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
 
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
@@ -90,7 +90,7 @@ describe('store -- Headers and Epoch Accumulators', async () => {
       )
     const node = await PortalNetwork.create({
       transport: TransportLayer.WEB,
-      supportedNetworks: [NetworkId.HistoryNetwork],
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
     })
     const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
     const block1Rlp =
@@ -126,7 +126,7 @@ describe('store -- Headers and Epoch Accumulators', async () => {
   it('Should store and retrieve an EpochAccumulator from DB', async () => {
     const node = await PortalNetwork.create({
       transport: TransportLayer.WEB,
-      supportedNetworks: [NetworkId.HistoryNetwork],
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
     })
     const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
     const epochAccumulator = require('../../testData/testEpoch.json')
@@ -146,7 +146,7 @@ describe('store -- Headers and Epoch Accumulators', async () => {
 describe('store -- Block Bodies and Receipts', async () => {
   const node = await PortalNetwork.create({
     transport: TransportLayer.WEB,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const serializedBlock = testBlocks.block207686
@@ -222,7 +222,7 @@ describe('Header Proof Tests', async () => {
   const _epoch1 = EpochAccumulator.deserialize(hexToBytes(_epochRaw))
   const node = await PortalNetwork.create({
     transport: TransportLayer.WEB,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   // network.accumulator.replaceAccumulator(accumulator)

--- a/packages/portalnetwork/test/networks/history/types.spec.ts
+++ b/packages/portalnetwork/test/networks/history/types.spec.ts
@@ -246,7 +246,7 @@ describe('Header With Proof serialization/deserialization tests', async () => {
     )
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
   const history = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const serializedBlock1 = hexToBytes(testData[1000001].content_value)

--- a/packages/portalnetwork/test/networks/protocol.spec.ts
+++ b/packages/portalnetwork/test/networks/protocol.spec.ts
@@ -25,7 +25,7 @@ describe('network wire message tests', async () => {
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
   const baseNetwork = node.networks.get(NetworkId.HistoryNetwork) as BaseNetwork
   it('BaseNetwork', async () => {
@@ -183,7 +183,7 @@ describe('handleFindNodes message handler tests', async () => {
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [NetworkId.HistoryNetwork],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
   })
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   type sendResponse = (src: INodeAddress, requestId: bigint, payload: Uint8Array) => Promise<void>

--- a/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
+++ b/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
@@ -58,8 +58,7 @@ describe('StateNetwork AccountTrieNode Gossip', async () => {
     r: 254,
   }
   const client = await PortalNetwork.create({
-    supportedNetworks: [NetworkId.StateNetwork],
-    radius: BigInt(2 ** config.r),
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: BigInt(2 ** config.r) }],
     config: {
       enr: config.enr,
       peerId: config.peerId,

--- a/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
@@ -16,8 +16,7 @@ describe('StateNetwork', async () => {
       enr: enr1,
       peerId: pk,
     },
-    radius,
-    supportedNetworks: [NetworkId.StateNetwork],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius }],
   })
   const stateNetwork = ultralight.networks.get(NetworkId.StateNetwork)
   it('should start with state network', () => {


### PR DESCRIPTION
Clients should be able to configure individual networks with unique `radius` settings.  

However, all `supported subnetworks` are initialized using a global radius value.  

This adds a type: `NetworkConfig`, and updates the type `PortalNetworkOpts` to accept as `supportedNetworks` a list of `NetworkConfig` options instead of simply a list of `NetworkId`.  `NetworkConfig` includes `NetworkId` as well as a `radius` value.

`PortalNetwork` client code was updated to assign each network its unique radius value.

CLI and test scripts were updated to pass the new `NetworkConfig` list into client constructors. 

```
export interface NetworkConfig {
  networkId: NetworkId
  radius: bigint
}

export interface PortalNetworkOpts {
  supportedNetworks?: NetworkConfig[]
  ...
}
```