### PR TITLE
Cli: debug --networks option

### DIFF
--- a/packages/cli/scripts/devnet.ts
+++ b/packages/cli/scripts/devnet.ts
@@ -53,8 +53,8 @@ const args: any = yargs(hideBin(process.argv))
   })
   .option('networks', {
     describe: 'supported subnetworks',
-    array: true,
-    default: ['history', 'beacon', 'state'],
+    string: true,
+    default: 'history,beacon,state',
     optional: true,
   })
   .option('connectNodes', {
@@ -72,10 +72,10 @@ const args: any = yargs(hideBin(process.argv))
 const main = async () => {
   console.log(`starting ${args.numNodes} nodes`)
 
-  const networks =
-    args.networks !== false
-      ? (args.networks as Array<string>).map((network) => `--networks=${network}`)
-      : []
+  // const networks =
+  //   args.networks !== false
+  //     ? (args.networks as Array<string>).map((network) => `--networks=${network}`)
+  //     : []
   const cmd = 'hostname -I'
   const pubIp = execSync(cmd).toString().split(' ')
   const ip = '0.0.0.0'
@@ -95,7 +95,7 @@ const main = async () => {
           `--metrics=true`,
           `--metricsPort=${18545 + idx}`,
           `--bindAddress-${ip}:${args.port + idx}`,
-          ...networks,
+          `--networks=${args.networks}`,
         ],
         { stdio: ['pipe', 'pipe', process.stderr] },
       )
@@ -112,7 +112,7 @@ const main = async () => {
           `--metrics=true`,
           `--metricsPort=${18545 + x}`,
           `--bindAddress=${ip}:${args.port + x}`,
-          ...networks,
+          `--networks=${args.networks}`,
         ],
         { stdio: ['pipe', 'pipe', process.stderr] },
       )

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -80,7 +80,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   })
   .option('networks', {
     describe: 'subnetworks to enable',
-    array: true,
+    string: true,
     optional: true,
   })
   .option('storageHistory', {
@@ -151,8 +151,9 @@ const main = async () => {
     trustedBlockRoot: args.trustedBlockRoot,
   } as any
   let networks: NetworkConfig[] = []
-  if (args.networks) {
-    for (const network of args.networks) {
+  if (args.networks !== undefined) {
+    const active = args.networks.split(',')
+    for (const network of active) {
       let networkdb
       if (args.dataDir !== undefined) {
         networkdb = {
@@ -301,7 +302,7 @@ const main = async () => {
       },
     })
     server.http().listen(args.rpcPort, rpcAddr)
-
+    log(`Started Portal Client on Networks: ${networks.map((n) => n.networkId).join(', ')}`)
     log(`Started JSON RPC Server address=http://${rpcAddr}:${args.rpcPort}`)
   }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -276,7 +276,7 @@ export interface ClientOpts {
   metricsPort: number
   dataDir?: string
   web3?: string
-  networks?: (string | number)[]
+  networks?: string
   storageHistory: number
   storageBeacon: number
   storageState: number
@@ -289,6 +289,6 @@ export interface DevnetOpts {
   ip?: string
   promConfig?: boolean
   port: number
-  networks: string[]
+  networks: string
   connectNodes: boolean
 }


### PR DESCRIPTION
### Issue: 

The CLI option `--networks` is supposed to accept a string array as a list of networks to activate.

`--networks=history,state`

However, this does not work.  What does work is passing multiple `--networks` options separately, like: 

`--networks=history --networks=state`

This is generally bad UX, but also causes ultralight to start incorrectly in  `portal-hive` tests.

### Fix:

The `--networks` options now expects to be a string, and will split the string into an array of networks.

So now `--networks=history,state` will act as expected.


**This fixes several failing `portal-hive` tests**