### PR TITLE
uTP socket closing fix

### DIFF
--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -272,11 +272,6 @@ export class PortalNetworkUTP {
             `Storing: ${toHexString(key)}.  ${request.contentKeys.length} still streaming.`,
           )
           await this.returnContent(request.networkId, [value], [key])
-          if (request.contentKeys.length === 0) {
-            request.socket.close()
-            request.close()
-            this.openContentRequest.delete(request.socketKey)
-          }
           if (request.socket.state === ConnectionState.GotFin) {
             for (let i = request.socket.reader!.startingDataNr; i < request.socket.finNr!; i++) {
               if (request.socket.reader!.packets[i] === undefined) {
@@ -287,9 +282,6 @@ export class PortalNetworkUTP {
                 [Uint8Array.from(request.socket.reader!.bytes)],
                 request.contentKeys,
               )
-              request.socket.close()
-              request.close()
-              this.openContentRequest.delete(request.socketKey)
             }
           }
         }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -263,6 +263,30 @@ export class PortalNetworkUTP {
   async _handleDataPacket(request: ContentRequest, packet: DataPacket) {
     switch (request.requestCode) {
       case RequestCode.FINDCONTENT_READ:
+        await request.socket.handleDataPacket(packet)
+        if (request.socket.state === ConnectionState.GotFin) {
+          // FIN packet number marks the end of data stream
+          if (request.socket.finNr === undefined) {
+            throw new Error('Failed to record FIN packet number')
+          }
+          // Check if all packets have been received from startingDataNr to finNr
+          for (let i = request.socket.finNr - 1; i >= request.socket.reader!.startingDataNr; i--) {
+            if (request.socket.reader!.packets[i] === undefined) {
+              // If any packet is missing, return and wait for out of order packet
+              return
+            }
+          }
+          // If all packets have been received, return content
+          await this.returnContent(
+            request.networkId,
+            [Uint8Array.from(request.socket.reader!.bytes)],
+            request.contentKeys,
+          )
+          request.socket.close()
+          request.close()
+          this.openContentRequest.delete(request.socketKey)
+        }
+        return
       case RequestCode.ACCEPT_READ:
         await request.socket.handleDataPacket(packet)
         while (request.socket.reader!.contents.length > 0) {
@@ -272,18 +296,6 @@ export class PortalNetworkUTP {
             `Storing: ${toHexString(key)}.  ${request.contentKeys.length} still streaming.`,
           )
           await this.returnContent(request.networkId, [value], [key])
-          if (request.socket.state === ConnectionState.GotFin) {
-            for (let i = request.socket.reader!.startingDataNr; i < request.socket.finNr!; i++) {
-              if (request.socket.reader!.packets[i] === undefined) {
-                return
-              }
-              await this.returnContent(
-                request.networkId,
-                [Uint8Array.from(request.socket.reader!.bytes)],
-                request.contentKeys,
-              )
-            }
-          }
         }
         return
       default:


### PR DESCRIPTION
Removes some logic that was prematurely closing a uTP socket before the FIN packet was received.

The `history-trin-bridge` hive tests have been failing for Ultralight for some time and removing this logic for early closure of uTP sockets in the `READ_ACCEPT` flow resolves this test failure.  It also resolves a related issue where FIN packets were being received for these prematurely closed sockets leading to logged errors about receiving messages for sockets that didn't exist (which were the FIN packets sent to close these sockets).

To validate this fix locally: 

Build the Ultralight docker image locally with `docker buildx build .  --tag ultralight:latest`
Update lines 2-3 of the `[hive directory root]/clients/ultralight/Dockerfile` to:
```
ARG baseimage=ultralight
ARG tag=latest
```

Run `./hive --sim portal --client ultralight,trin-bridge --sim.limit="history-trin-bridge" --docker.output` to verify that the bridge tests are now passing.