### PR TITLE
refactor network.store

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -26,7 +26,6 @@ import type { Debugger } from 'debug'
 import type {
   AcceptMessage,
   BeaconLightClientNetwork,
-  BeaconLightClientNetworkContentType,
   HistoryNetwork,
   HistoryNetworkContentType,
   NodesMessage,
@@ -879,11 +878,7 @@ export class portal {
   async historyStore(params: [string, string]) {
     const [contentKey, content] = params.map((param) => fromHexString(param))
     try {
-      await this._history.store(
-        contentKey[0] as HistoryNetworkContentType,
-        toHexString(contentKey.slice(1)),
-        content,
-      )
+      await this._history.store(toHexString(contentKey), content)
       return true
     } catch {
       return false
@@ -893,11 +888,7 @@ export class portal {
     const [contentKey, content] = params
     try {
       const contentKeyBytes = fromHexString(contentKey)
-      await this._state.store(
-        contentKeyBytes[0],
-        toHexString(contentKeyBytes.slice(1)),
-        fromHexString(content),
-      )
+      await this._state.store(toHexString(contentKeyBytes), fromHexString(content))
       this.logger(`stored ${contentKey} in state network db`)
       return true
     } catch {
@@ -917,11 +908,7 @@ export class portal {
   async beaconStore(params: [string, string]) {
     const [contentKey, content] = params.map((param) => fromHexString(param))
     try {
-      await this._beacon.store(
-        contentKey[0] as BeaconLightClientNetworkContentType,
-        toHexString(contentKey),
-        content,
-      )
+      await this._beacon.store(toHexString(contentKey), content)
       return true
     } catch (e) {
       console.log(e)

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -61,8 +61,8 @@ export class ultralight {
       `ultralight_addContentToDB request received for ${HistoryNetworkContentType[type]} ${contentKey}`,
     )
     try {
-      await this._history.store(type, '0x' + contentKey.slice(4), fromHexString(value))
-      this.logger(`${type} value for 0x${contentKey.slice(4)} added to content DB`)
+      await this._history.store(contentKey, fromHexString(value))
+      this.logger(`${type} value for ${contentKey} added to content DB`)
       return `${type} value for ${contentKey} added to content DB`
     } catch (err: any) {
       this.logger(`Error trying to load content to DB. ${err.message.toString()}`)

--- a/packages/portalnetwork/src/networks/history/util.ts
+++ b/packages/portalnetwork/src/networks/history/util.ts
@@ -165,6 +165,7 @@ export const addRLPSerializedBlock = async (
     setHardfork: true,
   })
   const header = block.header
+  const headerKey = getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(blockHash))
   if (header.number < MERGE_BLOCK) {
     // Only generate proofs for pre-merge headers
     const proof: Witnesses = witnesses ?? (await network.generateInclusionProof(header.number))
@@ -177,11 +178,7 @@ export const addRLPSerializedBlock = async (
     } catch {
       throw new Error('Header proof failed validation')
     }
-    await network.store(
-      HistoryNetworkContentType.BlockHeader,
-      toHexString(header.hash()),
-      headerProof,
-    )
+    await network.store(headerKey, headerProof)
   } else {
     const headerProof = BlockHeaderWithProof.serialize({
       header: header.serialize(),
@@ -189,11 +186,7 @@ export const addRLPSerializedBlock = async (
     })
     await network.indexBlockhash(header.number, toHexString(header.hash()))
 
-    await network.store(
-      HistoryNetworkContentType.BlockHeader,
-      toHexString(header.hash()),
-      headerProof,
-    )
+    await network.store(headerKey, headerProof)
   }
   const sszBlock = sszEncodeBlockBody(block)
   await network.addBlockBody(sszBlock, toHexString(header.hash()), header.serialize())

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -149,7 +149,7 @@ export abstract class BaseNetwork extends EventEmitter {
     return bytesToUnprefixedHex(digest(fromHexString(contentKey)))
   }
 
-  abstract store(contentType: any, hashKey: string, value: Uint8Array): Promise<void>
+  abstract store(contentKey: string, value: Uint8Array): Promise<void>
 
   public async handle(message: ITalkReqMessage, src: INodeAddress) {
     const id = message.id

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -107,7 +107,7 @@ export class StateNetwork extends BaseNetwork {
               `received ${StateNetworkContentType[contentType]} content corresponding to ${contentHash}`,
             )
             try {
-              await this.store(key[0], toHexString(key.slice(1)), decoded.value as Uint8Array)
+              await this.store(toHexString(key), decoded.value as Uint8Array)
             } catch {
               this.logger('Error adding content to DB')
             }
@@ -136,17 +136,14 @@ export class StateNetwork extends BaseNetwork {
     }
   }
 
-  public store = async (
-    contentType: StateNetworkContentType,
-    contentKey: string,
-    content: Uint8Array,
-  ) => {
+  public store = async (contentKey: string, content: Uint8Array) => {
+    const _contentKey = fromHexString(contentKey)
+    const contentType = _contentKey[0]
     try {
-      const fullkey = Uint8Array.from([contentType, ...fromHexString(contentKey)])
       if (contentType === StateNetworkContentType.AccountTrieNode) {
-        await this.receiveAccountTrieNodeOffer(fullkey, content)
+        await this.receiveAccountTrieNodeOffer(_contentKey, content)
       } else {
-        await this.stateDB.storeContent(fullkey, content)
+        await this.stateDB.storeContent(_contentKey, content)
       }
       this.logger(`content added for: ${contentKey}`)
       this.emit('ContentAdded', contentKey, contentType, content)

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -45,7 +45,7 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -56,7 +56,7 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -81,11 +81,7 @@ describe('Find Content tests', () => {
 
     const bootstrap = specTestVectors.bootstrap['6718368']
 
-    await network1.store(
-      BeaconLightClientNetworkContentType.LightClientBootstrap,
-      bootstrap.content_key,
-      hexToBytes(bootstrap.content_value),
-    )
+    await network1.store(bootstrap.content_key, hexToBytes(bootstrap.content_value))
     await new Promise((resolve) => {
       setTimeout(resolve, 5000)
     })
@@ -112,7 +108,7 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -123,7 +119,7 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -168,11 +164,7 @@ describe('Find Content tests', () => {
       '8a47012e91f7e797f682afeeab374fa3b3186c82de848dc44195b4251154a2ed',
       'node1 added node2 to routing table',
     )
-    await network1.store(
-      BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
-      optimisticUpdate.content_key,
-      hexToBytes(optimisticUpdate.content_value),
-    )
+    await network1.store(optimisticUpdate.content_key, hexToBytes(optimisticUpdate.content_value))
     const res = await network2.sendFindContent(
       node1.discv5.enr.nodeId,
       concatBytes(
@@ -214,7 +206,7 @@ describe('Find Content tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -225,7 +217,7 @@ describe('Find Content tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -287,7 +279,7 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -298,7 +290,7 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -348,7 +340,6 @@ describe('OFFER/ACCEPT tests', () => {
       'node1 added node2 to routing table',
     )
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
       getBeaconContentKey(
         BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({ signatureSlot: 6718463n }),
@@ -403,7 +394,7 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -414,7 +405,7 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -466,7 +457,6 @@ describe('OFFER/ACCEPT tests', () => {
       LightClientOptimisticUpdateKey.serialize({ signatureSlot: 6718463n }),
     )
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
       staleOptimisticUpdateContentKey,
       hexToBytes(optimisticUpdate.content_value),
     )
@@ -498,7 +488,7 @@ describe('OFFER/ACCEPT tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -509,7 +499,7 @@ describe('OFFER/ACCEPT tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -532,7 +522,6 @@ describe('OFFER/ACCEPT tests', () => {
       }),
     )
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientBootstrap,
       bootstrapKey,
       concatBytes(
         network1.beaconConfig.forkName2ForkDigest(ForkName.capella),
@@ -577,7 +566,7 @@ describe('beacon light client sync tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -588,7 +577,7 @@ describe('beacon light client sync tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -630,7 +619,6 @@ describe('beacon light client sync tests', () => {
     const optimisticUpdate = ssz.capella.LightClientOptimisticUpdate.fromJson(optimisticUpdateJson)
 
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientBootstrap,
       getBeaconContentKey(
         BeaconLightClientNetworkContentType.LightClientBootstrap,
         LightClientBootstrapKey.serialize({
@@ -645,7 +633,6 @@ describe('beacon light client sync tests', () => {
     await network1.storeUpdateRange(updatesByRange)
 
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
       getBeaconContentKey(
         BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({
@@ -704,7 +691,7 @@ describe('beacon light client sync tests', () => {
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -715,7 +702,7 @@ describe('beacon light client sync tests', () => {
     })
     const node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 2n ** 256n - 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr2,
         bindAddrs: {
@@ -772,13 +759,11 @@ describe('beacon light client sync tests', () => {
       }),
     )
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
       rangeKey,
       LightClientUpdatesByRange.serialize([update1, update2, update3, update4]),
     )
 
     await network1.store(
-      BeaconLightClientNetworkContentType.LightClientBootstrap,
       bootstrapKey,
       concatBytes(
         network1.beaconConfig.forkName2ForkDigest(ForkName.capella),

--- a/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
+++ b/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
@@ -19,6 +19,7 @@ import {
   TransportLayer,
   addRLPSerializedBlock,
   getBeaconContentKey,
+  getContentKey,
   toHexString,
 } from '../../../src/index.js'
 
@@ -42,7 +43,7 @@ describe('eth_getBlockByNumber', () => {
       enr2.setLocationMultiaddr(initMa2)
       const node1 = await PortalNetwork.create({
         transport: TransportLayer.NODE,
-        supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+        supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
         config: {
           enr: enr1,
           bindAddrs: {
@@ -54,7 +55,7 @@ describe('eth_getBlockByNumber', () => {
 
       const node2 = await PortalNetwork.create({
         transport: TransportLayer.NODE,
-        supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+        supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
         config: {
           enr: enr2,
           bindAddrs: {
@@ -79,8 +80,8 @@ describe('eth_getBlockByNumber', () => {
 
       const blockRlp = block1000.raw
       const blockHash = block1000.hash
-
-      await network1.store(HistoryNetworkContentType.EpochAccumulator, epochHash, hexToBytes(epoch))
+      const epochKey = getContentKey(HistoryNetworkContentType.EpochAccumulator, epochHash)
+      await network1.store(epochKey, hexToBytes(epoch))
       await addRLPSerializedBlock(blockRlp, blockHash, network1)
       await network1.sendPing(network2?.enr!.toENR())
       const retrieved = await node2.ETH.getBlockByNumber(1000, false)
@@ -103,8 +104,8 @@ describe('eth_getBlockByNumber', () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [
-        { networkId: NetworkId.BeaconChainNetwork, radius: 1n },
-        { networkId: NetworkId.HistoryNetwork, radius: 1n },
+        { networkId: NetworkId.BeaconChainNetwork },
+        { networkId: NetworkId.HistoryNetwork },
       ],
       config: {
         enr: enr1,
@@ -147,7 +148,6 @@ describe('eth_getBlockByNumber', () => {
     const optimisticUpdate = ssz.capella.LightClientOptimisticUpdate.fromJson(optimisticUpdateJson)
 
     await beacon.store(
-      BeaconLightClientNetworkContentType.LightClientBootstrap,
       getBeaconContentKey(
         BeaconLightClientNetworkContentType.LightClientBootstrap,
         LightClientBootstrapKey.serialize({
@@ -176,7 +176,6 @@ describe('eth_getBlockByNumber', () => {
     await beacon.storeUpdateRange(updatesByRange)
 
     await beacon.store(
-      BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
       getBeaconContentKey(
         BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -57,7 +57,7 @@ it('gossip test', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -68,7 +68,7 @@ it('gossip test', async () => {
   })
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -91,8 +91,7 @@ it('gossip test', async () => {
     'node1 added node2 to routing table',
   )
   await network1.store(
-    HistoryNetworkContentType.EpochAccumulator,
-    '0xf216a28afb2212269b634b9b44ff327a4a79f261640ff967f7e3283e3a184c70',
+    '0x03f216a28afb2212269b634b9b44ff327a4a79f261640ff967f7e3283e3a184c70',
     hexToBytes(epoch25),
   )
   // await network2.store(
@@ -115,11 +114,8 @@ it('gossip test', async () => {
         value: proof,
       },
     })
-    await network1.store(
-      HistoryNetworkContentType.BlockHeader,
-      toHexString(testBlock.hash()),
-      headerWith,
-    )
+    const headerKey = getContentKey(HistoryNetworkContentType.BlockHeader, testBlock.hash())
+    await network1.store(headerKey, headerWith)
   }
 
   // Fancy workaround to allow us to "await" an event firing as expected following this - https://github.com/ljharb/tape/pull/503#issuecomment-619358911
@@ -158,7 +154,7 @@ it('FindContent', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -170,7 +166,7 @@ it('FindContent', async () => {
 
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -186,8 +182,7 @@ it('FindContent', async () => {
   const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
 
   await network1.store(
-    HistoryNetworkContentType.EpochAccumulator,
-    '0xf216a28afb2212269b634b9b44ff327a4a79f261640ff967f7e3283e3a184c70',
+    '0x03f216a28afb2212269b634b9b44ff327a4a79f261640ff967f7e3283e3a184c70',
     hexToBytes(epoch25),
   )
   assert.equal(
@@ -226,7 +221,7 @@ it('eth_getBlockByHash', async () => {
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -238,7 +233,7 @@ it('eth_getBlockByHash', async () => {
 
   const node2 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 2n ** 256n - 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
       enr: enr2,
       bindAddrs: {
@@ -253,8 +248,7 @@ it('eth_getBlockByHash', async () => {
   const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   await network1.store(
-    HistoryNetworkContentType.EpochAccumulator,
-    '0xf216a28afb2212269b634b9b44ff327a4a79f261640ff967f7e3283e3a184c70',
+    '0x03f216a28afb2212269b634b9b44ff327a4a79f261640ff967f7e3283e3a184c70',
     hexToBytes(epoch25),
   )
   assert.equal(

--- a/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
@@ -140,7 +140,7 @@ describe('API tests', async () => {
 
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,
-    supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
     config: {
       enr: enr1,
       bindAddrs: {
@@ -155,11 +155,7 @@ describe('API tests', async () => {
   it('stores and retrieves bootstrap', async () => {
     const bootstrap = specTestVectors.bootstrap['6718368']
 
-    await network.store(
-      BeaconLightClientNetworkContentType.LightClientBootstrap,
-      bootstrap.content_key,
-      hexToBytes(bootstrap.content_value),
-    )
+    await network.store(bootstrap.content_key, hexToBytes(bootstrap.content_value))
     const retrievedBootstrap = await network.findContentLocally(hexToBytes(bootstrap.content_key))
 
     assert.equal(
@@ -172,11 +168,7 @@ describe('API tests', async () => {
 
   it('stores and retrieves finality update', async () => {
     const finalityUpdate = specTestVectors.finalityUpdate['6718368']
-    await network.store(
-      BeaconLightClientNetworkContentType.LightClientFinalityUpdate,
-      finalityUpdate.content_key,
-      hexToBytes(finalityUpdate.content_value),
-    )
+    await network.store(finalityUpdate.content_key, hexToBytes(finalityUpdate.content_value))
 
     network.lightClient = {
       //@ts-ignore
@@ -207,11 +199,7 @@ describe('API tests', async () => {
 
   it('stores and retrieves optimistic update', async () => {
     const optimisticUpdate = specTestVectors.optimisticUpdate['6718463']
-    await network.store(
-      BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
-      optimisticUpdate.content_key,
-      hexToBytes(optimisticUpdate.content_value),
-    )
+    await network.store(optimisticUpdate.content_key, hexToBytes(optimisticUpdate.content_value))
 
     network.lightClient = {
       //@ts-ignore
@@ -264,11 +252,7 @@ describe('API tests', async () => {
 
   it('stores and retrieves a batch of LightClientUpdates', async () => {
     const updatesByRange = specTestVectors.updateByRange['6684738']
-    await network.store(
-      BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
-      updatesByRange.content_key,
-      hexToBytes(updatesByRange.content_value),
-    )
+    await network.store(updatesByRange.content_key, hexToBytes(updatesByRange.content_value))
 
     const reconstructedRange = await network['constructLightClientRange'](
       hexToBytes(updatesByRange.content_key).slice(1),
@@ -293,7 +277,7 @@ describe('constructor/initialization tests', async () => {
   it('starts the bootstrap finder mechanism when no trusted block root is provided', async () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -311,7 +295,7 @@ describe('constructor/initialization tests', async () => {
   it('starts with a sync strategy of `trustedBootStrap` when a trusted block root is provided', async () => {
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {
@@ -345,7 +329,7 @@ describe('constructor/initialization tests', async () => {
     const trustedBlockRoot = '0x8e4fc820d749f9cf352d074f784071f65483ea673d8e9b8188870e950125a582'
     const node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
-      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.BeaconChainNetwork }],
       config: {
         enr: enr1,
         bindAddrs: {

--- a/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
+++ b/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
@@ -1,7 +1,12 @@
 import { fromHexString } from '@chainsafe/ssz'
 import { assert, describe, it } from 'vitest'
 
-import { HistoryNetworkContentType, NetworkId, PortalNetwork } from '../../../src/index.js'
+import {
+  HistoryNetworkContentType,
+  NetworkId,
+  PortalNetwork,
+  getContentKey,
+} from '../../../src/index.js'
 
 import type { HistoryNetwork } from '../../../src/index.js'
 
@@ -13,10 +18,11 @@ const headerWithProofkey = '0x0088e96d4537bea4d9c05d12549907b32561d3bf31f45aae73
 describe('BlockIndex', async () => {
   const ultralight = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
   const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-  await history.store(HistoryNetworkContentType.BlockHeader, hash, fromHexString(headerWithProof))
+  const headerKey = getContentKey(HistoryNetworkContentType.BlockHeader, fromHexString(hash))
+  await history.store(headerKey, fromHexString(headerWithProof))
   const stored = await history.get(headerWithProofkey)
 
   it('should store block header', () => {
@@ -36,7 +42,7 @@ describe('BlockIndex', async () => {
 
   const ultralight2 = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     db: ultralight.db.db,
   })
   const history2 = ultralight2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork

--- a/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
@@ -35,7 +35,7 @@ describe('history Network FINDCONTENT/FOUNDCONTENT message handlers', async () =
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
 
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
@@ -69,8 +69,8 @@ describe('history Network FINDCONTENT/FOUNDCONTENT message handlers', async () =
   // TODO: Write good `handleFindContent` tests
 
   td.reset()
-
-  await network.store(HistoryNetworkContentType.BlockHeader, block1Hash, hexToBytes(block1Rlp))
+  const headerKey = getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(block1Hash))
+  await network.store(headerKey, hexToBytes(block1Rlp))
   const contentKey = ContentKeyType.serialize(
     concatBytes(Uint8Array.from([HistoryNetworkContentType.BlockHeader]), hexToBytes(block1Hash)),
   )
@@ -82,30 +82,26 @@ describe('history Network FINDCONTENT/FOUNDCONTENT message handlers', async () =
 
 describe('store -- Headers and Epoch Accumulators', async () => {
   it('Should store and retrieve block header from DB', async () => {
+    const epochKey = '0x035ec1ffb8c3b146f42606c74ced973dc16ec5a107c0345858c343fc94780b4218'
     const epoch =
       '0x' +
-      readFileSync(
-        './test/networks/history/testData/0x035ec1ffb8c3b146f42606c74ced973dc16ec5a107c0345858c343fc94780b4218.portalcontent',
-        { encoding: 'hex' },
-      )
+      readFileSync(`./test/networks/history/testData/${epochKey}.portalcontent`, {
+        encoding: 'hex',
+      })
     const node = await PortalNetwork.create({
       bindAddress: '127.0.0.1',
       transport: TransportLayer.WEB,
-      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     })
     const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
     const block1Rlp =
       '0xf90211a0d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479405a56e2d52c817161883f50c441c3228cfe54d9fa0d67e4d450343046425ae4271474353857ab860dbc0a1dde64b41b5cd3a532bf3a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008503ff80000001821388808455ba422499476574682f76312e302e302f6c696e75782f676f312e342e32a0969b900de27b6ac6a67742365dd65f55a0526c41fd18e1b16f1a1215c2e66f5988539bd4979fef1ec4'
     const block1Hash = '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6'
-    await network.store(
-      HistoryNetworkContentType.EpochAccumulator,
-      '0x5ec1ffb8c3b146f42606c74ced973dc16ec5a107c0345858c343fc94780b4218',
-      hexToBytes(epoch),
-    )
+    await network.store(epochKey, hexToBytes(epoch))
     const proof = await network.generateInclusionProof(1n)
+    const headerKey = getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(block1Hash))
     await network.store(
-      HistoryNetworkContentType.BlockHeader,
-      block1Hash,
+      headerKey,
       BlockHeaderWithProof.serialize({
         header: hexToBytes(block1Rlp),
         proof: {
@@ -128,18 +124,14 @@ describe('store -- Headers and Epoch Accumulators', async () => {
     const node = await PortalNetwork.create({
       bindAddress: '127.0.0.1',
       transport: TransportLayer.WEB,
-      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     })
     const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
     const epochAccumulator = require('../../testData/testEpoch.json')
     const rebuilt = EpochAccumulator.deserialize(hexToBytes(epochAccumulator.serialized))
     const hashRoot = EpochAccumulator.hashTreeRoot(rebuilt)
     const contentKey = getContentKey(HistoryNetworkContentType.EpochAccumulator, hashRoot)
-    await network.store(
-      HistoryNetworkContentType.EpochAccumulator,
-      toHexString(hashRoot),
-      hexToBytes(epochAccumulator.serialized),
-    )
+    await network.store(contentKey, hexToBytes(epochAccumulator.serialized))
     const fromDB = await network.retrieve(contentKey)
     assert.equal(fromDB, epochAccumulator.serialized, 'Retrieve EpochAccumulator test passed.')
   })
@@ -149,7 +141,7 @@ describe('store -- Block Bodies and Receipts', async () => {
   const node = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const serializedBlock = testBlocks.block207686
@@ -162,8 +154,8 @@ describe('store -- Block Bodies and Receipts', async () => {
       { encoding: 'hex' },
     )
   const epochHash = '0x987cb6206e5bae4b68ce0eeb6c05ae090d02b7331e47d1705a2a515ac88475aa'
-
-  await network.store(HistoryNetworkContentType.EpochAccumulator, epochHash, hexToBytes(epoch))
+  const epochKey = getContentKey(HistoryNetworkContentType.EpochAccumulator, hexToBytes(epochHash))
+  await network.store(epochKey, hexToBytes(epoch))
   const _epochHash = toHexString(epochRootByBlocknumber(207686n)!)
   it('Should store and retrieve a block body from DB', async () => {
     assert.equal(epochHash, _epochHash, 'Epoch hash matches expected value')
@@ -177,16 +169,16 @@ describe('store -- Block Bodies and Receipts', async () => {
       value: proof,
     },
   })
-  await network.store(
+  const headerKey = getContentKey(
     HistoryNetworkContentType.BlockHeader,
-    serializedBlock.blockHash,
-    headerWithProof,
+    hexToBytes(serializedBlock.blockHash),
   )
-  await network.store(
+  await network.store(headerKey, headerWithProof)
+  const bodyKey = getContentKey(
     HistoryNetworkContentType.BlockBody,
-    serializedBlock.blockHash,
-    sszEncodeBlockBody(block),
+    hexToBytes(serializedBlock.blockHash),
   )
+  await network.store(bodyKey, sszEncodeBlockBody(block))
   const header = BlockHeaderWithProof.deserialize(
     hexToBytes(
       await network.get(
@@ -224,17 +216,17 @@ describe('Header Proof Tests', async () => {
   const node = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   // network.accumulator.replaceAccumulator(accumulator)
+  const epochKey = getContentKey(
+    HistoryNetworkContentType.EpochAccumulator,
+    hexToBytes(_epoch1Hash),
+  )
   it('HistoryNetwork can create and verify proofs for a HeaderRecord from an EpochAccumulator', async () => {
     const _block1000 = require('../../testData/testBlock1000.json')
-    await network.store(
-      HistoryNetworkContentType.EpochAccumulator,
-      _epoch1Hash,
-      hexToBytes(_epochRaw),
-    )
+    await network.store(epochKey, hexToBytes(_epochRaw))
     const proof = await network.generateInclusionProof(1000n)
     const headerWith = BlockHeaderWithProof.serialize({
       header: hexToBytes(_block1000.rawHeader),
@@ -243,7 +235,11 @@ describe('Header Proof Tests', async () => {
         value: proof,
       },
     })
-    await network.store(HistoryNetworkContentType.BlockHeader, _block1000.hash, headerWith)
+    const headerKey = getContentKey(
+      HistoryNetworkContentType.BlockHeader,
+      hexToBytes(_block1000.hash),
+    )
+    await network.store(headerKey, headerWith)
     assert.equal(proof.length, 15, 'Proof has correct size')
     assert.ok(
       network.verifyInclusionProof(proof, _block1000.hash, 1000n),


### PR DESCRIPTION
Issue: 

Use of `network.store` among different subnetworks was inconsistent.  

The method was built to accept as parameters the separate elements of a content key (typically *type* and *hash*), which would then be combined into a contentKey in the `store` method.  

1. Internal BeaconChainNetwork methods were misusing the method, and passing the full content key into `store`.  When uTP sent content to store in beacon, it had to repeat this inconsistency, creating a need for a conditional that treated beacon content differently than other networks.

2. Requiring the two elements of content keys to be passed into `store` as separate parameters often ended up requiring the content key to be deconstructed by the method calling `store`.

Solution:

Update `store` to accept the full content key as one parameter instead of the two separate parameters, and update all of the calls to store.  This simplifies most of the calls to `store`, and removes any need to treat beacon chain content differently than other networks.