### PR TITLE
docs/refactor: update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ de2f8:ultralight Started JSON RPC Server address=http://localhost:8545
 
 This will start a single instance of the Ultralight client running locally.  
 
-## Connecting to the testnet
+## Connecting to the devnet (developer testnet)
 
-Follow the above quickstart guide and run `npm run dev-testnet` to start the client with the current list of bootnodes.  The client will attempt to ping all of bootnodes in the provided default bootnode list.
+1. Change active folder: `cd packages/cli`
+2. Run: `npm run devnet`
+3. Client starts with the current list of bootnodes which will attempt to ping all of bootnodes in the provided default bootnode list (specified in `packages/cli/bootnodes.txt`)
 
 ### Additional Documentation
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,9 @@ The easiest way to get started with Ultralight is to use the `npm run dev` scrip
   --web3              web3 JSON RPC HTTP endpoint for local Ethereum node    [string]
   --networks          subnetworks to enable  (options are: `history`, `state`, `beacon`) [default: `history`]
   --trustedBlockRoot  a trusted blockroot to start light client syncing of the beacon chain [string]
+  --radiusHistory     2^r radius for history network client                  [number] [default: 0]
+  --radiusBeacon      2^r radius for beacon network client                   [number] [default: 0]
+  --radiusState       2^r radius for state network client                    [number] [default: 0]
 ```
 ### Starting with the same Node ID 
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,6 +52,17 @@ Run a local network of CLI Ultralight clients.  Test JSON-RPC calls in a termina
 
 Note, all nodes are connected to each other as bootnodes for each network by default.  To turn off this behavior, pass `--connectNodes=false`.
 
+### CLI Parameters
+```sh
+  --pks           text file containing private keys for nodes in devnet  [string]
+  --numNodes      number of random nodes to start                        [number] (default: 1)
+  --ip            public ip address of the node                          [string]
+  --promConfig    create prometheus scrape_target file                   [boolean] (default: false)
+  --port          starting port number                                   [number] (default: 9000)
+  --networks      supported subnetworks                                  [array] (default: [`history`, `beacon`, `state`])
+  --connectNodes  connect all nodes on network start                     [boolean] (default: false)
+```
+
 ### Using the Devnet
 #### From the command-line:
   *Make JSON-RPC calls using `curl` or `httpie`*

--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -58,7 +58,7 @@ const args: any = yargs(hideBin(process.argv))
     optional: true,
   })
   .option('connectNodes', {
-    describe: 'connet all nodes on network start',
+    describe: 'connect all nodes on network start',
     boolean: true,
     default: false,
   })


### PR DESCRIPTION
I've updated two READMEs:
- `README.md`: correct the script name for running the "devnet"
- `packages/cli/README.md`: add missing CLI parameters