### PR TITLE
statenetwork: use address hash in content keys

### DIFF
--- a/packages/portalnetwork/src/networks/history/types.ts
+++ b/packages/portalnetwork/src/networks/history/types.ts
@@ -151,6 +151,10 @@ export const EpochAccumulator = new ListCompositeType(HeaderRecordType, EPOCH_SI
 export const MasterAccumulatorType = new ContainerType({
   historicalEpochs: HistoricalEpochsType,
 })
+export const HistoricalHashesAccumulator = new ContainerType({
+  historicalEpochs: HistoricalEpochsType,
+  currentEpoch: EpochAccumulator,
+})
 export const sszTransactionType = new ByteListType(MAX_TRANSACTION_LENGTH)
 export const allTransactionsType = new ListCompositeType(sszTransactionType, MAX_TRANSACTION_COUNT)
 export const sszUnclesType = new ByteListType(MAX_ENCODED_UNCLES_LENGTH)

--- a/packages/portalnetwork/src/networks/state/types.ts
+++ b/packages/portalnetwork/src/networks/state/types.ts
@@ -85,12 +85,12 @@ export const AccountTrieNodeRetrieval = new ContainerType({
 /* ----------------- Contract Trie Node --------------------- */
 
 export type TStorageTrieNodeKey = {
-  address: Bytes20
+  addressHash: Bytes32
   path: TNibbles
   nodeHash: Bytes32
 }
 export const StorageTrieNodeKey = new ContainerType({
-  address: new ByteVectorType(20),
+  addressHash: new ByteVectorType(32),
   path: Nibbles,
   nodeHash: new ByteVectorType(32),
 })
@@ -114,11 +114,11 @@ export const StorageTrieNodeRetrieval = new ContainerType({
 /* ----------------- Contract Code --------------------- */
 
 export type TContractCodeKey = {
-  address: Bytes20
+  addressHash: Bytes32
   codeHash: Bytes32
 }
 export const ContractCodeKey = new ContainerType({
-  address: new ByteVectorType(20),
+  addressHash: new ByteVectorType(32),
   codeHash: new ByteVectorType(32),
 })
 export type TContractOffer = {
@@ -141,12 +141,13 @@ type Bytes32 = Uint8Array
 export type Bytes20 = Uint8Array
 export type Uint256 = BigInt
 export type Address = Bytes20
+export type AddressHash = Bytes32
 export type StateRoot = Bytes32
 export type StateRootHex = string
 export type MPTWitnessNode = Uint8Array
 export type Slot = Uint256
 export type StorageTrieProofKey = {
-  address: Address
+  addressHash: AddressHash
   slot: Slot
   stateRoot: StateRoot
 }

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -51,8 +51,8 @@ export class AccountTrieNodeContentKey {
 }
 
 export class StorageTrieNodeContentKey {
-  static encode({ address, path, nodeHash }: TStorageTrieNodeKey): Uint8Array {
-    const key = StorageTrieNodeKey.serialize({ address, path, nodeHash })
+  static encode({ addressHash, path, nodeHash }: TStorageTrieNodeKey): Uint8Array {
+    const key = StorageTrieNodeKey.serialize({ addressHash, path, nodeHash })
     return Uint8Array.from([0x21, ...key])
   }
   static decode(key: Uint8Array): TStorageTrieNodeKey {
@@ -61,8 +61,8 @@ export class StorageTrieNodeContentKey {
 }
 
 export class ContractCodeContentKey {
-  static encode({ address, codeHash }: TContractCodeKey): Uint8Array {
-    const key = ContractCodeKey.serialize({ address, codeHash })
+  static encode({ addressHash, codeHash }: TContractCodeKey): Uint8Array {
+    const key = ContractCodeKey.serialize({ addressHash, codeHash })
     return Uint8Array.from([0x22, ...key])
   }
   static decode(key: Uint8Array): TContractCodeKey {
@@ -74,7 +74,7 @@ export class StateNetworkContentKey {
   static encode(opts: TAccountTrieNodeKey | TStorageTrieNodeKey | TContractCodeKey): Uint8Array {
     if ('codeHash' in opts) {
       return ContractCodeContentKey.encode(opts)
-    } else if ('address' in opts) {
+    } else if ('addressHash' in opts) {
       return StorageTrieNodeContentKey.encode(opts)
     } else {
       return AccountTrieNodeContentKey.encode(opts)

--- a/packages/portalnetwork/test/networks/history/portalSpecTests.spec.ts
+++ b/packages/portalnetwork/test/networks/history/portalSpecTests.spec.ts
@@ -10,7 +10,7 @@ import {
   BlockBodyContentType,
   BlockHeaderWithProof,
   EpochAccumulator,
-  MasterAccumulatorType,
+  HistoricalHashesAccumulator,
   decodeHistoryNetworkContentKey,
 } from '../../../src/index.js'
 
@@ -19,17 +19,17 @@ describe('Accumulator spec tests', () => {
     const acc = readFileSync(
       resolve(
         __dirname,
-        '../../../../portal-spec-tests/tests/mainnet/history/accumulator/finished_accumulator.ssz',
+        '../../../../portal-spec-tests/tests/mainnet/history/accumulator/historical_hashes_accumulator.ssz',
       ),
     )
-    const masterAccumulator = MasterAccumulatorType.deserialize(acc)
+    const masterAccumulator = HistoricalHashesAccumulator.deserialize(acc)
     assert.equal(masterAccumulator.historicalEpochs.length, 1897)
   })
   it('should deserialize an epoch accumulator', () => {
     const acc = readFileSync(
       resolve(
         __dirname,
-        '../../../../portal-spec-tests/tests/mainnet/history/accumulator/epoch-accumulator-00122.ssz',
+        '../../../../portal-spec-tests/tests/mainnet/history/accumulator/epoch-record-00122.ssz',
       ),
     )
     const epochAccumulator = EpochAccumulator.deserialize(acc)

--- a/packages/portalnetwork/test/networks/state/content.spec.ts
+++ b/packages/portalnetwork/test/networks/state/content.spec.ts
@@ -1,320 +1,233 @@
-import { fromHexString, toHexString } from '@chainsafe/ssz'
-import { RLP } from '@ethereumjs/rlp'
-import { Trie, decodeNode } from '@ethereumjs/trie'
-import { Account, padToEven, unprefixedHexToBytes } from '@ethereumjs/util'
+import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { readFileSync } from 'fs'
-import { assert, describe, expect, it } from 'vitest'
+import yaml from 'js-yaml'
+import { resolve } from 'path'
+import { assert, describe, it } from 'vitest'
 
 import {
   AccountTrieNodeContentKey,
   AccountTrieNodeOffer,
+  AccountTrieNodeRetrieval,
   ContractCodeContentKey,
   ContractCodeOffer,
+  ContractRetrieval,
+  StateNetworkContentId,
   StorageTrieNodeContentKey,
   StorageTrieNodeOffer,
-} from '../../../src/networks/state/index.js'
+  fromHexString,
+  packNibbles,
+  toHexString,
+} from '../../../src/index.js'
 
-import type { LeafNode, TrieNode } from '@ethereumjs/trie'
-
-const sampleAccounts: [string, { balance: string }][] = [
-  ['1a2694ec07cf5e4d68ba40f3e7a14c53f3038c6e', { balance: '0x3636cd06e2db3a8000' }],
-  ['4549b15979255f7e65e99b0d5604db98dfcac8bf', { balance: '0xd8d726b7177a800000' }],
-  ['40eddb448d690ed72e05c225d34fc8350fa1e4c5', { balance: '0x17b7883c06916600000' }],
-]
-
-interface ITrieNodeContent {
-  contentKey: Uint8Array
-  content: Uint8Array
-}
-interface IValueNodeContent extends ITrieNodeContent {
-  address: string
-  nodeHash: Uint8Array
-  key: string
-  value: string
-}
-interface IContent {
-  address: string
-  blockNumber: string
-  blockHash: string
-  stateRoot: string
-  storageHash: string
-  codeHash: string
-  balance: string
-  nonce: string
-  storageProofs: { key: string; value: string; proof: string[] }[]
-  accountProof: string[]
-  valueNodeContents: IValueNodeContent[]
-  trieNodeContents: ITrieNodeContent[]
-}
-describe('Account Trie Node Content Type', async () => {
-  const genesisBlock = {
-    stateRoot: '0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544',
-    blockHash: '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+describe('Account Trie Node', async () => {
+  interface AccountTrieNodeKeyData {
+    path: number[]
+    node_hash: string
+    content_key: string
+    content_id: string
   }
-  const _accountNodeSamples: [string, Uint8Array][] = JSON.parse(
-    readFileSync('./test/networks/state/testdata/accountNodeSamples.json', {
-      encoding: 'utf-8',
-    }),
-  )
-  const samples = Object.fromEntries(
-    _accountNodeSamples.map(([k, v]) => {
-      return [k, Uint8Array.from(Object.values(v))]
-    }),
-  )
-
-  const decoded = Object.entries(samples).map(([k, v]) => {
-    const key = AccountTrieNodeContentKey.decode(fromHexString(k))
-    const des = AccountTrieNodeOffer.deserialize(v)
-    const proof = des.proof.map((node) => decodeNode(node))
-    return {
-      nodeHash: toHexString(key.nodeHash),
-      path: key.path,
-      blockHash: toHexString(des.blockHash),
-      proof,
-    }
-  })
-
-  const sampleTrie = new Trie({ useKeyHashing: true })
-  const allNodes = decoded
-    .map((sample) => {
-      return sample.proof.map((node) => toHexString(node.serialize()))
-    })
-    .flat()
-  const uniqueNodes = Array.from(new Set(allNodes))
-  const trieNodes: [Uint8Array, Uint8Array][] = uniqueNodes.map((bytes) => {
-    const rlp = fromHexString(bytes)
-    const nodeHash = sampleTrie['hash'](rlp)
-    return [nodeHash, rlp]
-  })
-  for (const [hash, rlp] of trieNodes) {
-    await sampleTrie.database().put(hash, rlp)
+  interface AccountTrieNodeData {
+    proof: string[]
+    block_hash: string
+    content_value: string
   }
-  sampleTrie.root(fromHexString(genesisBlock.stateRoot))
+  const keyData: AccountTrieNodeKeyData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/account_trie_node_key.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content key', () => {
+    const contentKey = AccountTrieNodeContentKey.encode({
+      nodeHash: fromHexString(keyData.node_hash),
+      path: packNibbles(keyData.path.map((x) => x.toString(16))),
+    })
+    assert.equal(keyData.content_key, toHexString(contentKey))
+  })
+  it('decodes a content key', () => {
+    const decoded = AccountTrieNodeContentKey.decode(fromHexString(keyData.content_key))
+    assert.equal(toHexString(decoded.nodeHash), keyData.node_hash)
+    assert.deepEqual(decoded, {
+      nodeHash: fromHexString(keyData.node_hash),
+      path: packNibbles(keyData.path.map((x) => x.toString(16))),
+    })
+  })
+  it('creates the correct content id', () => {
+    const contentId = StateNetworkContentId.fromKeyObj({
+      nodeHash: fromHexString(keyData.node_hash),
+      path: packNibbles(keyData.path.map((x) => x.toString(16))),
+    })
+    assert.equal(keyData.content_id, toHexString(contentId))
+  })
 
-  const addrs: string[] = sampleAccounts.map(([a, _]) => a)
-
-  const found: [number[], TrieNode][] = []
-  await sampleTrie.walkAllNodes(async (node, key) => {
-    found.push([key, node])
+  const nodeWithProofData: AccountTrieNodeData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/account_trie_node_with_proof.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content value', () => {
+    const serialized = AccountTrieNodeOffer.serialize({
+      blockHash: fromHexString(nodeWithProofData.block_hash),
+      proof: nodeWithProofData.proof.map((x) => fromHexString(x)),
+    })
+    assert.equal(nodeWithProofData.content_value, toHexString(serialized))
   })
-  it('should find all nodes', () => {
-    expect(found.length).toEqual(uniqueNodes.length)
-  })
-
-  it('should import samples', () => {
-    expect(_accountNodeSamples.length).toEqual(6)
-  })
-  for (const sample of decoded) {
-    it('should have genesis blockHash', () => {
-      expect(sample.blockHash).toEqual(genesisBlock.blockHash)
+  const nodeData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/trie_node.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content value without proof', () => {
+    const serialized = AccountTrieNodeRetrieval.serialize({
+      node: fromHexString(nodeData.trie_node),
     })
-    it('first node in proof should be rootnode', () => {
-      expect(new Trie({ useKeyHashing: true })['hash'](sample.proof[0].serialize()))
-    })
-    it('last node in proof should be target node', () => {
-      expect(sampleTrie['hash'](sample.proof[sample.proof.length - 1].serialize()))
-    })
-  }
-  for (const [idx, address] of addrs.entries()) {
-    it('should find address in trie', async () => {
-      const res = await sampleTrie.get(unprefixedHexToBytes(address))
-      expect(res === null).toBeFalsy()
-      expect(res!.length).toBeGreaterThan(0)
-      const acc = Account.fromRlpSerializedAccount(res!)
-      expect(acc.balance).toEqual(BigInt(sampleAccounts[idx][1].balance))
-    })
-    const proof = decoded[idx * 2].proof
-    const _proof = await sampleTrie.createProof(unprefixedHexToBytes(address))
-    it(`trie should produce same proof (${_proof.length}) as sample content (${proof.length})`, () => {
-      assert.equal(_proof.length, proof.length)
-      assert.deepEqual(
-        _proof,
-        proof.map((n) => n.serialize()),
-      )
-    })
-  }
-})
-describe('Storage Trie Node Content Type', async () => {
-  const stored = readFileSync('./test/networks/state/testdata/sampleStorageContent.json', {
-    encoding: 'utf8',
-  })
-  const storedContent: IContent = JSON.parse(stored)
-  // console.log({ storedContent })
-  const { address, stateRoot, storageHash, blockHash } = storedContent
-  it('should load sample contents', async () => {
-    expect(storedContent.valueNodeContents.length).toEqual(10)
-    expect(storedContent.trieNodeContents.length).toEqual(46)
-  })
-  for (const c of storedContent.valueNodeContents) {
-    const { contentKey, content, nodeHash, value } = c
-    const decodedKey = StorageTrieNodeContentKey.decode(Uint8Array.from(Object.values(contentKey)))
-    it('should decode content key', () => {
-      expect(decodedKey).toBeDefined()
-    })
-    it('should decode to key obj', () => {
-      expect(toHexString(decodedKey.address)).toEqual(address.toLowerCase())
-      expect(toHexString(decodedKey.nodeHash)).toEqual(nodeHash)
-    })
-    const decodedContent = StorageTrieNodeOffer.deserialize(Uint8Array.from(Object.values(content)))
-    it('should deserialize content', () => {
-      expect(decodedContent).toBeDefined()
-    })
-    it('should contain blockhash', () => {
-      expect(toHexString(decodedContent.blockHash)).toEqual(blockHash)
-    })
-    it('should contain storage proof', () => {
-      expect(decodedContent.storageProof.length).toBeGreaterThan(0)
-    })
-    it('should contain storage trie root', () => {
-      const storageRootNode = decodedContent.storageProof[0]
-      const nodeHash = new Trie({ useKeyHashing: true })['hash'](storageRootNode)
-      assert.deepEqual(nodeHash, fromHexString(storageHash))
-    })
-    it('should contain value trie node', () => {
-      const valueNode = decodedContent.storageProof.slice(-1)[0]
-      const node = decodeNode(valueNode) as LeafNode
-      try {
-        assert.deepEqual(RLP.decode(node.value()), unprefixedHexToBytes(padToEven(value.slice(2))))
-      } catch (err: any) {
-        throw new Error(`${err.message}\n${value}`)
-      }
-    })
-    it('should contain expected trie node', () => {
-      const expectedNode = decodedContent.storageProof.slice(-1)[0]
-      const nodeHash = new Trie({ useKeyHashing: true })['hash'](expectedNode)
-      assert.deepEqual(nodeHash, decodedKey.nodeHash)
-    })
-    it('should contain account proof', () => {
-      expect(decodedContent.accountProof).toBeDefined()
-      expect(decodedContent.accountProof.length).toBeGreaterThan(0)
-    })
-    it('account proof should contain state root node', () => {
-      const stateRootNode = decodedContent.accountProof[0]
-      const nodeHash = new Trie({ useKeyHashing: true })['hash'](stateRootNode)
-      assert.deepEqual(nodeHash, fromHexString(stateRoot))
-    })
-    it('account proof should contain account trie node', () => {
-      const accountTrieNode = decodedContent.accountProof.slice(-1)[0]
-      const node = decodeNode(accountTrieNode)
-      const accountRLP = node.value()!
-      const account = Account.fromRlpSerializedAccount(accountRLP)
-      assert.deepEqual(account.storageRoot, fromHexString(storageHash))
-    })
-  }
-  for (const c of storedContent.trieNodeContents) {
-    const { contentKey, content } = c
-    const decodedKey = StorageTrieNodeContentKey.decode(Uint8Array.from(Object.values(contentKey)))
-    const decodedContent = StorageTrieNodeOffer.deserialize(Uint8Array.from(Object.values(content)))
-    it('should decode content key', () => {
-      expect(decodedKey).toBeDefined()
-    })
-    it('should decode to key obj', () => {
-      expect(toHexString(decodedKey.address)).toEqual(address.toLowerCase())
-    })
-    it('should deserialize content', () => {
-      expect(decodedContent).toBeDefined()
-    })
-    it('should contain blockhash', () => {
-      expect(toHexString(decodedContent.blockHash)).toEqual(blockHash)
-    })
-    it('should contain storage proof', () => {
-      expect(decodedContent.storageProof.length).toBeGreaterThan(0)
-    })
-    it('should contain storage trie root', () => {
-      const storageRootNode = decodedContent.storageProof[0]
-      const nodeHash = new Trie({ useKeyHashing: true })['hash'](storageRootNode)
-      assert.deepEqual(nodeHash, fromHexString(storageHash))
-    })
-    it('should contain expected trie node', () => {
-      const expectedNode = decodedContent.storageProof.slice(-1)[0]
-      const nodeHash = new Trie({ useKeyHashing: true })['hash'](expectedNode)
-      assert.deepEqual(nodeHash, decodedKey.nodeHash)
-    })
-    it('should contain account proof', () => {
-      expect(decodedContent.accountProof).toBeDefined()
-      expect(decodedContent.accountProof.length).toBeGreaterThan(0)
-    })
-    it('account proof should contain state root node', () => {
-      const stateRootNode = decodedContent.accountProof[0]
-      const nodeHash = new Trie({ useKeyHashing: true })['hash'](stateRootNode)
-      assert.deepEqual(nodeHash, fromHexString(stateRoot))
-    })
-    it('account proof should contain account trie node', () => {
-      const accountTrieNode = decodedContent.accountProof.slice(-1)[0]
-      const node = decodeNode(accountTrieNode)
-      const accountRLP = node.value()!
-      const account = Account.fromRlpSerializedAccount(accountRLP)
-      assert.deepEqual(account.storageRoot, fromHexString(storageHash))
-    })
-  }
-
-  it('should find expected values in sparse storage trie', async () => {
-    const storageTrie = new Trie({ useKeyHashing: true, root: fromHexString(storageHash) })
-    for (const { content } of storedContent.valueNodeContents) {
-      const decodedContent = StorageTrieNodeOffer.deserialize(
-        Uint8Array.from(Object.values(content)),
-      )
-      for (const bytes of decodedContent.storageProof) {
-        await storageTrie.database().put(new Trie({ useKeyHashing: true })['hash'](bytes), bytes)
-      }
-    }
-    storageTrie.root(fromHexString(storageHash))
-    for (const { key, value } of storedContent.valueNodeContents) {
-      const res = await storageTrie.get(fromHexString(key))
-      if (res) {
-        assert.deepEqual(unprefixedHexToBytes(padToEven(value.slice(2))), RLP.decode(res))
-      } else {
-        assert.equal(value, '0x')
-      }
-    }
+    assert.equal(nodeData.content_value, toHexString(serialized))
   })
 })
-describe.skip('Contract Code Content Type', async () => {
-  const sample: {
-    stateRoot: string
-    accountProof: string[]
-    blockHash: string
-    codeHash: string
+
+describe('Contract ByteCode', async () => {
+  interface ContractByteCodeKeyData {
     address: string
-    code: string
-  } = JSON.parse(
-    readFileSync('./test/networks/state/testdata/sampleContractCode.json', {
-      encoding: 'utf-8',
-    }),
-  )
-  const keyObj = {
-    address: fromHexString(sample.address),
-    codeHash: fromHexString(sample.codeHash),
+    code_hash: string
+    content_key: string
+    content_id: string
   }
-  const contentKey = ContractCodeContentKey.encode(keyObj)
-  it('should encode contentKey', () => {
-    assert.exists(contentKey)
-    assert.equal(contentKey[0], 0x22)
+  const keyData: ContractByteCodeKeyData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/contract_bytecode_key.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content key', () => {
+    const addressHash = keccak256(fromHexString(keyData.address))
+    const contentKey = ContractCodeContentKey.encode({
+      addressHash,
+      codeHash: fromHexString(keyData.code_hash),
+    })
+    assert.equal(keyData.content_key, toHexString(contentKey))
+    const contentId = StateNetworkContentId.fromKeyObj({
+      addressHash,
+      codeHash: fromHexString(keyData.code_hash),
+    })
+    assert.equal(keyData.content_id, toHexString(contentId))
   })
-
-  const accountProof = sample.accountProof.map(fromHexString)
-  const contentObj = {
-    accountProof,
-    code: fromHexString(sample.code),
-    blockHash: fromHexString(sample.blockHash),
-  }
-  const content = ContractCodeOffer.serialize(contentObj)
-
-  it('should serialize content', () => {
-    assert.exists(content)
+  it('decodes a content key', () => {
+    const decoded = ContractCodeContentKey.decode(fromHexString(keyData.content_key))
+    assert.equal(
+      toHexString(decoded.addressHash),
+      toHexString(keccak256(fromHexString(keyData.address))),
+    )
+    assert.deepEqual(decoded, {
+      addressHash: keccak256(fromHexString(keyData.address)),
+      codeHash: fromHexString(keyData.code_hash),
+    })
   })
-
-  it('should decode contentKey', () => {
-    const decoded = ContractCodeContentKey.decode(contentKey)
-    assert.deepEqual(decoded, keyObj)
+  const contractByteCodeWithProofData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/contract_bytecode_with_proof.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content value', () => {
+    const serialized = ContractCodeOffer.serialize({
+      accountProof: contractByteCodeWithProofData.account_proof.map((x) => fromHexString(x)),
+      blockHash: fromHexString(contractByteCodeWithProofData.block_hash),
+      code: fromHexString(contractByteCodeWithProofData.bytecode),
+    })
+    assert.equal(contractByteCodeWithProofData.content_value, toHexString(serialized))
   })
-  it('should deserialize content', () => {
-    const deserialized = ContractCodeOffer.deserialize(content)
-    assert.deepEqual(deserialized, contentObj)
-    assert.deepEqual(fromHexString(sample.code), deserialized.code)
-    const stateroot = new Trie({ useKeyHashing: true })['hash'](deserialized.accountProof[0])
-    assert.deepEqual(stateroot, fromHexString(sample.stateRoot))
-    const account = Account.fromRlpSerializedAccount(deserialized.accountProof.slice(-1)[0])
-    assert.deepEqual(account.codeHash, fromHexString(sample.codeHash))
+  const contractByteCodeData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/contract_bytecode.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content value without proof', () => {
+    const serialized = ContractRetrieval.serialize({
+      code: fromHexString(contractByteCodeData.bytecode),
+    })
+    assert.equal(contractByteCodeData.content_value, toHexString(serialized))
+  })
+})
+
+describe('Storage Trie Node', async () => {
+  const storageTrieNodeKeyData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/contract_storage_trie_node_key.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content key', () => {
+    const addressHash = keccak256(fromHexString(storageTrieNodeKeyData.address))
+    const contentKey = StorageTrieNodeContentKey.encode({
+      addressHash,
+      nodeHash: fromHexString(storageTrieNodeKeyData.node_hash),
+      path: packNibbles(storageTrieNodeKeyData.path.map((x) => x.toString(16))),
+    })
+    assert.equal(storageTrieNodeKeyData.content_key, toHexString(contentKey))
+  })
+  it('finds a content id', () => {
+    const contentId = StateNetworkContentId.fromKeyObj({
+      addressHash: keccak256(fromHexString(storageTrieNodeKeyData.address)),
+      nodeHash: fromHexString(storageTrieNodeKeyData.node_hash),
+      path: packNibbles(storageTrieNodeKeyData.path.map((x) => x.toString(16))),
+    })
+    assert.equal(storageTrieNodeKeyData.content_id, toHexString(contentId))
+  })
+  const storageTrieNodeData = yaml.load(
+    readFileSync(
+      resolve(
+        __dirname,
+        '../../../../portal-spec-tests/tests/mainnet/state/serialization/contract_storage_trie_node_with_proof.yaml',
+      ),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as any
+  it('serializes a content value', () => {
+    const serialized = StorageTrieNodeOffer.serialize({
+      accountProof: storageTrieNodeData.account_proof.map((x) => fromHexString(x)),
+      blockHash: fromHexString(storageTrieNodeData.block_hash),
+      storageProof: storageTrieNodeData.storage_proof.map((x) => fromHexString(x)),
+    })
+    assert.equal(storageTrieNodeData.content_value, toHexString(serialized))
   })
 })


### PR DESCRIPTION
Updates ultralight with changes made in https://github.com/ethereum/portal-network-specs/pull/329