### PR TITLE
RPC: add radius and storage methods to ultralight namespace

### DIFF
--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -52,9 +52,8 @@ export class ultralight {
     this.logger(`ultralight_addBlockToHistory request received`)
 
     const [blockHash, rlpHex] = params
-    const network = this._client.networks.get(NetworkId.HistoryNetwork) as never as HistoryNetwork
     try {
-      await addRLPSerializedBlock(rlpHex, blockHash, network)
+      await addRLPSerializedBlock(rlpHex, blockHash, this._history!)
       this.logger(`Block ${blockHash} added to content DB`)
       return `Block ${blockHash} added to content DB`
     } catch (err: any) {
@@ -83,7 +82,7 @@ export class ultralight {
     const [blockNum, blockHash] = params
     try {
       this.logger(`Indexed block ${BigInt(blockNum)} / ${blockNum} to ${blockHash} `)
-      await this._history.indexBlockhash(BigInt(blockNum), blockHash)
+      await this._history!.indexBlockhash(BigInt(blockNum), blockHash)
       return `Added ${blockNum} to block index`
     } catch (err: any) {
       throw {

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -9,18 +9,27 @@ import { INTERNAL_ERROR } from '../error-code.js'
 import { middleware, validators } from '../validators.js'
 
 import type { Debugger } from 'debug'
-import type { HistoryNetwork, PortalNetwork } from 'portalnetwork'
+import type {
+  BeaconLightClientNetwork,
+  HistoryNetwork,
+  PortalNetwork,
+  StateNetwork,
+} from 'portalnetwork'
 
 const methods = ['ultralight_store', 'ultralight_addBlockToHistory']
 
 export class ultralight {
   private _client: PortalNetwork
-  private _history: HistoryNetwork
+  private _history?: HistoryNetwork
+  private _state?: StateNetwork
+  private _beacon?: BeaconLightClientNetwork
   private logger: Debugger
 
   constructor(client: PortalNetwork, logger: Debugger) {
     this._client = client
-    this._history = this._client.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    this._history = this._client.network()[NetworkId.HistoryNetwork]
+    this._state = this._client.network()[NetworkId.StateNetwork]
+    this._beacon = this._client.network()[NetworkId.BeaconChainNetwork]
     this.logger = logger
     this.methods = middleware(this.methods.bind(this), 0, [])
     this.addContentToDB = middleware(this.addContentToDB.bind(this), 2, [

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -44,6 +44,10 @@ export class ultralight {
       [validators.hex],
       [validators.blockHash],
     ])
+    this.setNetworkRadius = middleware(this.setNetworkRadius.bind(this), 2, [
+      [validators.networkId],
+      [validators.distance],
+    ])
   }
   async methods() {
     return methods

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -24,6 +24,7 @@ const methods = [
   'ultralight_setNetworkRadius',
   'ultralight_getNetworkRadius',
   'ultralight_getNetworkStorageInfo',
+  'ultralight_getNetworkDBSize',
 ]
 
 export class ultralight {
@@ -60,6 +61,9 @@ export class ultralight {
       [validators.networkId],
     ])
     this.getNetworkStorageInfo = middleware(this.getNetworkStorageInfo.bind(this), 1, [
+      [validators.networkId],
+    ])
+    this.getNetworkDBSize = middleware(this.getNetworkDBSize.bind(this), 1, [
       [validators.networkId],
     ])
   }
@@ -161,5 +165,17 @@ export class ultralight {
       dbSize: await network.db.size(),
       radius: '0x' + network.nodeRadius.toString(16),
     }
+  }
+  async getNetworkDBSize(params: [NetworkId]) {
+    const [networkId] = params
+    const network = this._client.networks.get(networkId)
+    if (!network) {
+      throw {
+        code: INTERNAL_ERROR,
+        message: `Invalid network id ${networkId}`,
+      }
+    }
+    const size = await network.db.size()
+    return size
   }
 }

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -98,7 +98,7 @@ export class ultralight {
       `ultralight_addContentToDB request received for ${HistoryNetworkContentType[type]} ${contentKey}`,
     )
     try {
-      await this._history.store(contentKey, fromHexString(value))
+      await this._history!.store(contentKey, fromHexString(value))
       this.logger(`${type} value for ${contentKey} added to content DB`)
       return `${type} value for ${contentKey} added to content DB`
     } catch (err: any) {

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -23,6 +23,7 @@ const methods = [
   'ultralight_indexBlock',
   'ultralight_setNetworkRadius',
   'ultralight_getNetworkRadius',
+  'ultralight_getNetworkStorageInfo',
 ]
 
 export class ultralight {
@@ -56,6 +57,9 @@ export class ultralight {
       [validators.distance],
     ])
     this.getNetworkRadius = middleware(this.getNetworkRadius.bind(this), 1, [
+      [validators.networkId],
+    ])
+    this.getNetworkStorageInfo = middleware(this.getNetworkStorageInfo.bind(this), 1, [
       [validators.networkId],
     ])
   }
@@ -142,5 +146,20 @@ export class ultralight {
       }
     }
     return { radius: '0x' + network.nodeRadius.toString(16) }
+  }
+  async getNetworkStorageInfo(params: [NetworkId]) {
+    const [networkId] = params
+    const network = this._client.networks.get(networkId)
+    if (!network) {
+      throw {
+        code: INTERNAL_ERROR,
+        message: `Invalid network id ${networkId}`,
+      }
+    }
+    return {
+      maxStorage: network.maxStorage,
+      dbSize: await network.db.size(),
+      radius: '0x' + network.nodeRadius.toString(16),
+    }
   }
 }

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -25,6 +25,7 @@ const methods = [
   'ultralight_getNetworkRadius',
   'ultralight_getNetworkStorageInfo',
   'ultralight_getNetworkDBSize',
+  'ultralight_pruneNetworkDB',
 ]
 
 export class ultralight {
@@ -66,6 +67,7 @@ export class ultralight {
     this.getNetworkDBSize = middleware(this.getNetworkDBSize.bind(this), 1, [
       [validators.networkId],
     ])
+    this.pruneNetworkDB = middleware(this.pruneNetworkDB.bind(this), 1, [[validators.networkId]])
   }
   async methods() {
     return methods
@@ -177,5 +179,21 @@ export class ultralight {
     }
     const size = await network.db.size()
     return size
+  }
+  async pruneNetworkDB(params: [NetworkId]) {
+    const [networkId] = params
+    const network = this._client.networks.get(networkId)
+    if (!network) {
+      throw {
+        code: INTERNAL_ERROR,
+        message: `Invalid network id ${networkId}`,
+      }
+    }
+    await network.prune()
+    return {
+      maxStorage: network.maxStorage,
+      dbSize: await network.db.size(),
+      radius: '0x' + network.nodeRadius.toString(16),
+    }
   }
 }

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -16,7 +16,13 @@ import type {
   StateNetwork,
 } from 'portalnetwork'
 
-const methods = ['ultralight_store', 'ultralight_addBlockToHistory']
+const methods = [
+  'ultralight_methods',
+  'ultralight_addContentToDB',
+  'ultralight_addBlockToHistory',
+  'ultralight_indexBlock',
+  'ultralight_setNetworkRadius',
+]
 
 export class ultralight {
   private _client: PortalNetwork

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -22,6 +22,7 @@ const methods = [
   'ultralight_addBlockToHistory',
   'ultralight_indexBlock',
   'ultralight_setNetworkRadius',
+  'ultralight_getNetworkRadius',
 ]
 
 export class ultralight {
@@ -53,6 +54,9 @@ export class ultralight {
     this.setNetworkRadius = middleware(this.setNetworkRadius.bind(this), 2, [
       [validators.networkId],
       [validators.distance],
+    ])
+    this.getNetworkRadius = middleware(this.getNetworkRadius.bind(this), 1, [
+      [validators.networkId],
     ])
   }
   async methods() {
@@ -127,5 +131,16 @@ export class ultralight {
     } catch (err: any) {
       return `Error setting radius ${err.message.toString()}`
     }
+  }
+  async getNetworkRadius(params: [NetworkId]) {
+    const [networkId] = params
+    const network = this._client.networks.get(networkId)
+    if (!network) {
+      throw {
+        code: INTERNAL_ERROR,
+        message: `Invalid network id ${networkId}`,
+      }
+    }
+    return { radius: '0x' + network.nodeRadius.toString(16) }
   }
 }

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -91,4 +91,31 @@ export class ultralight {
       }
     }
   }
+  async setNetworkRadius(params: [NetworkId, string]) {
+    const [networkId, radius] = params
+    try {
+      switch (networkId) {
+        case NetworkId.HistoryNetwork: {
+          this._history!.nodeRadius = 2n ** BigInt(parseInt(radius)) - 1n
+          return '0x' + this._history!.nodeRadius.toString(16)
+        }
+        case NetworkId.StateNetwork: {
+          this._state!.nodeRadius = 2n ** BigInt(parseInt(radius)) - 1n
+          return '0x' + this._state!.nodeRadius.toString(16)
+        }
+        case NetworkId.BeaconChainNetwork: {
+          this._beacon!.nodeRadius = 2n ** BigInt(parseInt(radius)) - 1n
+          return '0x' + this._beacon!.nodeRadius.toString(16)
+        }
+        default: {
+          throw {
+            code: INTERNAL_ERROR,
+            message: `Invalid network id ${networkId}`,
+          }
+        }
+      }
+    } catch (err: any) {
+      return `Error setting radius ${err.message.toString()}`
+    }
+  }
 }

--- a/packages/cli/src/rpc/validators.ts
+++ b/packages/cli/src/rpc/validators.ts
@@ -328,6 +328,25 @@ export const validators = {
       }
     }
   },
+  /**
+   * MB validator to check if type is positive integer
+   * @param params parameters of method
+   * @param index index of parameter
+   */
+  get megabytes() {
+    return (params: any[], index: number) => {
+      if (
+        typeof params[index] !== 'number' ||
+        params[index] < 1 ||
+        !Number.isInteger(params[index])
+      ) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument is not whole number megabytes`,
+        }
+      }
+    }
+  },
 
   /**
    * validator to ensure required transaction fields are present, and checks for valid address and hex values.


### PR DESCRIPTION
Adds new custom methods to the `ultralight` RPC namespace: 

`ultralight_setNetworkRadius`
`ultralight_getNetworkRadius`
`ultralight_getNetworkStorageInfo`
`ultralight_getNetworkDBSize`
`ultralight_setNetworkStorage`
`ultralight_pruneNetworkDB`
