### PR TITLE
Parallel lookups in recursive find content

### DIFF
--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -8,6 +8,19 @@ import { hideBin } from 'yargs/helpers'
 import type { DevnetOpts } from '../src/types.js'
 import type { ChildProcessByStdio } from 'child_process'
 
+const bootnodes = [
+  'enr:-Jy4QIs2pCyiKna9YWnAF0zgf7bT0GzlAGoF8MEKFJOExmtofBIqzm71zDvmzRiiLkxaEJcs_Amr7XIhLI74k1rtlXICY5Z0IDAuMS4xLWFscGhhLjEtMTEwZjUwgmlkgnY0gmlwhKEjVaWJc2VjcDI1NmsxoQLSC_nhF1iRwsCw0n3J4jRjqoaRxtKgsEe5a-Dz7y0JloN1ZHCCIyg',
+  'enr:-Jy4QKSLYMpku9F0Ebk84zhIhwTkmn80UnYvE4Z4sOcLukASIcofrGdXVLAUPVHh8oPCfnEOZm1W1gcAxB9kV2FJywkCY5Z0IDAuMS4xLWFscGhhLjEtMTEwZjUwgmlkgnY0gmlwhJO2oc6Jc2VjcDI1NmsxoQLMSGVlxXL62N3sPtaV-n_TbZFCEM5AR7RDyIwOadbQK4N1ZHCCIyg',
+  'enr:-Jy4QH4_H4cW--ejWDl_W7ngXw2m31MM2GT8_1ZgECnfWxMzZTiZKvHDgkmwUS_l2aqHHU54Q7hcFSPz6VGzkUjOqkcCY5Z0IDAuMS4xLWFscGhhLjEtMTEwZjUwgmlkgnY0gmlwhJ31OTWJc2VjcDI1NmsxoQPC0eRkjRajDiETr_DRa5N5VJRm-ttCWDoO1QAMMCg5pIN1ZHCCIyg',
+  'enr:-IS4QGUtAA29qeT3cWVr8lmJfySmkceR2wp6oFQtvO_uMe7KWaK_qd1UQvd93MJKXhMnubSsTQPJ6KkbIu0ywjvNdNEBgmlkgnY0gmlwhMIhKO6Jc2VjcDI1NmsxoQJ508pIqRqsjsvmUQfYGvaUFTxfsELPso_62FKDqlxI24N1ZHCCI40',
+  'enr:-IS4QNaaoQuHGReAMJKoDd6DbQKMbQ4Mked3Gi3GRatwgRVVPXynPlO_-gJKRF_ZSuJr3wyHfwMHyJDbd6q1xZQVZ2kBgmlkgnY0gmlwhMIhKO6Jc2VjcDI1NmsxoQM2kBHT5s_Uh4gsNiOclQDvLK4kPpoQucge3mtbuLuUGYN1ZHCCI44',
+  'enr:-IS4QBdIjs6S1ZkvlahSkuYNq5QW3DbD-UDcrm1l81f2PPjnNjb_NDa4B5x4olHCXtx0d2ZeZBHQyoHyNnuVZ-P1GVkBgmlkgnY0gmlwhMIhKO-Jc2VjcDI1NmsxoQOO3gFuaCAyQKscaiNLC9HfLbVzFdIerESFlOGcEuKWH4N1ZHCCI40',
+  'enr:-IS4QM731tV0CvQXLTDcZNvgFyhhpAjYDKU5XLbM7sZ1WEzIRq4zsakgrv3KO3qyOYZ8jFBK-VzENF8o-vnykuQ99iABgmlkgnY0gmlwhMIhKO-Jc2VjcDI1NmsxoQMTq6Cdx3HmL3Q9sitavcPHPbYKyEibKPKvyVyOlNF8J4N1ZHCCI44',
+  'enr:-IS4QFV_wTNknw7qiCGAbHf6LxB-xPQCktyrCEZX-b-7PikMOIKkBg-frHRBkfwhI3XaYo_T-HxBYmOOQGNwThkBBHYDgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQKHPt5CQ0D66ueTtSUqwGjfhscU_LiwS28QvJ0GgJFd-YN1ZHCCE4k',
+  'enr:-IS4QDpUz2hQBNt0DECFm8Zy58Hi59PF_7sw780X3qA0vzJEB2IEd5RtVdPUYZUbeg4f0LMradgwpyIhYUeSxz2Tfa8DgmlkgnY0gmlwhKRc9_OJc2VjcDI1NmsxoQJd4NAVKOXfbdxyjSOUJzmA4rjtg43EDeEJu1f8YRhb_4N1ZHCCE4o',
+  'enr:-IS4QGG6moBhLW1oXz84NaKEHaRcim64qzFn1hAG80yQyVGNLoKqzJe887kEjthr7rJCNlt6vdVMKMNoUC9OCeNK-EMDgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQLJhXByb3LmxHQaqgLDtIGUmpANXaBbFw3ybZWzGqb9-IN1ZHCCE4k',
+  'enr:-IS4QA5hpJikeDFf1DD1_Le6_ylgrLGpdwn3SRaneGu9hY2HUI7peHep0f28UUMzbC0PvlWjN8zSfnqMG07WVcCyBhADgmlkgnY0gmlwhKRc9-KJc2VjcDI1NmsxoQJMpHmGj1xSP1O-Mffk_jYIHVcg6tY5_CjmWVg1gJEsPIN1ZHCCE4o',
+]
 const { Client } = jayson
 const require = createRequire(import.meta.url)
 
@@ -49,6 +62,11 @@ const args: any = yargs(hideBin(process.argv))
     boolean: true,
     default: false,
   })
+  .option('connectBootNodes', {
+    describe: 'connect to bootnodes on network start',
+    boolean: false,
+    default: false,
+  })
   .strict().argv as DevnetOpts
 
 const main = async () => {
@@ -60,7 +78,7 @@ const main = async () => {
       : []
   const cmd = 'hostname -I'
   const pubIp = execSync(cmd).toString().split(' ')
-  const ip = args.ip ?? pubIp[0]
+  const ip = '0.0.0.0'
   const children: ChildProcessByStdio<any, any, null>[] = []
   const file = require.resolve(process.cwd() + '/dist/index.js')
   if (args.pks !== undefined) {
@@ -137,6 +155,17 @@ const main = async () => {
         if (y === x) continue
         for (const network of args.networks) {
           await ultralights[y].request(`portal_${network}AddBootNode`, [peerEnr.result.enr])
+        }
+      }
+    }
+  }
+  if (args.connectBootNodes !== undefined) {
+    console.log('connecting to  bootnodes')
+    for (let x = 0; x < args.numNodes; x++) {
+      const ultralight = Client.http({ host: ip, port: 8545 + x })
+      for (const bootnode of bootnodes) {
+        for (const network of args.networks) {
+          await ultralight.request(`portal_${network}Ping`, [bootnode])
         }
       }
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -204,9 +204,9 @@ const main = async () => {
     trustedBlockRoot: args.trustedBlockRoot,
     bootnodes,
   })
-  portal.discv5.enableLogs()
+  // portal.discv5.enableLogs()
 
-  portal.enableLog('*')
+  // portal.enableLog('*')
 
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -73,9 +73,9 @@ export class ContentLookup {
       const results = await Promise.allSettled(promises)
 
       for (const result of results) {
-        if (result) {
+        if (result.status === 'fulfilled' && result.value !== undefined) {
           this.finished = true
-          return result
+          return result.value
         }
       }
     }

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -70,8 +70,7 @@ export class ContentLookup {
       // Process multiple peers in parallel
       const peerBatch = this.lookupPeers.splice(0, 5)
       const promises = peerBatch.map((peer) => this.processPeer(peer))
-
-      const results = await Promise.all(promises)
+      const results = await Promise.allSettled(promises)
 
       for (const result of results) {
         if (result) {

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -81,105 +81,105 @@ export class ContentLookup {
       }
     }
   }
-        return
-      }
-      this.contacted.push(nearestPeer.nodeId)
-      this.logger(`Requesting content from ${shortId(nearestPeer.nodeId)}`)
-      const res = await this.network.sendFindContent(nearestPeer.nodeId, this.contentKey)
-      if (!res) {
-        this.logger(`No response to findContent from ${shortId(nearestPeer.nodeId)}`)
-        continue
-      }
-      switch (res.selector) {
-        case 0: {
-          // findContent returned uTP connection ID
-          this.logger(
-            `received uTP connection ID from ${shortId(
-              this.network.routingTable.getValue(nearestPeer!.nodeId)!,
-            )}`,
-          )
-          finished = true
-          nearestPeer.hasContent = true
-          return new Promise((resolve, reject) => {
-            let timeout: any = undefined
-            const utpDecoder = (
-              contentKey: string,
-              contentType: HistoryNetworkContentType,
-              content: Uint8Array,
-            ) => {
-              const _contentKey = getContentKey(contentType, fromHexString(contentKey))
-              if (_contentKey === toHexString(this.contentKey)) {
-                this.logger(
-                  `Received content for this contentType: ${HistoryNetworkContentType[contentType]} + contentKey: ${toHexString(this.contentKey)}`,
-                )
-                this.network.removeListener('ContentAdded', utpDecoder)
-                clearTimeout(timeout)
-                resolve({ content, utp: true })
-              }
-            }
-            timeout = setTimeout(() => {
-              this.logger(`uTP stream timed out`)
-              this.network.removeListener('ContentAdded', utpDecoder)
-              reject('block not found')
-              // TODO: Set this as a configuration option
-            }, this.timeout)
-            this.network.on('ContentAdded', utpDecoder)
-          })
-        }
 
-        case 1: {
-          // findContent returned data sought
-          this.logger(`received content corresponding to ${shortId(toHexString(this.contentKey))}`)
-          finished = true
-          nearestPeer.hasContent = true
-          this.network.metrics?.successfulContentLookups.inc()
-          // POKE -- Offer content to neighbors who should have had content but don't if we receive content directly
-          for (const peer of this.contacted) {
-            if (
-              !this.network.routingTable.contentKeyKnownToPeer(peer, toHexString(this.contentKey))
-            ) {
-              // Only offer content if not already offered to this peer
-              await this.network.sendOffer(peer, [this.contentKey])
-            }
-          }
-          return { content: res.value as Uint8Array, utp: false }
-        }
-        case 2: {
-          // findContent request returned ENRs of nodes closer to content
-          this.logger(`received ${res.value.length} ENRs for closer nodes`)
-          if (!finished) {
-            for (const enr of res.value) {
-              const decodedEnr = ENR.decode(enr as Uint8Array)
-              // Disregard if nodes have been previously contacted during this lookup,
-              // Or if nodes are currently being ignored for unresponsiveness.
-              if (
-                this.contacted.includes(decodedEnr.nodeId) ||
-                this.network.routingTable.isIgnored(decodedEnr.nodeId)
-              ) {
-                continue
-              }
-              // Send a PING request to check liveness of any unknown nodes
-              if (!this.network.routingTable.getWithPending(decodedEnr.nodeId)?.value) {
-                const ping = await this.network.sendPing(decodedEnr)
-                if (!ping) {
-                  this.network.routingTable.evictNode(decodedEnr.nodeId)
-                  continue
-                }
-              }
-              if (!this.network.routingTable.getWithPending(decodedEnr.nodeId)?.value) {
-                continue
-              }
-              // Calculate distance and add to list of lookup peers
-              // Sort list by distance to keep closest node first
-              const dist = distance(decodedEnr.nodeId, this.contentId)
-              this.lookupPeers.map((peer) => peer.nodeId).includes(decodedEnr.nodeId) ||
-                this.lookupPeers.push({ nodeId: decodedEnr.nodeId, distance: dist })
-              this.lookupPeers = this.lookupPeers.sort(
-                (a, b) => Number(a.distance) - Number(b.distance),
+  private processPeer = async (peer: lookupPeer): Promise<ContentLookupResponse | void> => {
+    if (this.network.routingTable.isIgnored(peer.nodeId) || this.contacted.includes(peer.nodeId)) {
+      return
+    }
+    this.contacted.push(peer.nodeId)
+    this.logger(`Requesting content from ${shortId(peer.nodeId)}`)
+    const res = await this.network.sendFindContent!(peer.nodeId, this.contentKey)
+    if (this.finished) return
+    if (!res) {
+      this.logger(`No response to findContent from ${shortId(peer.nodeId)}`)
+      return
+    }
+    switch (res.selector) {
+      case 0: {
+        this.finished = true
+        // findContent returned uTP connection ID
+        this.logger(
+          `received uTP connection ID from ${shortId(this.network.routingTable.getValue(peer.nodeId)!)}`,
+        )
+        peer.hasContent = true
+        return new Promise((resolve, reject) => {
+          let timeout: any = undefined
+          const utpDecoder = (
+            contentKey: string,
+            contentType: HistoryNetworkContentType,
+            content: Uint8Array,
+          ) => {
+            const _contentKey = getContentKey(contentType, fromHexString(contentKey))
+            if (_contentKey === toHexString(this.contentKey)) {
+              this.logger(
+                `Received content for this contentType: ${HistoryNetworkContentType[contentType]} + contentKey: ${toHexString(this.contentKey)}`,
               )
+              this.network.removeListener('ContentAdded', utpDecoder)
+              clearTimeout(timeout)
+              resolve({ content, utp: true })
             }
           }
+          timeout = setTimeout(() => {
+            this.logger(`uTP stream timed out`)
+            this.network.removeListener('ContentAdded', utpDecoder)
+            reject('block not found')
+          }, this.timeout)
+          this.network.on('ContentAdded', utpDecoder)
+        })
+      }
+
+      case 1: {
+        this.finished = true
+        // findContent returned data sought
+        this.logger(`received content corresponding to ${shortId(toHexString(this.contentKey))}`)
+        peer.hasContent = true
+        this.network.metrics?.successfulContentLookups.inc()
+
+        // Offer content to neighbors who should have had content but don't if we receive content directly
+        for (const contactedPeer of this.contacted) {
+          if (
+            !this.network.routingTable.contentKeyKnownToPeer(
+              contactedPeer,
+              toHexString(this.contentKey),
+            )
+          ) {
+            // Only offer content if not already offered to this peer
+            await this.network.sendOffer(contactedPeer, [this.contentKey])
+          }
         }
+        return { content: res.value as Uint8Array, utp: false }
+      }
+
+      case 2: {
+        // findContent request returned ENRs of nodes closer to content
+        this.logger(`received ${res.value.length} ENRs for closer nodes`)
+        for (const enr of res.value) {
+          const decodedEnr = ENR.decode(enr as Uint8Array)
+          if (
+            this.contacted.includes(decodedEnr.nodeId) ||
+            this.network.routingTable.isIgnored(decodedEnr.nodeId)
+          ) {
+            continue
+          }
+          if (!this.network.routingTable.getWithPending(decodedEnr.nodeId)?.value) {
+            const ping = await this.network.sendPing(decodedEnr)
+            if (!ping) {
+              this.network.routingTable.evictNode(decodedEnr.nodeId)
+              continue
+            }
+          }
+          if (!this.network.routingTable.getWithPending(decodedEnr.nodeId)?.value) {
+            continue
+          }
+          const dist = distance(decodedEnr.nodeId, this.contentId)
+          if (!this.lookupPeers.map((peer) => peer.nodeId).includes(decodedEnr.nodeId)) {
+            this.lookupPeers.push({ nodeId: decodedEnr.nodeId, distance: dist })
+          }
+          this.lookupPeers = this.lookupPeers.sort(
+            (a, b) => Number(a.distance) - Number(b.distance),
+          )
+        }
+        return
       }
     }
   }

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -34,7 +34,7 @@ export class ContentLookup {
   private contentKey: Uint8Array
   private logger: Debugger
   private timeout: number
-
+  private finished: boolean
   constructor(network: BaseNetwork, contentKey: Uint8Array) {
     this.network = network
     this.lookupPeers = []
@@ -43,6 +43,7 @@ export class ContentLookup {
     this.contentId = serializedContentKeyToContentId(contentKey)
     this.logger = this.network.logger.extend('LOOKUP').extend(short(contentKey, 6))
     this.timeout = network.portal.utpTimout
+    this.finished = false
   }
 
   /**

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -265,7 +265,10 @@ export class StateNetwork extends BaseNetwork {
         }),
       )
       const request = await lookup.startLookup()
-      const requestContent = request && 'content' in request ? request.content : new Uint8Array()
+      if (request === undefined || !('content' in request)) {
+        throw new Error(`network doesn't have root node ${toHexString(stateroot)}`)
+      }
+      const requestContent = request.content
       const node = AccountTrieNodeRetrieval.deserialize(requestContent).node
       this.stateDB.db.temp.set(bytesToUnprefixedHex(stateroot), bytesToUnprefixedHex(node))
     }

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -212,7 +212,13 @@ describe('getAccount via network', async () => {
   const testAddress = '0x1a2694ec07cf5e4d68ba40f3e7a14c53f3038c6e'
   const stateRoot = trie['hash'](deserialized.proof[0])
   const found = await testClient.getAccount(testAddress, stateRoot, false)
-  const foundAccount = Account.fromRlpSerializedAccount(found!)
+  if (found === undefined) {
+    it('failed', () => {
+      assert.fail('failed to find account data')
+    })
+    return
+  }
+  const foundAccount = Account.fromRlpSerializedAccount(found)
   it('should find account data', async () => {
     assert.deepEqual(foundAccount.balance, BigInt('0x3636cd06e2db3a8000'), 'account data found')
   })

--- a/packages/portalnetwork/tsconfig.json
+++ b/packages/portalnetwork/tsconfig.json
@@ -13,7 +13,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
This improves the efficiency of recursive content lookups

We now make 5 requests at once to 5 closest peers:
```
while (!this.finished && this.lookupPeers.length > 0) {
      // Process multiple peers in parallel
      const peerBatch = this.lookupPeers.splice(0, 5)
      const promises = peerBatch.map((peer) => this.processPeer(peer))

      const results = await Promise.all(promises)

      for (const result of results) {
        if (result) {
          this.finished = true
          return result
        }
      }
    }
```

A new method: `processPeer` performs the content request and handles the response.

If there is no response, `processPeer` returns undefined.
If the response is an ENR list, the ENR's are added to the lookup, and `processPeer` returns **undefined**

If the reponse leads to a successfull content stream, either directly or via uTP, `processPeer` returns the **content response**

`ContentLookup` will proceed recursively in the same way as before, however will now make 5 parallel requests at a time in the process.  This should lead to more efficient lookups.