### PR TITLE
uTP: refactor without events

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -11,6 +11,7 @@ import {
   PingPongCustomDataType,
   PortalWireMessageType,
   fromHexString,
+  getContentKey,
   shortId,
   toHexString,
 } from 'portalnetwork'
@@ -636,11 +637,12 @@ export class portal {
           : await new Promise((resolve) => {
               const timeout = setTimeout(() => {
                 resolve(Uint8Array.from([]))
-              }, 2000)
-              this._client.uTP.on(
-                NetworkId.HistoryNetwork,
-                (_contentType: HistoryNetworkContentType, hash: string, value: Uint8Array) => {
-                  if (hash.slice(2) === contentKey.slice(4)) {
+              }, 10000)
+              this._history.on(
+                'ContentAdded',
+                (hash: string, _contentType: HistoryNetworkContentType, value: Uint8Array) => {
+                  const _contentKey = getContentKey(_contentType, fromHexString(hash))
+                  if (_contentKey === contentKey) {
                     clearTimeout(timeout)
                     resolve(value)
                   }
@@ -687,9 +689,9 @@ export class portal {
               const timeout = setTimeout(() => {
                 resolve(Uint8Array.from([]))
               }, 2000)
-              this._client.uTP.on(
-                NetworkId.StateNetwork,
-                (_contentType: StateNetworkContentType, hash: string, value: Uint8Array) => {
+              this._state.on(
+                'ContentAdded',
+                (hash: string, _contentType: StateNetworkContentType, value: Uint8Array) => {
                   if (hash.slice(2) === contentKey.slice(4)) {
                     clearTimeout(timeout)
                     resolve(value)

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -179,7 +179,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     this.peerId = opts.config.peerId as PeerId
     this.supportsRendezvous = false
     this.unverifiedSessionCache = new LRUCache({ max: 2500 })
-    this.uTP = new PortalNetworkUTP(this.logger)
+    this.uTP = new PortalNetworkUTP(this)
     this.utpTimout = opts.utpTimeout ?? 180000 // set default utpTimeout to 3 minutes
     this.refreshListeners = new Map()
     this.db = new DBManager(
@@ -224,15 +224,6 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     // TODO: Decide whether to put everything on a centralized event bus
     this.discv5.on('talkReqReceived', this.onTalkReq)
     this.discv5.on('talkRespReceived', this.onTalkResp)
-    this.uTP.on('Send', async (peerId: string, msg: Buffer, networkId: NetworkId) => {
-      const enr = this.networks.get(networkId)?.routingTable.getWithPending(peerId)?.value
-      try {
-        await this.sendPortalNetworkMessage(enr ?? peerId, msg, networkId, true)
-        this.uTP.emit('Sent')
-      } catch {
-        this.uTP.closeRequest(msg.readUInt16BE(2), peerId)
-      }
-    })
     // if (this.discv5.sessionService.transport instanceof HybridTransportService) {
     //   ;(this.discv5.sessionService as any).send = this.send.bind(this)
     // }

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -74,12 +74,6 @@ export class BeaconLightClientNetwork extends BaseNetwork {
       .extend('Portal')
       .extend('BeaconLightClientNetwork')
     this.routingTable.setLogger(this.logger)
-    client.uTP.on(
-      NetworkId.BeaconLightClientNetwork,
-      async (contentType: number, hash: string, value: Uint8Array) => {
-        await this.store(contentType, hash, value)
-      },
-    )
     this.on('ContentAdded', async (contentKey) => {
       // Gossip new content to 5 random nodes in routing table
       for (let x = 0; x < 5; x++) {

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -1,11 +1,12 @@
 import { distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
-import { toHexString } from '@chainsafe/ssz'
+import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { hexToBytes, short } from '@ethereumjs/util'
 
 import { serializedContentKeyToContentId, shortId } from '../util/index.js'
 
 import { HistoryNetworkContentType } from './history/types.js'
+import { getContentKey } from './history/util.js'
 
 import type { BaseNetwork } from './network.js'
 import type { NodeId } from '@chainsafe/enr'
@@ -106,7 +107,8 @@ export class ContentLookup {
               contentType: HistoryNetworkContentType,
               content: Uint8Array,
             ) => {
-              if (contentKey === toHexString(this.contentKey.slice(1))) {
+              const _contentKey = getContentKey(contentType, fromHexString(contentKey))
+              if (_contentKey === toHexString(this.contentKey)) {
                 this.logger(
                   `Received content for this contentType: ${HistoryNetworkContentType[contentType]} + contentKey: ${toHexString(this.contentKey)}`,
                 )

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -54,12 +54,6 @@ export class HistoryNetwork extends BaseNetwork {
     this.ETH = new ETH(this)
     this.gossipManager = new GossipManager(this)
     this.routingTable.setLogger(this.logger)
-    client.uTP.on(
-      NetworkId.HistoryNetwork,
-      async (contentType: number, hash: string, value: Uint8Array) => {
-        await this.store(contentType, hash, value)
-      },
-    )
   }
   /**
    *

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -46,12 +46,6 @@ export class StateNetwork extends BaseNetwork {
     this.logger = debug(this.enr.nodeId.slice(0, 5)).extend('Portal').extend('StateNetwork')
     this.stateDB = new StateDB(client.db.db)
     this.routingTable.setLogger(this.logger)
-    client.uTP.on(
-      NetworkId.StateNetwork,
-      async (contentType: any, contentKey: Uint8Array, content: Uint8Array) => {
-        await this.store(contentType, toHexString(contentKey.slice(1)), content)
-      },
-    )
   }
 
   /**

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
@@ -1,6 +1,7 @@
 import type { BasicPacketHeader, SelectiveAckHeader } from './PacketHeader.js'
 import type { Packet } from './index.js'
 import type { NetworkId } from '../../../networks/types.js'
+import type { PortalNetworkUTP } from '../index.js'
 import type { Debugger } from 'debug'
 
 export const BUFFER_SIZE = 512
@@ -98,6 +99,7 @@ export interface IData extends IPacket<PacketType.ST_DATA> {
 export type ICreate<T extends PacketType> = IBasic<T> | ISelectiveAck | IData
 
 export interface UtpSocketOptions {
+  utp: PortalNetworkUTP
   networkId: NetworkId
   remoteAddress: string
   sndId: number

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -78,6 +78,7 @@ export class PortalNetworkUTP extends EventEmitter {
     content?: Uint8Array,
   ): UtpSocket {
     const socket: UtpSocket = new UtpSocket({
+      utp: this,
       networkId,
       remoteAddress,
       sndId,
@@ -87,10 +88,6 @@ export class PortalNetworkUTP extends EventEmitter {
       type: requestCode % 2 === 0 ? UtpSocketType.WRITE : UtpSocketType.READ,
       logger: this.logger,
       content,
-    })
-    socket.on('send', async (remoteAddr, msg, networkId) => {
-      await this.send(remoteAddr, msg, networkId)
-      socket.emit('sent')
     })
     return socket
   }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -1,5 +1,4 @@
 import { BitVectorType, toHexString } from '@chainsafe/ssz'
-import { EventEmitter } from 'events'
 
 import {
   BeaconLightClientNetworkContentType,
@@ -25,6 +24,7 @@ import type {
   DataPacket,
   FinPacket,
   INewRequest,
+  PortalNetwork,
   SelectiveAckHeader,
   StatePacket,
   SynPacket,
@@ -32,14 +32,15 @@ import type {
 } from '../../../index.js'
 import type { Debugger } from 'debug'
 
-export class PortalNetworkUTP extends EventEmitter {
+export class PortalNetworkUTP {
+  client: PortalNetwork
   openContentRequest: Map<UtpSocketKey, ContentRequest>
   logger: Debugger
   working: boolean
 
-  constructor(logger: Debugger) {
-    super()
-    this.logger = logger.extend(`uTP`)
+  constructor(client: PortalNetwork) {
+    this.client = client
+    this.logger = client.logger.extend(`uTP`)
     this.openContentRequest = new Map()
     this.working = false
   }
@@ -171,12 +172,12 @@ export class PortalNetworkUTP extends EventEmitter {
   }
 
   async send(peerId: string, msg: Buffer, networkId: NetworkId) {
-    this.emit('Send', peerId, msg, networkId, true)
-    return new Promise((resolve, _reject) => {
-      this.once('Sent', () => {
-        resolve(true)
-      })
-    })
+    const enr = this.client.networks.get(networkId)?.routingTable.getWithPending(peerId)?.value
+    try {
+      await this.client.sendPortalNetworkMessage(enr ?? peerId, msg, networkId, true)
+    } catch {
+      this.closeRequest(msg.readUInt16BE(2), peerId)
+    }
   }
 
   async _handleSynPacket(request: ContentRequest, packet: SynPacket): Promise<void> {
@@ -293,9 +294,10 @@ export class PortalNetworkUTP extends EventEmitter {
     request.close()
     this.openContentRequest.delete(request.socketKey)
   }
-  async returnContent(network: NetworkId, contents: Uint8Array[], keys: Uint8Array[]) {
+  async returnContent(networkId: NetworkId, contents: Uint8Array[], keys: Uint8Array[]) {
     this.logger(`Decompressing stream into ${keys.length} pieces of content`)
-    switch (network) {
+    const network = this.client.networks.get(networkId)
+    switch (networkId) {
       case NetworkId.HistoryNetwork:
         for (const [idx, k] of keys.entries()) {
           const decodedContentKey = decodeHistoryNetworkContentKey(toHexString(k))
@@ -305,12 +307,7 @@ export class PortalNetworkUTP extends EventEmitter {
               HistoryNetworkContentType[k[0]]
             } to database`,
           )
-          this.emit(
-            NetworkId.HistoryNetwork,
-            decodedContentKey.contentType,
-            decodedContentKey.blockHash,
-            _content,
-          )
+          await network!.store(decodedContentKey.contentType, decodedContentKey.blockHash, _content)
         }
         break
       case NetworkId.BeaconLightClientNetwork:
@@ -325,7 +322,7 @@ export class PortalNetworkUTP extends EventEmitter {
             this.logger.extend(`FINISHED`)(`Missing content...`)
             continue
           } else {
-            this.emit(NetworkId.BeaconLightClientNetwork, k[0], toHexString(k), _content)
+            await network!.store(k[0], toHexString(k), _content)
           }
         }
         break
@@ -341,7 +338,7 @@ export class PortalNetworkUTP extends EventEmitter {
             this.logger.extend(`FINISHED`)(`Missing content...`)
             continue
           } else {
-            this.emit(NetworkId.StateNetwork, k[0], k, _content)
+            await network!.store(k[0], toHexString(k.slice(1)), _content)
           }
         }
         break

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -1,5 +1,4 @@
 import { BitArray, BitVectorType } from '@chainsafe/ssz'
-import EventEmitter from 'events'
 
 import { bitmap } from '../../../index.js'
 import { PacketManager } from '../Packets/PacketManager.js'
@@ -9,10 +8,17 @@ import { ContentReader } from './ContentReader.js'
 import { ContentWriter } from './ContentWriter.js'
 
 import type { NetworkId } from '../../../index.js'
-import type { ICreateData, ICreatePacketOpts, Packet, UtpSocketOptions } from '../index.js'
+import type {
+  ICreateData,
+  ICreatePacketOpts,
+  Packet,
+  PortalNetworkUTP,
+  UtpSocketOptions,
+} from '../index.js'
 import type { Debugger } from 'debug'
 
-export class UtpSocket extends EventEmitter {
+export class UtpSocket {
+  utp: PortalNetworkUTP
   networkId: NetworkId
   type: UtpSocketType
   content: Uint8Array
@@ -36,7 +42,7 @@ export class UtpSocket extends EventEmitter {
   updateRTT: (packetRTT: number, ackNr: number) => void
   updateWindow: () => void
   constructor(options: UtpSocketOptions) {
-    super()
+    this.utp = options.utp
     this.networkId = options.networkId
     this.content = options.content ?? Uint8Array.from([])
     this.remoteAddress = options.remoteAddress
@@ -106,7 +112,7 @@ export class UtpSocket extends EventEmitter {
     this.logger.extend('SEND').extend(PacketType[packet.header.pType])(
       `|| ackNr: ${packet.header.ackNr}`,
     )
-    this.emit('send', this.remoteAddress, msg, this.networkId, true)
+    await this.utp.send(this.remoteAddress, msg, this.networkId)
     return msg
   }
 
@@ -251,7 +257,7 @@ export class UtpSocket extends EventEmitter {
         if (this.ackNr === this.finNr) {
           this.logger(`All data packets received. Running compiler.`)
           await this.sendAckPacket()
-          this.emit('done')
+          await this.finish()
         }
       }
       // Send "Regular" ACK with the new this.ackNr
@@ -287,28 +293,20 @@ export class UtpSocket extends EventEmitter {
       return _content
     } else {
       // TODO: Else wait for all data packets.
-      return new Promise((res, _rej) => {
-        const panic = setTimeout(() => {
-          res(Uint8Array.from([]))
-        }, 5000)
-        this.once('done', async () => {
-          this.seqNr = this.seqNr + 1
-          this.ackNr = packet.header.seqNr
-          await this.sendAckPacket()
-          clearTimeout(panic)
-          let _content = await this.reader!.run()
-          this.logger(`Packet payloads compiled into ${_content.length} bytes.  Sending FIN-ACK`)
-          if (_content.length === 0) {
-            while (_content.length === 0) {
-              _content = await this.reader!.run()
-            }
-          }
-          this.close()
-          this._clearTimeout()
-          res(_content)
-        })
-      })
+      return
     }
+  }
+
+  async finish() {
+    let _content = await this.reader!.run()
+    this.logger(`Packet payloads compiled into ${_content.length} bytes.  Sending FIN-ACK`)
+    if (_content.length === 0) {
+      while (_content.length === 0) {
+        _content = await this.reader!.run()
+      }
+    }
+    this.close()
+    this._clearTimeout()
   }
 
   compare(): boolean {
@@ -321,7 +319,6 @@ export class UtpSocket extends EventEmitter {
   close(): void {
     clearInterval(this.packetManager.congestionControl.timeoutCounter)
     this.packetManager.congestionControl.removeAllListeners()
-    this.removeAllListeners()
   }
   logProgress() {
     const needed = this.writer!.dataNrs.filter((n) => !this.ackNrs.includes(n))

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -80,16 +80,7 @@ export class UtpSocket extends EventEmitter {
 
   setWriter(seqNr: number) {
     this.setSeqNr(seqNr)
-    this.writer = new ContentWriter(this.content, seqNr, this.logger)
-    this.writer.on('send', async (packetType: PacketType, bytes?: Uint8Array) => {
-      if (packetType === PacketType.ST_DATA && bytes) {
-        await this.sendDataPacket(bytes)
-        this.writer?.emit('sent')
-      } else {
-        await this.sendFinPacket()
-        this.writer?.emit('sent')
-      }
-    })
+    this.writer = new ContentWriter(this, this.content, seqNr, this.logger)
     void this.writer.start()
   }
   setState(state: ConnectionState) {

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -91,20 +91,18 @@ describe('Find Content tests', () => {
       hexToBytes(bootstrap.content_value),
     )
     await new Promise((resolve) => {
-      node2.uTP.on(NetworkId.BeaconLightClientNetwork, async () => {
-        const content = await network2.findContentLocally(hexToBytes(bootstrap.content_key))
-        assert.notOk(content === undefined, 'should retrieve content for bootstrap key')
-        assert.equal(
-          toHexString(content!),
-          bootstrap.content_value,
-          'retrieved correct content for bootstrap',
-        )
-        await node1.stop()
-        await node2.stop()
-        resolve(undefined)
-      })
-      void network2.sendFindContent(node1.discv5.enr.nodeId, hexToBytes(bootstrap.content_key))
+      setTimeout(resolve, 5000)
     })
+    const content = await network2.findContentLocally(hexToBytes(bootstrap.content_key))
+    assert.notOk(content === undefined, 'should retrieve content for bootstrap key')
+    assert.equal(
+      toHexString(content!),
+      bootstrap.content_value,
+      'retrieved correct content for bootstrap',
+    )
+    await node1.stop()
+    await node2.stop()
+    void network2.sendFindContent(node1.discv5.enr.nodeId, hexToBytes(bootstrap.content_key))
   })
   it('should find optimistic update', async () => {
     const optimisticUpdate = specTestVectors.optimisticUpdate['6718463']

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -1,4 +1,3 @@
-import { toHexString } from '@chainsafe/ssz'
 import { hexToBytes } from '@ethereumjs/util'
 import { createSecp256k1PeerId } from '@libp2p/peer-id-factory'
 import { randomBytes } from 'crypto'
@@ -20,7 +19,6 @@ import {
   createSocketKey,
   dropPrefixes,
   encodeWithVariantPrefix,
-  getContentKey,
   randUint16,
   startingNrs,
 } from '../../../src/index.js'
@@ -497,20 +495,4 @@ describe('PortalNetworkUTP test', async () => {
       'contentRequest removed from openContentRequest',
     )
   })
-  // it('return content', async () => {
-  //   const contents = [randomBytes(100), randomBytes(100), randomBytes(100)]
-  //   const contentHashes = contents.map(() => toHexString(randomBytes(32)))
-  //   const contentKeys = contentHashes.map((hash) =>
-  //     hexToBytes(getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(hash))),
-  //   )
-  //   // utp.on(NetworkId.HistoryNetwork, (selector, hash, value) => {
-  //   //   assert.equal(selector, HistoryNetworkContentType.BlockHeader, 'Stream selector correct')
-  //   //   assert.ok(contentHashes.includes(hash), 'Streamed a requested content hash')
-  //   //   assert.deepEqual(value, contents[contentHashes.indexOf(hash)], 'Stream content correct')
-  //   // })
-  //   await utp.returnContent(NetworkId.HistoryNetwork, contents, contentKeys)
-  //   const history = utp.client.networks.get(NetworkId.HistoryNetwork)
-  //   const stored = await history?.retrieve(toHexString(contentKeys[0]))
-  //   // assert.isDefined(stored)
-  // })
 })


### PR DESCRIPTION
event listeners within the uTP protocol caused a lot of memory issues and errors

this PR refactors `PortalNetworkUtp`, `UtpSocket`, and `ContentWriter` classes to use `async` methods instead of event listeners.  

Also fixes issue with content returned from `uTP` streams.  Event listeners waiting for the end of uTP streams were checking only the `hash` part of content keys.  This resulted in occasionally returning the wrong content type if multiple pieces of content with the same `hash` value were streamed at the same time.