### PR TITLE
Fix DB size scale mismatch

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -123,12 +123,13 @@ export abstract class BaseNetwork extends EventEmitter {
   }
 
   public async prune(newMaxStorage?: number) {
+    const MB = 1000000
     try {
       if (newMaxStorage !== undefined) {
         this.maxStorage = newMaxStorage
       }
       const size = await this.db.size()
-      while (size > this.maxStorage) {
+      while (size > this.maxStorage * MB) {
         const radius = this.nodeRadius / 2n
         for await (const [key, value] of this.db.db.iterator({ gte: bigIntToHex(radius) })) {
           void this.gossipContent(fromHexString(key), fromHexString(value))


### PR DESCRIPTION
issue: 

`network.prune` calls `this.db.size()`, and compares the result to the `maxStorage` setting.

The problem is that `db.size()` reports the size in **bytes**, and `maxStorage` is a **megabyte** value.  

fix:

`maxStorage` is multiplied by 1,000,000 to match the scale