### PR TITLE
Store Network radius value in DB

### DIFF
--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -125,15 +125,15 @@ export class ultralight {
     try {
       switch (networkId) {
         case NetworkId.HistoryNetwork: {
-          this._history!.nodeRadius = 2n ** BigInt(parseInt(radius)) - 1n
+          await this._history!.setRadius(2n ** BigInt(parseInt(radius)) - 1n)
           return '0x' + this._history!.nodeRadius.toString(16)
         }
         case NetworkId.StateNetwork: {
-          this._state!.nodeRadius = 2n ** BigInt(parseInt(radius)) - 1n
+          await this._state!.setRadius(2n ** BigInt(parseInt(radius)) - 1n)
           return '0x' + this._state!.nodeRadius.toString(16)
         }
         case NetworkId.BeaconChainNetwork: {
-          this._beacon!.nodeRadius = 2n ** BigInt(parseInt(radius)) - 1n
+          await this._beacon!.setRadius(2n ** BigInt(parseInt(radius)) - 1n)
           return '0x' + this._beacon!.nodeRadius.toString(16)
         }
         default: {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -281,6 +281,13 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     await this.discv5.start()
     await this.db.open()
     for (const network of this.networks.values()) {
+      try {
+        // Check for stored radius in db
+        const storedRadius = await network.db.get('radius')
+        await network.setRadius(BigInt(storedRadius))
+      } catch {
+        continue
+      }
       // Start kbucket refresh on 30 second interval
       this.refreshListeners.set(
         network.networkId,

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -283,7 +283,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     for (const network of this.networks.values()) {
       try {
         // Check for stored radius in db
-        const storedRadius = await network.db.get('radius')
+        const storedRadius = await network.db.db.get('radius')
         await network.setRadius(BigInt(storedRadius))
       } catch {
         continue

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -288,6 +288,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       } catch {
         continue
       }
+      await network.prune()
       // Start kbucket refresh on 30 second interval
       this.refreshListeners.set(
         network.networkId,

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -158,7 +158,16 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       eventLog: opts.eventLog,
       utpTimeout: opts.utpTimeout,
     })
-
+    for (const network of portal.networks.values()) {
+      try {
+        // Check for stored radius in db
+        const storedRadius = await network.db.db.get('radius')
+        await network.setRadius(BigInt(storedRadius))
+      } catch {
+        continue
+      }
+      await network.prune()
+    }
     return portal
   }
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -116,6 +116,11 @@ export abstract class BaseNetwork extends EventEmitter {
     return this.db.get(key)
   }
 
+  async setRadius(radius: bigint) {
+    this.nodeRadius = radius
+    await this.db.put('radius', radius.toString())
+  }
+
   public async prune(newMaxStorage?: number) {
     const MB = 1000000
     try {
@@ -128,7 +133,7 @@ export abstract class BaseNetwork extends EventEmitter {
         const radius = this.nodeRadius / 2n
         const pruned = await this.db.prune(radius)
         toDelete.push(...pruned)
-        this.nodeRadius = radius
+        await this.setRadius(radius)
         size = await this.db.size()
       }
       for (const [key, val] of toDelete) {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -96,7 +96,6 @@ export abstract class BaseNetwork extends EventEmitter {
       db,
       logger: this.logger,
     })
-    void this.prune()
     if (this.portal.metrics) {
       this.portal.metrics.knownHistoryNodes.collect = () => {
         this.portal.metrics?.knownHistoryNodes.set(this.routingTable.size)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -117,7 +117,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   async setRadius(radius: bigint) {
     this.nodeRadius = radius
-    await this.db.put('radius', radius.toString())
+    await this.db.db.put('radius', radius.toString())
   }
 
   public async prune(newMaxStorage?: number) {


### PR DESCRIPTION
Adds async method `setRadius` to `network` classes.

setRadius sets the `nodeRadius` attribute of the class, but now also stores that value in the network DB (as a string).

during `client.start`, the client will check each network's DB for a stored `radius` value, and call prune.

This way, a client that is restarted with a preexisting DB will immediately remember its own radius settings.  Currently, the radius ends up getting reset to 100%, causing the DB to bloat temporarily before pruning again.  This is likely the cause of the current public bootnode instability.