### PR TITLE
Configure storage size not radius

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,9 +23,9 @@ The easiest way to get started with Ultralight is to use the `npm run dev` scrip
   --web3              web3 JSON RPC HTTP endpoint for local Ethereum node    [string]
   --networks          subnetworks to enable  (options are: `history`, `state`, `beacon`) [default: `history`]
   --trustedBlockRoot  a trusted blockroot to start light client syncing of the beacon chain [string]
-  --radiusHistory     2^r radius for history network client                  [number] [default: 0]
-  --radiusBeacon      2^r radius for beacon network client                   [number] [default: 0]
-  --radiusState       2^r radius for state network client                    [number] [default: 0]
+  --storageHistory    Storage space allocated to HistoryNetwork DB in MB      [number] [default: 1024]
+  --storageBeacon     Storage space allocated to BeaconChainNetwork DB in MB  [number] [default: 1024]
+  --storageState      Storage space allocated to StateNetwork DB in MB        [number] [default: 1024]
 ```
 ### Starting with the same Node ID 
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -83,20 +83,20 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     array: true,
     optional: true,
   })
-  .option('radiusHistory', {
-    describe: `2^r radius for history network client`,
+  .option('storageHistory', {
+    describe: `Storage space allocated to HistoryNetwork DB in MB`,
     number: true,
-    default: 256,
+    default: 1024,
   })
-  .option('radiusBeacon', {
-    describe: `2^r radius for beacon network client`,
+  .option('storageBeacon', {
+    describe: `Storage space allocated to BeaconChainNetwork DB in MB`,
     number: true,
-    default: 256,
+    default: 1024,
   })
-  .option('radiusState', {
-    describe: `2^r radius for state network client`,
+  .option('storageState', {
+    describe: `Storage space allocated to StateNetwork DB in MB`,
     number: true,
-    default: 256,
+    default: 1024,
   })
   .option('trustedBlockRoot', {
     describe: 'a trusted blockroot to start light client syncing of the beacon chain',
@@ -165,7 +165,7 @@ const main = async () => {
         case 'history':
           networks.push({
             networkId: NetworkId.HistoryNetwork,
-            radius: 2n ** BigInt(args.radiusHistory) - 1n,
+            maxStorage: args.storageHistory,
             //@ts-ignore Because level doesn't know how to get along with itself
             db: networkdb,
           })
@@ -173,7 +173,7 @@ const main = async () => {
         case 'beacon':
           networks.push({
             networkId: NetworkId.BeaconChainNetwork,
-            radius: 2n ** BigInt(args.radiusBeacon) - 1n,
+            maxStorage: args.storageBeacon,
             //@ts-ignore Because level doesn't know how to get along with itself
             db: networkdb,
           })
@@ -181,7 +181,7 @@ const main = async () => {
         case 'state':
           networks.push({
             networkId: NetworkId.StateNetwork,
-            radius: 2n ** BigInt(args.radiusState) - 1n,
+            maxStorage: args.storageState,
             //@ts-ignore Because level doesn't know how to get along with itself
             db: networkdb,
           })
@@ -200,7 +200,7 @@ const main = async () => {
     networks = [
       {
         networkId: NetworkId.HistoryNetwork,
-        radius: 256n,
+        maxStorage: args.storageHistory,
         //@ts-ignore Because level doesn't know how to get along with itself
         db: networkdb,
       },
@@ -217,7 +217,7 @@ const main = async () => {
     }
     networks.push({
       networkId: NetworkId.BeaconChainNetwork,
-      radius: 256n,
+      maxStorage: args.storageBeacon,
       //@ts-ignore Because level doesn't know how to get along with itself
       db: networkdb,
     })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -156,7 +156,7 @@ const main = async () => {
       let networkdb
       if (args.dataDir !== undefined) {
         networkdb = {
-          db: new Level<string, string>(args.dataDir + '/' + network),
+          db: new Level<string, string>(args.dataDir + '/' + network, { createIfMissing: true }),
           path: args.dataDir + '/' + network,
         }
       }
@@ -192,7 +192,7 @@ const main = async () => {
     let networkdb
     if (args.dataDir !== undefined) {
       networkdb = {
-        db: new Level<string, string>(args.dataDir + '/' + 'history'),
+        db: new Level<string, string>(args.dataDir + '/' + 'history', { createIfMissing: true }),
         path: args.dataDir + '/' + 'history',
       }
     }
@@ -211,7 +211,7 @@ const main = async () => {
     let networkdb
     if (args.dataDir !== undefined) {
       networkdb = {
-        db: new Level<string, string>(args.dataDir + '/' + 'beacon'),
+        db: new Level<string, string>(args.dataDir + '/' + 'beacon', { createIfMissing: true }),
         path: args.dataDir + '/' + 'beacon',
       }
     }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -277,9 +277,9 @@ export interface ClientOpts {
   dataDir?: string
   web3?: string
   networks?: (string | number)[]
-  radiusHistory: number
-  radiusBeacon: number
-  radiusState: number
+  storageHistory: number
+  storageBeacon: number
+  storageState: number
   trustedBlockRoot?: string
 }
 

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -264,7 +264,6 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         this.logger(this.unverifiedSessionCache.get(enr.nodeId))
       }
     })
-
     if (opts.metrics) {
       this.metrics = opts.metrics
       this.metrics.knownDiscv5Nodes.collect = () =>

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -150,7 +150,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       bootnodes,
       db: opts.db,
       supportedNetworks: opts.supportedNetworks ?? [
-        { networkId: NetworkId.HistoryNetwork, radius: 1n },
+        { networkId: NetworkId.HistoryNetwork, maxStorage: 1024 },
       ],
       dbSize: dbSize as () => Promise<number>,
       metrics: opts.metrics,
@@ -193,7 +193,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
             new HistoryNetwork({
               client: this,
               networkId: NetworkId.HistoryNetwork,
-              radius: network.radius,
+              maxStorage: network.maxStorage,
               db: network.db,
             }),
           )
@@ -204,7 +204,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
             new StateNetwork({
               client: this,
               networkId: NetworkId.StateNetwork,
-              radius: network.radius,
+              maxStorage: network.maxStorage,
               db: network.db,
             }),
           )
@@ -220,7 +220,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
               new BeaconLightClientNetwork({
                 client: this,
                 networkId: NetworkId.BeaconChainNetwork,
-                radius: network.radius,
+                maxStorage: network.maxStorage,
                 trustedBlockRoot: opts.trustedBlockRoot,
                 sync: syncStrategy,
                 db: network.db,

--- a/packages/portalnetwork/src/client/dbManager.ts
+++ b/packages/portalnetwork/src/client/dbManager.ts
@@ -1,4 +1,3 @@
-import { bigIntToHex } from '@ethereumjs/util'
 import { MemoryLevel } from 'memory-level'
 
 import type { NetworkId } from '../index.js'
@@ -70,16 +69,6 @@ export class DBManager {
 
   sublevel(network: NetworkId) {
     return this.sublevels.get(network)!
-  }
-
-  async prune(radius: bigint, network?: NetworkId) {
-    if (network !== undefined) {
-      await this.sublevel(network).prune(radius)
-    } else {
-      for await (const key of this.db.keys({ gte: bigIntToHex(radius) })) {
-        await this.db.del(key)
-      }
-    }
   }
 
   async open() {

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -23,7 +23,7 @@ export enum TransportLayer {
 
 export interface NetworkConfig {
   networkId: NetworkId
-  maxStorage: number
+  maxStorage?: number
   db?: {
     db: AbstractLevel<string, string>
     path: string

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -23,7 +23,7 @@ export enum TransportLayer {
 
 export interface NetworkConfig {
   networkId: NetworkId
-  radius: bigint
+  maxStorage: number
   db?: {
     db: AbstractLevel<string, string>
     path: string

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -407,7 +407,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
       this.logger.extend('FINDCONTENT')(`No ENR found for ${shortId(dstId)}.  FINDCONTENT aborted.`)
       return
     }
-    this.metrics?.findContentMessagesSent.inc()
+    this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
     const payload = PortalWireMessageType.serialize({
       selector: MessageCodes.FINDCONTENT,
@@ -420,7 +420,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
 
     try {
       if (bytesToInt(res.subarray(0, 1)) === MessageCodes.CONTENT) {
-        this.metrics?.contentMessagesReceived.inc()
+        this.portal.metrics?.contentMessagesReceived.inc()
         this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
         let decoded = ContentMessageType.deserialize(res.subarray(1))
         switch (decoded.selector) {
@@ -533,7 +533,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
     network: Uint8Array,
     decodedContentMessage: FindContentMessage,
   ) => {
-    this.metrics?.contentMessagesSent.inc()
+    this.portal.metrics?.contentMessagesSent.inc()
 
     this.logger(
       `Received FindContent request for contentKey: ${toHexString(
@@ -708,7 +708,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
    */
   public override sendOffer = async (dstId: string, contentKeys: Uint8Array[]) => {
     if (contentKeys.length > 0) {
-      this.metrics?.offerMessagesSent.inc()
+      this.portal.metrics?.offerMessagesSent.inc()
       const offerMsg: OfferMessage = {
         contentKeys,
       }
@@ -729,7 +729,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
         try {
           const decoded = PortalWireMessageType.deserialize(res)
           if (decoded.selector === MessageCodes.ACCEPT) {
-            this.metrics?.acceptMessagesReceived.inc()
+            this.portal.metrics?.acceptMessagesReceived.inc()
             const msg = decoded.value as AcceptMessage
             const id = new DataView(msg.connectionId.buffer).getUint16(0, false)
             // Initiate uTP streams with serving of requested content

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -57,7 +57,7 @@ export class ContentLookup {
     // Don't support content lookups for networks that don't implement it (i.e. Canonical Indices)
     if (!this.network.sendFindContent) return
     this.logger(`starting recursive content lookup for ${toHexString(this.contentKey)}`)
-    this.network.metrics?.totalContentLookups.inc()
+    this.network.portal.metrics?.totalContentLookups.inc()
     try {
       const res = await this.network.get(toHexString(this.contentKey))
       return { content: hexToBytes(res), utp: false }
@@ -151,7 +151,7 @@ export class ContentLookup {
         // findContent returned data sought
         this.logger(`received content corresponding to ${shortId(toHexString(this.contentKey))}`)
         peer.hasContent = true
-        this.network.metrics?.successfulContentLookups.inc()
+        this.network.portal.metrics?.successfulContentLookups.inc()
 
         // Offer content to neighbors who should have had content but don't if we receive content directly
         for (const contactedPeer of this.contacted) {

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -166,7 +166,7 @@ export class HistoryNetwork extends BaseNetwork {
       this.logger(`No ENR found for ${shortId(dstId)}.  FINDCONTENT aborted.`)
       return
     }
-    this.metrics?.findContentMessagesSent.inc()
+    this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
     const payload = PortalWireMessageType.serialize({
       selector: MessageCodes.FINDCONTENT,
@@ -177,7 +177,7 @@ export class HistoryNetwork extends BaseNetwork {
 
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
-        this.metrics?.contentMessagesReceived.inc()
+        this.portal.metrics?.contentMessagesReceived.inc()
         this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         const contentKey = decodeHistoryNetworkContentKey(toHexString(key))

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -117,8 +117,16 @@ export abstract class BaseNetwork extends EventEmitter {
     return this.db.get(key)
   }
 
-  public async _prune(radius: bigint) {
-    await this.db.prune(radius)
+  public async prune(newMaxStorage?: number) {
+    if (newMaxStorage !== undefined) {
+      this.maxStorage = newMaxStorage
+    }
+    const size = await this.db.size()
+    while (size > this.maxStorage) {
+      const radius = this.nodeRadius / 2n
+      await this.db.prune(radius)
+      this.nodeRadius = radius
+    }
   }
 
   public streamingKey(contentKey: string) {
@@ -778,11 +786,6 @@ export abstract class BaseNetwork extends EventEmitter {
         await this.sendFindNodes(enr.nodeId, [x])
       }
     }
-  }
-
-  public async prune(radius: bigint) {
-    await this._prune(radius)
-    this.nodeRadius = radius
   }
 
   // Gossip (OFFER) content to any interested peers.

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -102,6 +102,7 @@ export abstract class BaseNetwork extends EventEmitter {
       db,
       logger: this.logger,
     })
+    void this.prune()
     if (this.portal.metrics) {
       this.portal.metrics.knownHistoryNodes.collect = () => {
         this.portal.metrics?.knownHistoryNodes.set(this.routingTable.size)

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -67,7 +67,7 @@ export class StateNetwork extends BaseNetwork {
       this.logger(`No ENR found for ${shortId(dstId)}.  FINDCONTENT aborted.`)
       return
     }
-    this.metrics?.findContentMessagesSent.inc()
+    this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
     const payload = PortalWireMessageType.serialize({
       selector: MessageCodes.FINDCONTENT,
@@ -81,7 +81,7 @@ export class StateNetwork extends BaseNetwork {
 
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
-        this.metrics?.contentMessagesReceived.inc()
+        this.portal.metrics?.contentMessagesReceived.inc()
         this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         const contentKey = decodeHistoryNetworkContentKey(toHexString(key))

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -44,7 +44,7 @@ describe('AccountTrieNode Gossip / Request', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: 2n ** 254n }],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -55,7 +55,7 @@ describe('AccountTrieNode Gossip / Request', async () => {
   })
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: 2n ** 254n }],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -68,6 +68,8 @@ describe('AccountTrieNode Gossip / Request', async () => {
   await node2.start()
   const network1 = node1.networks.get(NetworkId.StateNetwork) as StateNetwork
   const network2 = node2.networks.get(NetworkId.StateNetwork) as StateNetwork
+  network1.nodeRadius = 2n ** 254n - 1n
+  network2.nodeRadius = 2n ** 254n - 1n
   await network1!.sendPing(network2?.enr!.toENR())
   const storedEnr = network2.routingTable.getWithPending(node1.discv5.enr.nodeId)
   it('should find another node', async () => {
@@ -141,7 +143,7 @@ describe('getAccount via network', async () => {
       enr.setLocationMultiaddr(initMa)
       const node = await PortalNetwork.create({
         transport: TransportLayer.NODE,
-        supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: 2n ** 255n }],
+        supportedNetworks: [{ networkId: NetworkId.StateNetwork }],
         config: {
           enr,
           bindAddrs: {
@@ -159,6 +161,7 @@ describe('getAccount via network', async () => {
   )
 
   for (const [idx, network] of networks.entries()) {
+    network.nodeRadius = 2n ** 255n - 1n
     const pong1 = await network.sendPing(clients[(idx + 1) % clients.length].discv5.enr.toENR())
     const pong2 = await network.sendPing(clients[(idx + 2) % clients.length].discv5.enr.toENR())
     it(`client ${idx} connects to network`, async () => {


### PR DESCRIPTION
PortalNetwork users should not need to configure the node's **radius** directly.
**Radius** refers to the "area" of the network for which the node claims responsibility.  A node "should" store the content "in its radius".

However, what a user will actually care about (and want to configure) is the **storage space** allocated to each network.  It is this setting which should determine the correct radius for a node, not the other way around.  

With these changes, users will set a **maxStorage** size instead of a **radius** value for each subnetwork.  This will default at  `1024 MB`.  The `radius` for each network will *start* at `100%` (or `2^256`) .  As content is added, the node will evaluate the storage used, and prune to a smaller radius as needed to free up storage space.

Content that is pruned (deleted from the DB) will be gossiped back into the network to protect against loss.

TODO:  
1. Decide when and how often to check db size 
  - On an `interval`?
  - During `handleOffer` ?
    - Every time?
    - Random?
2. Determine threshold for pruning
  - `size > maxStorage` ?
  - `size > maxStorage * p%` ?
