### PR TITLE
Network DB access

### DIFF
--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -612,8 +612,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
       case BeaconLightClientNetworkContentType.LightClientOptimisticUpdate:
         // We store the optimistic update by the content type rather than key since we only want to have one (the most recent)
         // optimistic update and this ensures we don't accidentally store multiple
-        this.put(
-          this.networkId,
+        await this.put(
           intToHex(BeaconLightClientNetworkContentType.LightClientOptimisticUpdate),
           toHexString(value),
         )
@@ -621,14 +620,13 @@ export class BeaconLightClientNetwork extends BaseNetwork {
       case BeaconLightClientNetworkContentType.LightClientFinalityUpdate:
         // We store the optimistic update by the content type rather than key since we only want to have one (the most recent)
         // finality update and this ensures we don't accidentally store multiple
-        this.put(
-          this.networkId,
+        await this.put(
           intToHex(BeaconLightClientNetworkContentType.LightClientFinalityUpdate),
           toHexString(value),
         )
         break
       default:
-        this.put(this.networkId, contentKey, toHexString(value))
+        await this.put(contentKey, toHexString(value))
     }
 
     this.logger(
@@ -807,7 +805,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
             case BeaconLightClientNetworkContentType.LightClientBootstrap: {
               try {
                 // TODO: Verify the offered bootstrap isn't too old before accepting
-                await this.get(NetworkId.BeaconChainNetwork, toHexString(key))
+                await this.get(toHexString(key))
                 this.logger.extend('OFFER')(`Already have this content ${msg.contentKeys[x]}`)
               } catch (err) {
                 offerAccepted = true

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -59,7 +59,7 @@ export class ContentLookup {
     this.logger(`starting recursive content lookup for ${toHexString(this.contentKey)}`)
     this.network.metrics?.totalContentLookups.inc()
     try {
-      const res = await this.network.get(this.network.networkId, toHexString(this.contentKey))
+      const res = await this.network.get(toHexString(this.contentKey))
       return { content: hexToBytes(res), utp: false }
     } catch (err: any) {
       this.logger(`content key not in db ${err.message}`)

--- a/packages/portalnetwork/src/networks/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/networks/history/headerAccumulator.ts
@@ -98,7 +98,6 @@ export class AccumulatorManager {
     const header = BlockHeader.fromRLPSerializedHeader(
       hexToBytes(
         await this._history.get(
-          this._history.networkId,
           getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(blockHash)),
         ),
       ),
@@ -120,7 +119,6 @@ export class AccumulatorManager {
   }
   public generateInclusionProof = async (blockHash: string): Promise<HeaderProofInterface> => {
     const _blockHeader = await this._history.get(
-      this._history.networkId,
       getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(blockHash)),
     )
     if (_blockHeader === undefined) {
@@ -138,7 +136,6 @@ export class AccumulatorManager {
         ? EpochAccumulator.serialize(this.headerAccumulator.currentEpoch.slice(0, listIdx))
         : hexToBytes(
             await this._history.get(
-              this._history.networkId,
               getContentKey(
                 HistoryNetworkContentType.EpochAccumulator,
                 this.headerAccumulator.historicalEpochs[epochIdx - 1],
@@ -162,7 +159,6 @@ export class AccumulatorManager {
     const header = BlockHeader.fromRLPSerializedHeader(
       hexToBytes(
         await this._history.get(
-          this._history.networkId,
           getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(blockHash)),
         ),
       ),
@@ -176,7 +172,6 @@ export class AccumulatorManager {
       const epoch = EpochAccumulator.deserialize(
         hexToBytes(
           await this._history.get(
-            this._history.networkId,
             getContentKey(3, this.headerAccumulator.historicalEpochs[epochIndex - 1]),
           ),
         ),

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -147,8 +147,7 @@ export class HistoryNetwork extends BaseNetwork {
       }
     }
     await this.indexBlockhash(header.number, toHexString(header.hash()))
-    this.put(
-      this.networkId,
+    await this.put(
       getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(contentHash)),
       toHexString(value),
     )
@@ -254,11 +253,7 @@ export class HistoryNetwork extends BaseNetwork {
       case HistoryNetworkContentType.Receipt: {
         try {
           sszReceiptsListType.deserialize(value)
-          this.put(
-            this.networkId,
-            getContentKey(contentType, hexToBytes(hashKey)),
-            toHexString(value),
-          )
+          await this.put(getContentKey(contentType, hexToBytes(hashKey)), toHexString(value))
         } catch (err: any) {
           this.logger(`Received invalid bytes as receipt data for ${hashKey}`)
           return
@@ -268,11 +263,7 @@ export class HistoryNetwork extends BaseNetwork {
       case HistoryNetworkContentType.EpochAccumulator: {
         try {
           EpochAccumulator.deserialize(value)
-          this.put(
-            this.networkId,
-            getContentKey(contentType, hexToBytes(hashKey)),
-            toHexString(value),
-          )
+          await this.put(getContentKey(contentType, hexToBytes(hashKey)), toHexString(value))
         } catch (err: any) {
           this.logger(`Received invalid bytes as Epoch Accumulator corresponding to ${hashKey}`)
           return
@@ -316,7 +307,7 @@ export class HistoryNetwork extends BaseNetwork {
     }
     const bodyContentKey = getContentKey(HistoryNetworkContentType.BlockBody, hexToBytes(hashKey))
     if (block instanceof Block) {
-      this.put(this.networkId, bodyContentKey, toHexString(value))
+      await this.put(bodyContentKey, toHexString(value))
       // TODO: Decide when and if to build and store receipts.
       //       Doing this here caused a bottleneck when same receipt is gossiped via uTP at the same time.
       // if (block.transactions.length > 0) {
@@ -325,7 +316,7 @@ export class HistoryNetwork extends BaseNetwork {
     } else {
       this.logger(`Could not verify block content`)
       this.logger(`Adding anyway for testing...`)
-      this.put(this.networkId, bodyContentKey, toHexString(value))
+      await this.put(bodyContentKey, toHexString(value))
       // TODO: Decide what to do here.  We shouldn't be storing block bodies without a corresponding header
       // as it's against spec
       return

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -100,7 +100,7 @@ export abstract class BaseNetwork extends EventEmitter {
     this.db.addToStreaming(contentKey)
   }
 
-  public blockIndexKey() {
+  public blockIndex() {
     return this.db.getBlockIndex()
   }
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -409,7 +409,7 @@ export abstract class BaseNetwork extends EventEmitter {
               for await (const key of requestedKeys) {
                 let value = Uint8Array.from([])
                 try {
-                  value = hexToBytes(await this.get(this.networkId, toHexString(key)))
+                  value = hexToBytes(await this.get(toHexString(key)))
                   requestedData.push(value)
                 } catch (err: any) {
                   this.logger(`Error retrieving content -- ${err.toString()}`)
@@ -458,7 +458,7 @@ export abstract class BaseNetwork extends EventEmitter {
               continue
             }
             try {
-              await this.get(this.networkId, toHexString(msg.contentKeys[x]))
+              await this.get(toHexString(msg.contentKeys[x]))
               this.logger.extend('OFFER')(`Already have this content ${msg.contentKeys[x]}`)
             } catch (err) {
               offerAccepted = true
@@ -759,7 +759,7 @@ export abstract class BaseNetwork extends EventEmitter {
   }
 
   public async prune(radius: bigint) {
-    await this._prune(this.networkId, radius)
+    await this._prune(radius)
     this.nodeRadius = radius
   }
 
@@ -807,7 +807,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   public async retrieve(contentKey: string): Promise<string | undefined> {
     try {
-      const content = await this.get(this.networkId, contentKey)
+      const content = await this.get(contentKey)
       return content
     } catch (err: any) {
       this.logger(`Error retrieving content from DB -- ${err.message}`)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -25,6 +25,7 @@ import { FoundContent } from '../wire/types.js'
 import type {
   AcceptMessage,
   ContentRequest,
+  DBManager,
   FindContentMessage,
   FindNodesMessage,
   INewRequest,

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -65,10 +65,7 @@ export abstract class BaseNetwork extends EventEmitter {
   ) => Promise<Uint8Array>
   sendResponse: (src: INodeAddress, requestId: bigint, payload: Uint8Array) => Promise<void>
   findEnr: (nodeId: string) => ENR | undefined
-  put: (network: NetworkId, contentKey: string, content: string) => void
-  get: (network: NetworkId, contentKey: string) => Promise<string>
   streamingKey: (contentKey: string) => void
-  _prune: (network: NetworkId, radius: bigint) => Promise<void>
   portal: PortalNetwork
   constructor(client: PortalNetwork, radius?: bigint) {
     super()

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -48,6 +48,7 @@ export abstract class BaseNetwork extends EventEmitter {
   public routingTable: PortalNetworkRoutingTable | StateNetworkRoutingTable
   public metrics: PortalNetworkMetrics | undefined
   public nodeRadius: bigint
+  public db: DBManager
   private checkIndex: number
   abstract logger: Debugger
   abstract networkId: NetworkId
@@ -74,6 +75,7 @@ export abstract class BaseNetwork extends EventEmitter {
     this.sendMessage = client.sendPortalNetworkMessage.bind(client)
     this.sendResponse = client.sendPortalNetworkResponse.bind(client)
     this.findEnr = client.discv5.findEnr.bind(client.discv5)
+    this.db = client.db
     this.put = client.db.put.bind(client.db)
     this.get = client.db.get.bind(client.db)
     this.streamingKey = client.db.addToStreaming.bind(client.db)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -76,13 +76,10 @@ export abstract class BaseNetwork extends EventEmitter {
     this.sendResponse = client.sendPortalNetworkResponse.bind(client)
     this.findEnr = client.discv5.findEnr.bind(client.discv5)
     this.db = client.db
-    this.put = client.db.put.bind(client.db)
-    this.get = client.db.get.bind(client.db)
     this.streamingKey = client.db.addToStreaming.bind(client.db)
     this.blockIndex = client.db.getBlockIndex.bind(client.db)
     this.setBlockIndex = client.db.storeBlockIndex.bind(client.db)
     this.handleNewRequest = client.uTP.handleNewRequest.bind(client.uTP)
-    this._prune = client.db.prune.bind(client.db)
     this.enr = client.discv5.enr
     this.checkIndex = 0
     this.nodeRadius = radius ?? 2n ** 256n - 1n
@@ -94,6 +91,18 @@ export abstract class BaseNetwork extends EventEmitter {
         this.metrics?.knownHistoryNodes.set(this.routingTable.size)
       }
     }
+  }
+
+  public async put(contentKey: string, content: string) {
+    this.db.put(this.networkId, contentKey, content)
+  }
+
+  public async get(key: string) {
+    return this.db.get(this.networkId, key)
+  }
+
+  public async _prune(radius: bigint) {
+    await this.db.prune(this.networkId, radius)
   }
 
   abstract contentKeyToId: (contentKey: Uint8Array) => Uint8Array

--- a/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
+++ b/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
@@ -17,7 +17,7 @@ describe('BlockIndex', async () => {
   })
   const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   await history.store(HistoryNetworkContentType.BlockHeader, hash, fromHexString(headerWithProof))
-  const stored = await history.get(NetworkId.HistoryNetwork, headerWithProofkey)
+  const stored = await history.get(headerWithProofkey)
 
   it('should store block header', () => {
     assert.equal(stored, headerWithProof)

--- a/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
@@ -190,13 +190,11 @@ describe('store -- Block Bodies and Receipts', async () => {
   const header = BlockHeaderWithProof.deserialize(
     hexToBytes(
       await network.get(
-        NetworkId.HistoryNetwork,
         getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(serializedBlock.blockHash)),
       ),
     ),
   ).header
   const body = await network.get(
-    NetworkId.HistoryNetwork,
     getContentKey(HistoryNetworkContentType.BlockBody, hexToBytes(serializedBlock.blockHash)),
   )
   const rebuilt = reassembleBlock(header, hexToBytes(body!))

--- a/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
@@ -29,9 +29,9 @@ describe('StateNetwork', async () => {
   })
   it('should connect client db to stateDB', async () => {
     ultralight.db.put(NetworkId.StateNetwork, '0x1234', 'testvalue')
-    const value = await stateNetwork!.get(NetworkId.StateNetwork, '0x1234')
+    const value = await stateNetwork!.get('0x1234')
     expect(value).toEqual('testvalue')
-    stateNetwork!.put(NetworkId.StateNetwork, '0xabcd', 'testvalue2')
+    await stateNetwork!.put('0xabcd', 'testvalue2')
     const value2 = await ultralight.db.get(NetworkId.StateNetwork, '0xabcd')
     expect(value2).toEqual('testvalue2')
   })


### PR DESCRIPTION
This updates the way that `network` classes (`HistoryNetwork`, `StateNetwork`, etc) interact with the database.

These network classes now have direct access to the `DBManager`, and all of the `put`, `get`, `del`, and other database methods.

This does away with some of the `bind` usage.  Network database methods and defined like other async methods.  This removes the extraneous `networkId` parameter from `put`, `get`, and `prune`.

--
These changes will make way for greater database and `node radius` management on the sub-network level. 