### PR TITLE
Update Identifiers

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -162,7 +162,7 @@ const main = async () => {
           break
         case 'beacon':
           networks.push({
-            networkId: NetworkId.BeaconLightClientNetwork,
+            networkId: NetworkId.BeaconChainNetwork,
             radius: 2n ** BigInt(args.radiusBeacon) - 1n,
           })
           break
@@ -179,7 +179,7 @@ const main = async () => {
   }
 
   if (args.trustedBlockRoot !== undefined) {
-    networks.push({ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n })
+    networks.push({ networkId: NetworkId.BeaconChainNetwork, radius: 1n })
   }
 
   const bootnodes: Array<Enr> = []

--- a/packages/cli/src/rpc/modules/beacon.ts
+++ b/packages/cli/src/rpc/modules/beacon.ts
@@ -31,9 +31,7 @@ export class beacon {
    * @param rpcManager RPC client to which the module binds
    */
   constructor(client: PortalNetwork, logger: Debugger) {
-    this._beacon = client.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    this._beacon = client.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
     this.logger = logger.extend('beacon')
 
     this.methods = middleware(this.methods.bind(this), 0, [])

--- a/packages/cli/src/rpc/modules/beacon.ts
+++ b/packages/cli/src/rpc/modules/beacon.ts
@@ -32,7 +32,7 @@ export class beacon {
    */
   constructor(client: PortalNetwork, logger: Debugger) {
     this._beacon = client.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     this.logger = logger.extend('beacon')
 

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -106,7 +106,7 @@ export class portal {
     this._client = client
     this._history = this._client.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
     this._beacon = this._client.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     this._state = this._client.networks.get(NetworkId.StateNetwork) as StateNetwork
     this.logger = logger

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -199,7 +199,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         case NetworkId.StateNetwork:
           this.networks.set(network.networkId, new StateNetwork(this, network.radius))
           break
-        case NetworkId.BeaconLightClientNetwork:
+        case NetworkId.BeaconChainNetwork:
           {
             const syncStrategy =
               opts.trustedBlockRoot !== undefined
@@ -308,7 +308,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   public network = (): {
     [NetworkId.HistoryNetwork]: HistoryNetwork | undefined
     [NetworkId.StateNetwork]: StateNetwork | undefined
-    [NetworkId.BeaconLightClientNetwork]: BeaconLightClientNetwork | undefined
+    [NetworkId.BeaconChainNetwork]: BeaconLightClientNetwork | undefined
   } => {
     const history = this.networks.get(NetworkId.HistoryNetwork)
       ? (this.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork)
@@ -316,13 +316,13 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     const state = this.networks.get(NetworkId.StateNetwork)
       ? (this.networks.get(NetworkId.StateNetwork) as StateNetwork)
       : undefined
-    const beacon = this.networks.get(NetworkId.BeaconLightClientNetwork)
-      ? (this.networks.get(NetworkId.BeaconLightClientNetwork) as BeaconLightClientNetwork)
+    const beacon = this.networks.get(NetworkId.BeaconChainNetwork)
+      ? (this.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork)
       : undefined
     return {
       [NetworkId.HistoryNetwork]: history,
       [NetworkId.StateNetwork]: state,
-      [NetworkId.BeaconLightClientNetwork]: beacon,
+      [NetworkId.BeaconChainNetwork]: beacon,
     }
   }
 

--- a/packages/portalnetwork/src/client/eth.ts
+++ b/packages/portalnetwork/src/client/eth.ts
@@ -29,7 +29,7 @@ export class ETH {
     this.activeNetworks = Object.keys(portal.network()) as NetworkId[]
     this.history = portal.network()['0x500b']
     this.state = portal.network()['0x500a']
-    this.beacon = portal.network()['0x501a']
+    this.beacon = portal.network()['0x500c']
     this.logger = portal.logger.extend(`ETH_GETBLOCKBYNUMBER`)
   }
 
@@ -64,7 +64,7 @@ export class ETH {
     let blockHash
     if (blockNumber === 'latest' || blockNumber === 'finalized') {
       // Requires beacon light client to be running to get `latest` or `finalized` blocks
-      this.networkCheck([NetworkId.BeaconLightClientNetwork])
+      this.networkCheck([NetworkId.BeaconChainNetwork])
       let clHeader
       if (blockNumber === 'latest') {
         clHeader = this.beacon!.lightClient?.getHead() as capella.LightClientHeader

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -50,7 +50,7 @@ import type { LightClientUpdate } from '@lodestar/types/lib/allForks/types.js'
 import type { Debugger } from 'debug'
 
 export class BeaconLightClientNetwork extends BaseNetwork {
-  networkId: NetworkId.BeaconLightClientNetwork
+  networkId: NetworkId.BeaconChainNetwork
   beaconConfig: BeaconConfig
   networkName = 'BeaconLightClientNetwork'
   logger: Debugger
@@ -69,7 +69,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
     const genesisRoot = hexToBytes(genesisData.mainnet.genesisValidatorsRoot)
     this.beaconConfig = createBeaconConfig(defaultChainConfig, genesisRoot)
 
-    this.networkId = NetworkId.BeaconLightClientNetwork
+    this.networkId = NetworkId.BeaconChainNetwork
     this.logger = debug(this.enr.nodeId.slice(0, 5))
       .extend('Portal')
       .extend('BeaconLightClientNetwork')
@@ -114,7 +114,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
    */
   private getBootstrap = async (nodeId: string, network: NetworkId) => {
     // We check the network ID because NodeAdded is emitted regardless of network
-    if (network !== NetworkId.BeaconLightClientNetwork) return
+    if (network !== NetworkId.BeaconChainNetwork) return
     const decoded = await this.sendFindContent(
       nodeId,
       concatBytes(
@@ -150,7 +150,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
    */
   private getBootStrapVote = async (nodeId: string, network: NetworkId) => {
     try {
-      if (network === NetworkId.BeaconLightClientNetwork) {
+      if (network === NetworkId.BeaconChainNetwork) {
         // We check the network ID because NodeAdded is emitted regardless of network
         if (this.bootstrapFinder.has(nodeId)) {
           return
@@ -802,7 +802,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
             case BeaconLightClientNetworkContentType.LightClientBootstrap: {
               try {
                 // TODO: Verify the offered bootstrap isn't too old before accepting
-                await this.get(NetworkId.BeaconLightClientNetwork, toHexString(key))
+                await this.get(NetworkId.BeaconChainNetwork, toHexString(key))
                 this.logger.extend('OFFER')(`Already have this content ${msg.contentKeys[x]}`)
               } catch (err) {
                 offerAccepted = true

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -12,10 +12,10 @@ const BYTE_SIZE = 256
 export enum NetworkId {
   StateNetwork = '0x500a',
   HistoryNetwork = '0x500b',
-  TxGossipNetwork = '0x500c',
-  HeaderGossipNetwork = '0x500d',
-  CanonicalIndicesNetwork = '0x500e',
-  BeaconLightClientNetwork = '0x501a',
+  BeaconChainNetwork = '0x500c',
+  CanonicalTxIndexNetwork = '0x500d',
+  VerkleStateNetwork = '0x500e',
+  TransactionGossipNetwork = '0x500f',
   UTPNetwork = '0x757470',
   Rendezvous = '0x72656e',
 }

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -16,17 +16,29 @@ export enum NetworkId {
   CanonicalTxIndexNetwork = '0x500d',
   VerkleStateNetwork = '0x500e',
   TransactionGossipNetwork = '0x500f',
+  Angelfood_StateNetwork = '0x504a',
+  Angelfood_HistoryNetwork = '0x504b',
+  Angelfood_BeaconChainNetwork = '0x504c',
+  Angelfood_CanonicalTxIndexNetwork = '0x504d',
+  Angelfood_VerkleStateNetwork = '0x504e',
+  Angelfood_TransactionGossipNetwork = '0x504f',
   UTPNetwork = '0x757470',
   Rendezvous = '0x72656e',
 }
 
 export type SubNetwork<T extends NetworkId> = T extends '0x500a'
   ? HistoryNetwork
-  : T extends '0x500b'
-    ? StateNetwork
-    : T extends '0x501a'
-      ? BeaconLightClientNetwork
-      : never
+  : T extends '0x504a'
+    ? HistoryNetwork
+    : T extends '0x500b'
+      ? StateNetwork
+      : T extends '0x504b'
+        ? StateNetwork
+        : T extends '0x500c'
+          ? BeaconLightClientNetwork
+          : T extends '0x504c'
+            ? BeaconLightClientNetwork
+            : never
 
 export class Bloom {
   bitvector: Uint8Array

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -310,7 +310,7 @@ export class PortalNetworkUTP {
           await network!.store(decodedContentKey.contentType, decodedContentKey.blockHash, _content)
         }
         break
-      case NetworkId.BeaconLightClientNetwork:
+      case NetworkId.BeaconChainNetwork:
         for (const [idx, k] of keys.entries()) {
           const _content = contents[idx]
           this.logger.extend(`FINISHED`)(

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -46,7 +46,7 @@ describe('Find Content tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -59,7 +59,7 @@ describe('Find Content tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -73,10 +73,10 @@ describe('Find Content tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     await network1!.sendPing(network2?.enr!.toENR())
     assert.equal(
@@ -121,7 +121,7 @@ describe('Find Content tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -134,7 +134,7 @@ describe('Find Content tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -148,10 +148,10 @@ describe('Find Content tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     // Stub out light client
@@ -231,7 +231,7 @@ describe('Find Content tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -244,7 +244,7 @@ describe('Find Content tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -258,10 +258,10 @@ describe('Find Content tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     await network1!.sendPing(network2?.enr!.toENR())
     assert.equal(
@@ -312,7 +312,7 @@ describe('OFFER/ACCEPT tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -325,7 +325,7 @@ describe('OFFER/ACCEPT tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -341,10 +341,10 @@ describe('OFFER/ACCEPT tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     // Stub out light client and set the light client's head slot value to equal our optimistic update slot
@@ -436,7 +436,7 @@ describe('OFFER/ACCEPT tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -449,7 +449,7 @@ describe('OFFER/ACCEPT tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -462,10 +462,10 @@ describe('OFFER/ACCEPT tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     // Stub out light client and set the light client's head slot value to equal our optimistic update slot
@@ -539,7 +539,7 @@ describe('OFFER/ACCEPT tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -552,7 +552,7 @@ describe('OFFER/ACCEPT tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -565,10 +565,10 @@ describe('OFFER/ACCEPT tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     await network1!.sendPing(network2?.enr!.toENR())
@@ -626,7 +626,7 @@ describe('beacon light client sync tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -639,7 +639,7 @@ describe('beacon light client sync tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -653,10 +653,10 @@ describe('beacon light client sync tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     const bootstrapJSON = require('./testdata/bootstrap.json').data
@@ -761,7 +761,7 @@ describe('beacon light client sync tests', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr1,
@@ -774,7 +774,7 @@ describe('beacon light client sync tests', () => {
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconLightClientNetwork, radius: 2n ** 256n - 1n },
+        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
       ],
       config: {
         enr: enr2,
@@ -789,10 +789,10 @@ describe('beacon light client sync tests', () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
     const network2 = node2.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     const capellaForkDigest = network1.beaconConfig.forkName2ForkDigest(ForkName.capella)

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -45,9 +45,7 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -58,9 +56,7 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -72,12 +68,8 @@ describe('Find Content tests', () => {
 
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
     await network1!.sendPing(network2?.enr!.toENR())
     assert.equal(
       network1?.routingTable.getWithPending(
@@ -120,9 +112,7 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -133,9 +123,7 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -147,12 +135,8 @@ describe('Find Content tests', () => {
 
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     // Stub out light client
     network1.lightClient = {
@@ -230,9 +214,7 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -243,9 +225,7 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -257,12 +237,8 @@ describe('Find Content tests', () => {
 
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
     await network1!.sendPing(network2?.enr!.toENR())
     assert.equal(
       network1?.routingTable.getWithPending(
@@ -311,9 +287,7 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -324,9 +298,7 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -340,12 +312,8 @@ describe('OFFER/ACCEPT tests', () => {
     node2.enableLog('*BeaconLightClientNetwork')
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     // Stub out light client and set the light client's head slot value to equal our optimistic update slot
     network1.lightClient = {
@@ -435,9 +403,7 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -448,9 +414,7 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -461,12 +425,8 @@ describe('OFFER/ACCEPT tests', () => {
     })
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     // Stub out light client and set the light client's head slot value to equal our optimistic update slot
     network1.lightClient = {
@@ -538,9 +498,7 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -551,9 +509,7 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -564,12 +520,8 @@ describe('OFFER/ACCEPT tests', () => {
     })
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     await network1!.sendPing(network2?.enr!.toENR())
 
@@ -625,9 +577,7 @@ describe('beacon light client sync tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -638,9 +588,7 @@ describe('beacon light client sync tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -652,12 +600,8 @@ describe('beacon light client sync tests', () => {
 
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     const bootstrapJSON = require('./testdata/bootstrap.json').data
     const bootstrap = ssz.capella.LightClientBootstrap.fromJson(bootstrapJSON)
@@ -760,9 +704,7 @@ describe('beacon light client sync tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -773,9 +715,7 @@ describe('beacon light client sync tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n },
-      ],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -788,12 +728,8 @@ describe('beacon light client sync tests', () => {
     //   node2.enableLog('*')
     await node1.start()
     await node2.start()
-    const network1 = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
-    const network2 = node2.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const network1 = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
+    const network2 = node2.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     const capellaForkDigest = network1.beaconConfig.forkName2ForkDigest(ForkName.capella)
 

--- a/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
+++ b/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
@@ -114,9 +114,7 @@ describe('eth_getBlockByNumber', () => {
 
     await node1.start()
 
-    const beacon = node1.networks.get(
-      NetworkId.BeaconChainNetwork,
-    ) as BeaconLightClientNetwork
+    const beacon = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     const history = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
     const bootstrapJSON = require('../testdata/bootstrap.json').data

--- a/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
+++ b/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
@@ -102,7 +102,7 @@ describe('eth_getBlockByNumber', () => {
 
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [NetworkId.BeaconLightClientNetwork, NetworkId.HistoryNetwork],
+      supportedNetworks: [NetworkId.BeaconChainNetwork, NetworkId.HistoryNetwork],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -115,7 +115,7 @@ describe('eth_getBlockByNumber', () => {
     await node1.start()
 
     const beacon = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
+      NetworkId.BeaconChainNetwork,
     ) as BeaconLightClientNetwork
 
     const history = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork

--- a/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
@@ -140,7 +140,7 @@ describe('API tests', async () => {
 
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -150,7 +150,7 @@ describe('API tests', async () => {
     },
   })
 
-  const network = <BeaconLightClientNetwork>node1.networks.get(NetworkId.BeaconLightClientNetwork)
+  const network = <BeaconLightClientNetwork>node1.networks.get(NetworkId.BeaconChainNetwork)
 
   it('stores and retrieves bootstrap', async () => {
     const bootstrap = specTestVectors.bootstrap['6718368']
@@ -293,7 +293,7 @@ describe('constructor/initialization tests', async () => {
   it('starts the bootstrap finder mechanism when no trusted block root is provided', async () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -302,9 +302,7 @@ describe('constructor/initialization tests', async () => {
         peerId: id1,
       },
     })
-    const beacon = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
-    ) as BeaconLightClientNetwork
+    const beacon = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
     const listeners = beacon.portal.listeners('NodeAdded')
     assert.equal(listeners.length, 1, 'bootstrap vote listener is running')
     assert.equal(listeners[0], beacon['getBootStrapVote'])
@@ -313,7 +311,7 @@ describe('constructor/initialization tests', async () => {
   it('starts with a sync strategy of `trustedBootStrap` when a trusted block root is provided', async () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -323,9 +321,7 @@ describe('constructor/initialization tests', async () => {
       },
       trustedBlockRoot: bytesToHex(randomBytes(32)),
     })
-    const beacon = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
-    ) as BeaconLightClientNetwork
+    const beacon = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
     const listeners = beacon.portal.listeners('NodeAdded')
     assert.equal(listeners.length, 1, 'bootstrap listener is running')
     assert.equal(listeners[0], beacon['getBootstrap'])
@@ -349,7 +345,7 @@ describe('constructor/initialization tests', async () => {
     const trustedBlockRoot = '0x8e4fc820d749f9cf352d074f784071f65483ea673d8e9b8188870e950125a582'
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconLightClientNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -359,9 +355,7 @@ describe('constructor/initialization tests', async () => {
       },
       trustedBlockRoot,
     })
-    const beacon = node1.networks.get(
-      NetworkId.BeaconLightClientNetwork,
-    ) as BeaconLightClientNetwork
+    const beacon = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconLightClientNetwork
 
     await beacon.initializeLightClient(trustedBlockRoot)
     assert.equal((beacon.lightClient as any).checkpointRoot, trustedBlockRoot)


### PR DESCRIPTION
Updates the `Network Identifiers` for each subnetwork.  Also adds identifiers for **Angelfood** test network.

https://github.com/ethereum/portal-network-specs/blob/master/portal-wire-protocol.md#angelfood-identifiers

Changed the name of `BeaconLightClientNetwork` to `BeaconChainNetwork` to align with naming in the spec.  