### PR TITLE
Fix content lookup bug

### DIFF
--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -449,7 +449,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
             this.logger.extend('FOUNDCONTENT')(`received uTP Connection ID ${id}`)
             decoded = await new Promise((resolve, _reject) => {
               // TODO: Figure out how to clear this listener
-              this.on('ContentAdded', (contentKey, contentType, value) => {
+              this.on('ContentAdded', (contentKey, value) => {
                 if (contentKey === toHexString(key)) {
                   resolve({ selector: 0, value })
                 }
@@ -692,7 +692,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
     this.logger(
       `storing ${BeaconLightClientNetworkContentType[contentType]} content corresponding to ${contentKey}`,
     )
-    this.emit('ContentAdded', contentKey, contentType, value)
+    this.emit('ContentAdded', contentKey, value)
   }
 
   /**

--- a/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
+++ b/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
@@ -1,3 +1,4 @@
+import { fromHexString } from '@chainsafe/ssz'
 import { bytesToHex, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { genesisData } from '@lodestar/config/networks'
 import { getCurrentSlot } from '@lodestar/light-client/utils'
@@ -261,7 +262,8 @@ export class UltralightTransport implements LightClientTransport {
   }
 
   onOptimisticUpdate(handler: (optimisticUpdate: LightClientOptimisticUpdate) => void): void {
-    this.network.on('ContentAdded', (_contentKey, contentType, content: Uint8Array) => {
+    this.network.on('ContentAdded', (_contentKey, content: Uint8Array) => {
+      const contentType = fromHexString(_contentKey)[0]
       if (contentType === BeaconLightClientNetworkContentType.LightClientOptimisticUpdate) {
         const forkhash = content.slice(0, 4)
         const forkname = this.network.beaconConfig.forkDigest2ForkName(
@@ -277,7 +279,8 @@ export class UltralightTransport implements LightClientTransport {
     })
   }
   onFinalityUpdate(handler: (finalityUpdate: LightClientFinalityUpdate) => void): void {
-    this.network.on('ContentAdded', (_contentKey, contentType, content: Uint8Array) => {
+    this.network.on('ContentAdded', (_contentKey, content: Uint8Array) => {
+      const contentType = fromHexString(_contentKey)[0]
       if (contentType === BeaconLightClientNetworkContentType.LightClientFinalityUpdate) {
         const forkhash = content.slice(0, 4)
         const forkname = this.network.beaconConfig.forkDigest2ForkName(

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -1,11 +1,9 @@
 import { distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
-import { fromHexString, toHexString } from '@chainsafe/ssz'
+import { toHexString } from '@chainsafe/ssz'
 import { hexToBytes, short } from '@ethereumjs/util'
 
 import { serializedContentKeyToContentId, shortId } from '../util/index.js'
-
-import { getContentKey } from './history/util.js'
 
 import type { BaseNetwork } from './network.js'
 import type { NodeId } from '@chainsafe/enr'
@@ -117,12 +115,8 @@ export class ContentLookup {
         peer.hasContent = true
         return new Promise((resolve) => {
           let timeout: any = undefined
-          const utpDecoder = (contentKey: string, contentType: number, content: Uint8Array) => {
-            const _contentKey = getContentKey(contentType, fromHexString(contentKey))
-            if (
-              contentKey === toHexString(this.contentKey) ||
-              _contentKey === toHexString(this.contentKey)
-            ) {
+          const utpDecoder = (contentKey: string, content: Uint8Array) => {
+            if (contentKey === toHexString(this.contentKey)) {
               this.logger(`Received content for this contentKey: ${toHexString(this.contentKey)}`)
               this.network.removeListener('ContentAdded', utpDecoder)
               clearTimeout(timeout)

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -274,7 +274,7 @@ export class HistoryNetwork extends BaseNetwork {
       }
     }
 
-    this.emit('ContentAdded', contentKey, contentType, value)
+    this.emit('ContentAdded', contentKey, value)
     if (this.routingTable.values().length > 0) {
       // Gossip new content to network (except header accumulators)
       this.gossipManager.add(hashKey, contentType)

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -146,7 +146,7 @@ export class StateNetwork extends BaseNetwork {
         await this.stateDB.storeContent(_contentKey, content)
       }
       this.logger(`content added for: ${contentKey}`)
-      this.emit('ContentAdded', contentKey, contentType, content)
+      this.emit('ContentAdded', contentKey, content)
     } catch (err: any) {
       this.logger(`Error storing content: ${err.message}`)
     }

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -21,6 +21,7 @@ import {
   NetworkId,
   PortalNetwork,
   TransportLayer,
+  fromHexString,
   getBeaconContentKey,
   toHexString,
 } from '../../src/index.js'
@@ -350,7 +351,8 @@ describe('OFFER/ACCEPT tests', () => {
     )
 
     await new Promise((resolve) => {
-      network2.on('ContentAdded', (contentKey, contentType) => {
+      network2.on('ContentAdded', (contentKey) => {
+        const contentType = fromHexString(contentKey)[0]
         if (contentType === BeaconLightClientNetworkContentType.LightClientOptimisticUpdate)
           // Update the light client stub to report the new "optimistic head"
           network2.lightClient = {

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -15,6 +15,7 @@ import {
   PortalNetwork,
   TransportLayer,
   addRLPSerializedBlock,
+  fromHexString,
   generatePreMergeHeaderProof,
   getContentKey,
   toHexString,
@@ -124,7 +125,8 @@ describe('gossip test', async () => {
 
     // Fancy workaround to allow us to "await" an event firing as expected following this - https://github.com/ljharb/tape/pull/503#issuecomment-619358911
     const end = new EventEmitter()
-    network2.on('ContentAdded', async (key, contentType, content: Uint8Array) => {
+    network2.on('ContentAdded', async (key, content: Uint8Array) => {
+      const contentType = fromHexString(key)[0]
       if (contentType === 0) {
         const headerWithProof = BlockHeaderWithProof.deserialize(content)
         const header = BlockHeader.fromRLPSerializedHeader(headerWithProof.header, {


### PR DESCRIPTION
Removes `HistoryNetwork` based logic from `ContentLookup`

Old hack was in place for parsing the `contentKey` during content lookup.

This is no longer relevant, and caused bugs in performance of other networks.

 `uTPDecoder` method within `ContentLookup` was edited to no longer require the `ContentType` parameter, as this info is already in the `ContentKey`.