### PR TITLE
Reject out of radius

### DIFF
--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -1,3 +1,4 @@
+import { digest } from '@chainsafe/as-sha256'
 import { toHexString } from '@chainsafe/ssz'
 import {
   bytesToHex,
@@ -103,6 +104,10 @@ export class BeaconLightClientNetwork extends BaseNetwork {
         this.portal.on('NodeAdded', this.getBootstrap)
         break
     }
+  }
+
+  public contentKeyToId = (contentKey: Uint8Array): Uint8Array => {
+    return digest(contentKey)
   }
 
   /**

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -1,3 +1,4 @@
+import { digest } from '@chainsafe/as-sha256'
 import { ENR } from '@chainsafe/enr'
 import { ProofType, createProof } from '@chainsafe/persistent-merkle-tree'
 import { Block, BlockHeader } from '@ethereumjs/block'
@@ -51,6 +52,10 @@ export class HistoryNetwork extends BaseNetwork {
     this.logger = debug(this.enr.nodeId.slice(0, 5)).extend('Portal').extend('HistoryNetwork')
     this.gossipManager = new GossipManager(this)
     this.routingTable.setLogger(this.logger)
+  }
+
+  public contentKeyToId = (contentKey: Uint8Array): Uint8Array => {
+    return digest(contentKey)
   }
   /**
    *

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -93,6 +93,8 @@ export abstract class BaseNetwork extends EventEmitter {
     }
   }
 
+  abstract contentKeyToId: (contentKey: Uint8Array) => Uint8Array
+
   abstract store(contentType: any, hashKey: string, value: Uint8Array): Promise<void>
 
   public async handle(message: ITalkReqMessage, src: INodeAddress) {

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -48,6 +48,10 @@ export class StateNetwork extends BaseNetwork {
     this.routingTable.setLogger(this.logger)
   }
 
+  public contentKeyToId = (contentKey: Uint8Array): Uint8Array => {
+    return StateNetworkContentId.fromBytes(contentKey)
+  }
+
   /**
    * Send FINDCONTENT request for content corresponding to `key` to peer corresponding to `dstId`
    * @param dstId node id of peer

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -186,7 +186,7 @@ describe('getAccount via network', async () => {
   const result = await networks[0].receiveAccountTrieNodeOffer(contentKey, content)
   await new Promise((r) => setTimeout(r, 1000))
   it('should gossip some content', () => {
-    expect(result.gossipCount).toEqual(4)
+    expect(result.gossipCount).toEqual(3)
   })
   const storedInNodes = await Promise.all(
     clients.map(async (client) => {


### PR DESCRIPTION
Issue:  client accepts `contentKeys` from `OFFER` with `contentId` outside of the `nodeRadius`  

When the client sends gossip, it only sends to those peers for whom the `contentId` lies in their node radius.

However, upon receiving gossip, the client did not compare the incoming content id's to its own radius, instead, accepting every piece of offered content not already stored.  

This PR adds a distance check to the `handleOffer` method, which filters out content not in the node's radius.  


-- 
**Note** This update will cause some `portal-hive` tests to fail.  This is due to Ultralight defaulting to a radius of 0.  A PR has been submitted to the `hive` repo adding commandline flags to the startup script that set the node radius to `2^256 - 1`.  Merging that update into hive should resolve the broken test cases.