### PR TITLE
RPC: FindContent bug

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -26,11 +26,9 @@ import type {
   AcceptMessage,
   BeaconLightClientNetwork,
   HistoryNetwork,
-  HistoryNetworkContentType,
   NodesMessage,
   PortalNetwork,
   StateNetwork,
-  StateNetworkContentType,
 } from 'portalnetwork'
 
 const methods = [
@@ -660,19 +658,12 @@ export class portal {
               const timeout = setTimeout(() => {
                 resolve(Uint8Array.from([]))
               }, 10000)
-              this._history.on(
-                'ContentAdded',
-                (
-                  _contentKey: string,
-                  _contentType: HistoryNetworkContentType,
-                  value: Uint8Array,
-                ) => {
-                  if (_contentKey === contentKey) {
-                    clearTimeout(timeout)
-                    resolve(value)
-                  }
-                },
-              )
+              this._history.on('ContentAdded', (_contentKey: string, value: Uint8Array) => {
+                if (_contentKey === contentKey) {
+                  clearTimeout(timeout)
+                  resolve(value)
+                }
+              })
             })
     this.logger.extend('findContent')(`request returned ${content.length} bytes`)
     res.selector === FoundContent.UTP && this.logger.extend('findContent')('utp')
@@ -714,15 +705,12 @@ export class portal {
               const timeout = setTimeout(() => {
                 resolve(Uint8Array.from([]))
               }, 2000)
-              this._state.on(
-                'ContentAdded',
-                (hash: string, _contentType: StateNetworkContentType, value: Uint8Array) => {
-                  if (hash === contentKey) {
-                    clearTimeout(timeout)
-                    resolve(value)
-                  }
-                },
-              )
+              this._state.on('ContentAdded', (hash: string, value: Uint8Array) => {
+                if (hash === contentKey) {
+                  clearTimeout(timeout)
+                  resolve(value)
+                }
+              })
             })
     this.logger.extend('findContent')(`request returned ${content.length} bytes`)
     res.selector === FoundContent.UTP && this.logger.extend('findContent')('utp')

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -107,7 +107,7 @@ export class StateNetwork extends BaseNetwork {
               `received ${StateNetworkContentType[contentType]} content corresponding to ${contentHash}`,
             )
             try {
-              await this.store(toHexString(key), decoded.value as Uint8Array)
+              await this.stateDB.storeContent(key, decoded.value as Uint8Array)
             } catch {
               this.logger('Error adding content to DB')
             }

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -197,7 +197,7 @@ describe('getAccount via network', async () => {
 
   const testAddress = '0x1a2694ec07cf5e4d68ba40f3e7a14c53f3038c6e'
   const stateRoot = trie['hash'](deserialized.proof[0])
-  const found = await testClient.getAccount(testAddress, stateRoot, false)
+  const found = await testClient.getAccount(testAddress, stateRoot, true)
   if (found === undefined) {
     it('failed', () => {
       assert.fail('failed to find account data')
@@ -211,7 +211,8 @@ describe('getAccount via network', async () => {
 
   const temp = [...testClient.stateDB.db.tempKeys()]
   const perm: string[] = await testClient.stateDB.keys()
-  it('should have all nodes in temp or permanent db', async () => {
+  console.log({ temp, perm })
+  it(`should have all ${uniqueStored.length} nodes in temp or permanent db`, async () => {
     expect(temp.length + perm.length).toEqual(uniqueStored.length)
     for (const key of temp) {
       expect(perm.includes(key)).toBeFalsy()


### PR DESCRIPTION
Recent update removed the `ContentType` parameter from the `ContentAdded` event.

RPC `findContent` methods rely on this event, but were not updated accordingly.

Also fixes FindContent bug in `StateProtocol` which processed AccountTrieNode content like an OFFER (they are different SSZ types)