### PR TITLE
Make header proof validation optional in `addRLPSerializedBlock`

### DIFF
--- a/packages/portalnetwork/src/networks/history/util.ts
+++ b/packages/portalnetwork/src/networks/history/util.ts
@@ -163,7 +163,7 @@ export const reassembleBlock = (rawHeader: Uint8Array, rawBody?: Uint8Array) => 
  * Takes an RLP encoded block as a hex string and adds the block header and block body to the `portal` content DB
  * @param rlpHex RLP encoded block as hex string
  * @param blockHash block hash as 0x prefixed hex string
- * @param portal a running `PortalNetwork` client
+ * @param network a running `PortalNetwork` client
  */
 export const addRLPSerializedBlock = async (
   rlpHex: string,
@@ -185,7 +185,7 @@ export const addRLPSerializedBlock = async (
     try {
       await network.validateHeader(headerProof, blockHash)
     } catch {
-      throw new Error('Header proof failed validation')
+      network.logger('Header proof failed validation while loading block from RLP')
     }
     await network.store(headerKey, headerProof)
   } else {


### PR DESCRIPTION
This is a quick follow-on to #603 to make sure we don't break current RPC scripts related to loading blocks locally with `addRLPSerializedBlock`.  This utility is non-standard anyway so not a huge deal but logically inconsistent since we should "never" accept pre-merge headers without a proof anymore.  We just don't store all the accumulators locally to be able to construct them on the fly.

A full solution would involve updating the bridge scripts for pre-merge blocks to construct the header proofs and then load them that way.