### PR TITLE
Add typecheck script to portalnetwork

### DIFF
--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -13,6 +13,7 @@
     "docs": "typedoc src/index.ts",
     "test": "npx vitest run test/* -c=./vitest.config.unit.ts",
     "test:integration": "npx vitest run ./test/integration/*.spec.ts -c=./vitest.config.integration.ts",
+    "typecheck": "tsc -p ./tsconfig.types.json",
     "coverage": "c8 npm run test",
     "coverage:all": "c8 npm run test:all",
     "lint": "../../config/cli/lint.sh",

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -6,7 +6,7 @@ describe('Client unit tests', () => {
     const node = await PortalNetwork.create({
       bindAddress: '192.168.0.1',
       transport: TransportLayer.WEB,
-      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     })
     assert.equal(
       node.discv5.enr.getLocationMultiaddr('udp')!.toOptions().host,

--- a/packages/portalnetwork/test/client/eth/eth.spec.ts
+++ b/packages/portalnetwork/test/client/eth/eth.spec.ts
@@ -10,8 +10,8 @@ describe('ETH class base level API checks', async () => {
   const ultralight = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
     supportedNetworks: [
-      { networkId: NetworkId.HistoryNetwork, radius: 1n },
-      { networkId: NetworkId.StateNetwork, radius: 1n },
+      { networkId: NetworkId.HistoryNetwork },
+      { networkId: NetworkId.StateNetwork },
     ],
   })
   const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork

--- a/packages/portalnetwork/test/client/provider.spec.ts
+++ b/packages/portalnetwork/test/client/provider.spec.ts
@@ -24,7 +24,7 @@ it('Test provider functionality', async () => {
       enr,
       peerId,
     },
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
 
   const block = await provider.getBlock(5000)

--- a/packages/portalnetwork/test/integration/stateGenesis.spec.ts
+++ b/packages/portalnetwork/test/integration/stateGenesis.spec.ts
@@ -132,6 +132,7 @@ describe('genesisDevnet', async () => {
       expect(foundAccount.balance).toBeGreaterThan(0n)
       assert.deepEqual(
         foundAccount.balance,
+        // @ts-ignore disregard string index type complaints since we can't easily configure a giant list of addresses as a type
         BigInt(mainnet.alloc[testAddress].balance),
         'account data found',
       )

--- a/packages/portalnetwork/test/networks/history/headerProof.spec.ts
+++ b/packages/portalnetwork/test/networks/history/headerProof.spec.ts
@@ -218,9 +218,9 @@ describe('Bellatrix - Capella header proof tests', () => {
 
 describe('it should verify a post-Capella header proof', () => {
   const forkConfig = createChainForkConfig({})
-  let proof
+  let proof: any
   beforeAll(async () => {
-    proof = (await import('./testData/slot9682944Proof.json')).default
+    proof = await import('./testData/slot9682944Proof.json')
   })
   it('should instantiate a proof from json', () => {
     const headerProof = HistoricalSummariesBlockProof.fromJson(proof)

--- a/packages/portalnetwork/test/networks/history/headerProof.spec.ts
+++ b/packages/portalnetwork/test/networks/history/headerProof.spec.ts
@@ -220,7 +220,7 @@ describe('it should verify a post-Capella header proof', () => {
   const forkConfig = createChainForkConfig({})
   let proof
   beforeAll(async () => {
-    proof = await import('./testData/slot9682944Proof.json')
+    proof = (await import('./testData/slot9682944Proof.json')).default
   })
   it('should instantiate a proof from json', () => {
     const headerProof = HistoricalSummariesBlockProof.fromJson(proof)

--- a/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
@@ -206,7 +206,7 @@ describe('Header Tests', async () => {
         blockHash: toHexString(header.hash()),
       })
       assert.ok(res, 'validated post-merge proof')
-    } catch (err) {
+    } catch (err: any) {
       assert.fail(err.message)
     }
     await network.store(headerKey, serializedHeaderWithProof)

--- a/packages/portalnetwork/test/networks/history/portalSpecTests.spec.ts
+++ b/packages/portalnetwork/test/networks/history/portalSpecTests.spec.ts
@@ -80,7 +80,7 @@ describe('pre-merge header tests', () => {
     })
     assert.equal(header.number, 1000010n)
     assert.equal(
-      bytesToHex(headerWithProof.proof.value![0]),
+      bytesToHex((headerWithProof.proof.value! as Uint8Array[])[0]),
       '0xcead98e305c70563000000000000000000000000000000000000000000000000',
     )
   })

--- a/packages/portalnetwork/test/networks/history/types.spec.ts
+++ b/packages/portalnetwork/test/networks/history/types.spec.ts
@@ -284,8 +284,12 @@ describe('Header With Proof serialization/deserialization tests', async () => {
       'stored epoch hash matches valid epoch',
     )
   })
-  const total_difficulty = new UintBigintType(32).deserialize(headerWithProof.proof.value![0])
-  const total_difficulty2 = new UintBigintType(32).deserialize(headerWithProof2.proof.value![0])
+  const total_difficulty = new UintBigintType(32).deserialize(
+    (headerWithProof.proof.value! as Uint8Array[])[0],
+  )
+  const total_difficulty2 = new UintBigintType(32).deserialize(
+    (headerWithProof2.proof.value! as Uint8Array[])[0],
+  )
   it('should calculate total difficulty', () => {
     assert.equal(
       total_difficulty2 - total_difficulty,

--- a/packages/portalnetwork/test/networks/history/types.spec.ts
+++ b/packages/portalnetwork/test/networks/history/types.spec.ts
@@ -246,7 +246,7 @@ describe('Header With Proof serialization/deserialization tests', async () => {
     )
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
   const history = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const serializedBlock1 = hexToBytes(testData[1000001].content_value)

--- a/packages/portalnetwork/test/networks/history/util.spec.ts
+++ b/packages/portalnetwork/test/networks/history/util.spec.ts
@@ -110,12 +110,16 @@ describe('BlockHeader ssz serialization/deserialization with pre and post shangh
     assertType<Uint8Array>(preEncoded)
     assertType<Uint8Array>(postEncoded)
 
-    const deserializedPreBlock = decodeSszBlockBody(preEncoded, false)
+    const deserializedPreBlock = decodeSszBlockBody(
+      preEncoded,
+      false,
+    ) as PostShanghaiBlockBodyContent
+
     const deserializedPostBlock = decodeSszBlockBody(
       postEncoded,
       true,
     ) as PostShanghaiBlockBodyContent
-    assert.equal(deserializedPreBlock['allWithdrawals'], undefined)
+    assert.equal(deserializedPreBlock.allWithdrawals, undefined)
     assert.ok(
       deserializedPostBlock.allWithdrawals !== undefined &&
         deserializedPostBlock.allWithdrawals.length === 16,

--- a/packages/portalnetwork/test/networks/protocol.spec.ts
+++ b/packages/portalnetwork/test/networks/protocol.spec.ts
@@ -185,7 +185,7 @@ describe('handleFindNodes message handler tests', async () => {
   const node = await PortalNetwork.create({
     bindAddress: '192.168.0.1',
     transport: TransportLayer.WEB,
-    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork, radius: 1n }],
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
   })
   const network = node.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   type sendResponse = (src: INodeAddress, requestId: bigint, payload: Uint8Array) => Promise<void>

--- a/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
+++ b/packages/portalnetwork/test/networks/state/accountTrieNode.spec.ts
@@ -59,7 +59,7 @@ describe('StateNetwork AccountTrieNode Gossip', async () => {
   }
   const client = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
-    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius: BigInt(2 ** config.r) }],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork }],
     config: {
       enr: config.enr,
       peerId: config.peerId,

--- a/packages/portalnetwork/test/networks/state/content.spec.ts
+++ b/packages/portalnetwork/test/networks/state/content.spec.ts
@@ -224,9 +224,9 @@ describe('Storage Trie Node', async () => {
   ) as any
   it('serializes a content value', () => {
     const serialized = StorageTrieNodeOffer.serialize({
-      accountProof: storageTrieNodeData.account_proof.map((x) => fromHexString(x)),
+      accountProof: storageTrieNodeData.account_proof.map((x: string) => fromHexString(x)),
       blockHash: fromHexString(storageTrieNodeData.block_hash),
-      storageProof: storageTrieNodeData.storage_proof.map((x) => fromHexString(x)),
+      storageProof: storageTrieNodeData.storage_proof.map((x: string) => fromHexString(x)),
     })
     assert.equal(storageTrieNodeData.content_value, toHexString(serialized))
   })

--- a/packages/portalnetwork/test/networks/state/content.spec.ts
+++ b/packages/portalnetwork/test/networks/state/content.spec.ts
@@ -157,7 +157,9 @@ describe('Contract ByteCode', async () => {
   ) as any
   it('serializes a content value', () => {
     const serialized = ContractCodeOffer.serialize({
-      accountProof: contractByteCodeWithProofData.account_proof.map((x) => fromHexString(x)),
+      accountProof: contractByteCodeWithProofData.account_proof.map((x: string) =>
+        fromHexString(x),
+      ),
       blockHash: fromHexString(contractByteCodeWithProofData.block_hash),
       code: fromHexString(contractByteCodeWithProofData.bytecode),
     })
@@ -199,7 +201,7 @@ describe('Storage Trie Node', async () => {
     const contentKey = StorageTrieNodeContentKey.encode({
       addressHash,
       nodeHash: fromHexString(storageTrieNodeKeyData.node_hash),
-      path: packNibbles(storageTrieNodeKeyData.path.map((x) => x.toString(16))),
+      path: packNibbles(storageTrieNodeKeyData.path.map((x: number) => x.toString(16))),
     })
     assert.equal(storageTrieNodeKeyData.content_key, toHexString(contentKey))
   })
@@ -207,7 +209,7 @@ describe('Storage Trie Node', async () => {
     const contentId = StateNetworkContentId.fromKeyObj({
       addressHash: keccak256(fromHexString(storageTrieNodeKeyData.address)),
       nodeHash: fromHexString(storageTrieNodeKeyData.node_hash),
-      path: packNibbles(storageTrieNodeKeyData.path.map((x) => x.toString(16))),
+      path: packNibbles(storageTrieNodeKeyData.path.map((x: number) => x.toString(16))),
     })
     assert.equal(storageTrieNodeKeyData.content_id, toHexString(contentId))
   })

--- a/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/state/stateNetwork.spec.ts
@@ -9,15 +9,13 @@ import type { StateNetwork } from '../../../src/index.js'
 describe('StateNetwork', async () => {
   const pk = await createSecp256k1PeerId()
   const enr1 = SignableENR.createFromPeerId(pk)
-  const r = 4n
-  const radius = 2n ** (256n - r) - 1n
   const ultralight = await PortalNetwork.create({
     bindAddress: '127.0.0.1',
     config: {
       enr: enr1,
       peerId: pk,
     },
-    supportedNetworks: [{ networkId: NetworkId.StateNetwork, radius }],
+    supportedNetworks: [{ networkId: NetworkId.StateNetwork }],
   })
   const stateNetwork = ultralight.networks.get(NetworkId.StateNetwork)
   it('should start with state network', () => {

--- a/packages/portalnetwork/tsconfig.types.json
+++ b/packages/portalnetwork/tsconfig.types.json
@@ -1,0 +1,105 @@
+{
+  "include": ["./src/**/*.ts", "./src/**/*.json", "./test/**/*.ts", "./test/**/*.json"],
+  "exclude": ["dist"],
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    "composite": true /* Enable constraints that allow a TypeScript project to be used with project references. */,
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "esnext" /* Specify what module code is generated. */,
+    //"rootDir": "./src" /* Specify the root folder within your source files. */,
+    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    "typeRoots": [
+      "./node_modules/types",
+      "./types"
+    ] /* Specify multiple folders that act like `./node_modules/@types`. */,
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    "resolveJsonModule": true /* Enable importing .json files */,
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+    "declarationMap": true /* Create sourcemaps for d.ts files. */,
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    // "removeComments": true,                           /* Disable emitting comments. */
+    "noEmit": true /* Disable emitting files from a compilation. */,
+    "importHelpers": true /* Allow importing helper functions from tslib once per project, instead of including them per-file. */,
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
Adds a new non-required `typecheck` npm script for portalnetwork that typechecks all source and test files.

Not going to add it to CI yet as there are some annoying type failures I'm not excited about fixing.