### PR TITLE
Database: directly use content keys

### DIFF
--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -168,8 +168,8 @@ export class ultralight {
       }
     }
     return {
-      maxStorage: network.maxStorage,
-      dbSize: await network.db.size(),
+      maxStorage: network.maxStorage + 'MB',
+      dbSize: (await network.db.size()) / 1000000 + 'MB',
       radius: '0x' + network.nodeRadius.toString(16),
     }
   }
@@ -196,8 +196,8 @@ export class ultralight {
     }
     await network.prune()
     return {
-      maxStorage: network.maxStorage,
-      dbSize: await network.db.size(),
+      maxStorage: network.maxStorage + 'MB',
+      dbSize: (await network.db.size()) / 1000000 + 'MB',
       radius: '0x' + network.nodeRadius.toString(16),
     }
   }
@@ -212,8 +212,8 @@ export class ultralight {
     }
     await network.prune(maxStorage)
     return {
-      maxStorage,
-      dbSize: await network.db.size(),
+      maxStorage: network.maxStorage + 'MB',
+      dbSize: (await network.db.size()) / 1000000 + 'MB',
       radius: '0x' + network.nodeRadius.toString(16),
     }
   }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -2,13 +2,7 @@ import { digest } from '@chainsafe/as-sha256'
 import { EntryStatus, distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
 import { BitArray, fromHexString, toHexString } from '@chainsafe/ssz'
-import {
-  bigIntToHex,
-  bytesToInt,
-  bytesToUnprefixedHex,
-  concatBytes,
-  hexToBytes,
-} from '@ethereumjs/util'
+import { bytesToInt, bytesToUnprefixedHex, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { EventEmitter } from 'events'
 
 import {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -128,18 +128,23 @@ export abstract class BaseNetwork extends EventEmitter {
       if (newMaxStorage !== undefined) {
         this.maxStorage = newMaxStorage
       }
-      const size = await this.db.size()
+      let size = await this.db.size()
+      const toDelete: [string, string][] = []
       while (size > this.maxStorage * MB) {
         const radius = this.nodeRadius / 2n
-        for await (const [key, value] of this.db.db.iterator({ gte: bigIntToHex(radius) })) {
-          void this.gossipContent(fromHexString(key), fromHexString(value))
-          await this.db.del(key)
-        }
+        const pruned = await this.db.prune(radius)
+        toDelete.push(...pruned)
         this.nodeRadius = radius
+        size = await this.db.size()
+      }
+      for (const [key, val] of toDelete) {
+        void this.gossipContent(fromHexString(key), fromHexString(val))
       }
     } catch (err: any) {
       this.logger(`Error pruning content: ${err.message}`)
+      return `Error pruning content: ${err.message}`
     }
+    return this.db.size()
   }
 
   public streamingKey(contentKey: string) {

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -65,16 +65,13 @@ export class NetworkDB {
   async put(key: string, val: string) {
     if (!key.startsWith('0x')) throw new Error('Key must be 0x prefixed hex string')
     if (!val.startsWith('0x')) throw new Error('Key must be 0x prefixed hex string')
-    const databaseKey = this.databaseKey(key)
     try {
-      await this.db.put(databaseKey, val)
+      await this.db.put(key, val)
     } catch (err: any) {
       this.logger(`Error putting content in DB: ${err.toString()}`)
     }
     this.streaming.delete(key)
-    this.logger(
-      `Put ${key} in DB as ${databaseKey}.  Size=${fromHexString(padToEven(val)).length} bytes`,
-    )
+    this.logger(`Put ${key} in DB.  Size=${fromHexString(padToEven(val)).length} bytes`)
   }
   /**
    * Get a value from the database by key.
@@ -91,13 +88,10 @@ export class NetworkDB {
     while (this.streaming.has(key)) {
       await new Promise((resolve) => setTimeout(resolve, 100))
     }
-    const databaseKey = this.databaseKey(key)
-    this.logger(`Getting ${key} from DB. dbKey: ${databaseKey}`)
-    const val = await this.db.get(databaseKey)
+    this.logger(`Getting ${key} from DB`)
+    const val = await this.db.get(key)
     this.logger(
-      `Got ${key} from DB with key: ${databaseKey}.  Size=${
-        fromHexString(padToEven(val)).length
-      } bytes`,
+      `Got ${key} from DB with key: ${key}.  Size=${fromHexString(padToEven(val)).length} bytes`,
     )
     clearTimeout(timeout)
     return val
@@ -107,8 +101,7 @@ export class NetworkDB {
    * @param key Content Key - 0x prefixed hex string
    */
   async del(key: string): Promise<void> {
-    const databaseKey = this.databaseKey(key)
-    await this.db.del(databaseKey)
+    await this.db.del(key)
   }
   /**
    * Perform multiple put and/or del operations in bulk.

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -58,16 +58,6 @@ export class NetworkDB {
     await this.db.close()
   }
   /**
-   * Derive the database key from the content key
-   * @param contentKey 0x prefixed hex string
-   * @returns database key
-   */
-  databaseKey(contentKey: string): string {
-    const contentId = this.contentId(contentKey).slice(2)
-    const d = BigInt.asUintN(32, distance(contentId, this.nodeId))
-    return bigIntToHex(d)
-  }
-  /**
    * Put content in the database
    * @param key Content Key - 0x prefixed hex string
    * @param val Content - 0x prefixed hex string

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -193,7 +193,7 @@ export class PortalNetworkUTP {
           request.socket.setAckNr(packet.header.seqNr)
           request.socket.setReader(packet.header.seqNr)
           request.socket.reader!.bytesExpected = Infinity
-          break
+          return
         } else {
           throw new Error('READ socket should not get acks')
         }
@@ -201,7 +201,7 @@ export class PortalNetworkUTP {
       case RequestCode.FOUNDCONTENT_WRITE:
         break
       case RequestCode.OFFER_WRITE:
-        request.socket.logger(`socket.seqNr: ${request.socket.getSeqNr()}`)
+        request.socket.logger(`(${request.socket.state})socket.seqNr: ${request.socket.getSeqNr()}`)
         if (packet.header.seqNr === request.socket.finNr) {
           break
         }

--- a/packages/portalnetwork/test/util/db.spec.ts
+++ b/packages/portalnetwork/test/util/db.spec.ts
@@ -1,5 +1,5 @@
 import { distance } from '@chainsafe/discv5'
-import { bigIntToHex, bytesToHex, randomBytes } from '@ethereumjs/util'
+import { bytesToHex, randomBytes } from '@ethereumjs/util'
 import debug from 'debug'
 import { assert, describe, expect, it } from 'vitest'
 

--- a/packages/portalnetwork/test/util/db.spec.ts
+++ b/packages/portalnetwork/test/util/db.spec.ts
@@ -1,3 +1,4 @@
+import { distance } from '@chainsafe/discv5'
 import { bigIntToHex, bytesToHex, randomBytes } from '@ethereumjs/util'
 import debug from 'debug'
 import { assert, describe, expect, it } from 'vitest'
@@ -40,8 +41,11 @@ describe('networkdb', async () => {
   })
   const r = 2n ** 255n - 1n
   let i = 0
-  for await (const _ of historyDB.db.iterator({ gte: bigIntToHex(r) })) {
-    i++
+  for await (const [key] of historyDB.db.keys()) {
+    const d = distance(nodeId, historyDB.contentId(key))
+    if (d > r) {
+      i++
+    }
   }
   const size1 = await historyDB.size()
   it('should have total size', () => {
@@ -56,7 +60,7 @@ describe('networkdb', async () => {
   for await (const _ of historyDB.db.iterator()) {
     e++
   }
-  it('should have pruned all', () => {
+  it(`should have ${e} / ${length} remaining`, () => {
     expect(e).toEqual(length - i)
   })
 })


### PR DESCRIPTION
Database Keys were previously based on `distance` calculation.

This allowed for optimized database pruning by sorting content automatically by distance and using the native `gte` base iterator from level db.

However, it did not allow for re-gossiping content during the pruning process, as there is no direct way to recalculate content KEYS from the database key.

It also meant that a database was only useful for a node with a specific node id.  if a client were to restart with a new nodeID, the database would be unusable.

Solution:

- Store content in the database directly by content key.
- Remove `databaseKey` function
- Refactor `prune` to calculate distance 


--

This PR will be breaking for any active ultralight databases.
