### PR TITLE
History: in-memory blockhash index

### DIFF
--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -111,7 +111,7 @@ export class ultralight {
     const [blockNum, blockHash] = params
     try {
       this.logger(`Indexed block ${BigInt(blockNum)} / ${blockNum} to ${blockHash} `)
-      await this._history!.indexBlockhash(BigInt(blockNum), blockHash)
+      await this._history!.indexBlockHash(BigInt(blockNum), blockHash)
       return `Added ${blockNum} to block index`
     } catch (err: any) {
       throw {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -289,6 +289,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   public start = async () => {
     await this.discv5.start()
     await this.db.open()
+    const storedIndex = await this.db.getBlockIndex()
     for (const network of this.networks.values()) {
       try {
         // Check for stored radius in db
@@ -296,6 +297,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         await network.setRadius(BigInt(storedRadius))
       } catch {
         // No action
+      }
+      if (network instanceof HistoryNetwork) {
+        network.blockHashIndex = storedIndex
       }
       await network.prune()
       // Start kbucket refresh on 30 second interval

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -295,7 +295,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         const storedRadius = await network.db.db.get('radius')
         await network.setRadius(BigInt(storedRadius))
       } catch {
-        continue
+        // No action
       }
       await network.prune()
       // Start kbucket refresh on 30 second interval

--- a/packages/portalnetwork/src/client/eth.ts
+++ b/packages/portalnetwork/src/client/eth.ts
@@ -90,10 +90,9 @@ export class ETH {
       this.logger.extend('getBlockByHash')(lookupResponse)
       if (!lookupResponse || !('content' in lookupResponse)) {
         // Header not found by hash, try to find by number if known
-        const blockIndex = await this.history!.blockIndex()
-        const blockNumber = blockIndex.get(blockHash)
+        const blockNumber = this.history!.blockHashToNumber(blockHash)
         if (blockNumber !== undefined) {
-          const block = await this.getBlockByNumber(BigInt(blockNumber), includeTransactions)
+          const block = await this.getBlockByNumber(blockNumber, includeTransactions)
           return block
         }
         return undefined
@@ -191,7 +190,7 @@ export class ETH {
       }
     } else {
       // Header not found by number.  If block hash is known, search for header by hash
-      const blockHash = await this.history!.blockNumberToHash(BigInt(blockNumber))
+      const blockHash = this.history!.blockNumberToHash(BigInt(blockNumber))
       if (blockHash !== undefined) {
         return this.getBlockByHash(blockHash, includeTransactions)
       }

--- a/packages/portalnetwork/src/networks/history/util.ts
+++ b/packages/portalnetwork/src/networks/history/util.ts
@@ -232,7 +232,7 @@ export const addRLPSerializedBlock = async (
       header: header.serialize(),
       proof: { selector: 0, value: null },
     })
-    await network.indexBlockhash(header.number, toHexString(header.hash()))
+    await network.indexBlockHash(header.number, toHexString(header.hash()))
 
     await network.store(headerKey, headerProof)
   }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -57,7 +57,6 @@ export abstract class BaseNetwork extends EventEmitter {
   public networkId: NetworkId
   abstract networkName: string
   public enr: SignableENR
-  public blockHashIndex: Map<string, string>
   handleNewRequest: (request: INewRequest) => Promise<ContentRequest>
   sendMessage: (
     enr: ENR | string,
@@ -76,7 +75,6 @@ export abstract class BaseNetwork extends EventEmitter {
     this.sendResponse = client.sendPortalNetworkResponse.bind(client)
     this.findEnr = client.discv5.findEnr.bind(client.discv5)
     this.handleNewRequest = client.uTP.handleNewRequest.bind(client.uTP)
-    this.blockHashIndex = new Map()
     this.enr = client.discv5.enr
     this.checkIndex = 0
     this.nodeRadius = radius ?? 2n ** 256n - 1n
@@ -95,15 +93,6 @@ export abstract class BaseNetwork extends EventEmitter {
         this.portal.metrics?.knownHistoryNodes.set(this.routingTable.size)
       }
     }
-  }
-
-  public blockNumberToHash(blockNumber: bigint): string | undefined {
-    return this.blockHashIndex.get('0x' + blockNumber.toString(16))
-  }
-
-  public blockHashToNumber(blockHash: string): bigint | undefined {
-    const blockNumber = this.blockHashIndex.get(blockHash)
-    return blockNumber === undefined ? undefined : BigInt(blockNumber)
   }
 
   public async put(contentKey: string, content: string) {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -57,8 +57,7 @@ export abstract class BaseNetwork extends EventEmitter {
   public networkId: NetworkId
   abstract networkName: string
   public enr: SignableENR
-  public blockIndex: () => Promise<Map<string, string>>
-  public setBlockIndex: (blockIndex: Map<string, string>) => Promise<void>
+  public blockHashIndex: Map<string, string>
   handleNewRequest: (request: INewRequest) => Promise<ContentRequest>
   sendMessage: (
     enr: ENR | string,
@@ -77,12 +76,7 @@ export abstract class BaseNetwork extends EventEmitter {
     this.sendResponse = client.sendPortalNetworkResponse.bind(client)
     this.findEnr = client.discv5.findEnr.bind(client.discv5)
     this.handleNewRequest = client.uTP.handleNewRequest.bind(client.uTP)
-    this.blockIndex = () => {
-      return client.db.getBlockIndex()
-    }
-    this.setBlockIndex = (blockIndex: Map<string, string>) => {
-      return client.db.storeBlockIndex(blockIndex)
-    }
+    this.blockHashIndex = new Map()
     this.enr = client.discv5.enr
     this.checkIndex = 0
     this.nodeRadius = radius ?? 2n ** 256n - 1n
@@ -103,14 +97,12 @@ export abstract class BaseNetwork extends EventEmitter {
     }
   }
 
-  public async blockNumberToHash(blockNumber: bigint): Promise<string | undefined> {
-    const blockIndex = await this.blockIndex()
-    return blockIndex.get('0x' + blockNumber.toString(16))
+  public blockNumberToHash(blockNumber: bigint): string | undefined {
+    return this.blockHashIndex.get('0x' + blockNumber.toString(16))
   }
 
-  public async blockHashToNumber(blockHash: string): Promise<bigint | undefined> {
-    const blockIndex = await this.blockIndex()
-    const blockNumber = blockIndex.get(blockHash)
+  public blockHashToNumber(blockHash: string): bigint | undefined {
+    const blockNumber = this.blockHashIndex.get(blockHash)
     return blockNumber === undefined ? undefined : BigInt(blockNumber)
   }
 

--- a/packages/portalnetwork/test/client/eth/ethCall.spec.ts
+++ b/packages/portalnetwork/test/client/eth/ethCall.spec.ts
@@ -88,7 +88,7 @@ describe.skip('ethCall', () => {
   //     toHexString(block.header.hash()),
   //     history,
   //   )
-  //   await history.indexBlockhash(block.header.number, toHexString(block.header.hash()))
+  //   await history.indexBlockHash(block.header.number, toHexString(block.header.hash()))
   //   const greeterInput = '0xcfae3217'
   //   const tx: RpcTx = {
   //     to: address.toString(),

--- a/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
+++ b/packages/portalnetwork/test/networks/history/blockIndex.spec.ts
@@ -28,14 +28,13 @@ describe('BlockIndex', async () => {
   it('should store block header', () => {
     assert.equal(stored, headerWithProof)
   })
-  it('should save block index', async () => {
+  it('should save block index', () => {
     const numberHex = '0x' + BigInt(1).toString(16)
-    const index = await history.blockIndex()
-    assert.isTrue(index.has(numberHex))
-    assert.equal(index.get(numberHex), hash)
+    assert.isTrue(history.blockHashIndex.has(numberHex))
+    assert.equal(history.blockHashIndex.get(numberHex), hash)
   })
   it('should store blockIndex in DB', async () => {
-    const expected = Array.from(await history.blockIndex())
+    const expected = Array.from(history.blockHashIndex)
     const stored = JSON.parse(await ultralight.db.db.get('block_index'))
     assert.deepEqual(stored, expected)
   })
@@ -45,10 +44,11 @@ describe('BlockIndex', async () => {
     supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     db: ultralight.db.db,
   })
+  await ultralight2.start()
   const history2 = ultralight2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   it('should start with blockIndex in DB', async () => {
-    const expected = await history.blockIndex()
-    const stored = await history2.blockIndex()
-    assert.deepEqual(stored, expected)
+    const expected = history.blockHashIndex
+    const stored = history2.blockHashIndex
+    assert.deepEqual(stored, expected, `Expected ${expected.size} but got ${stored.size}`)
   })
 })


### PR DESCRIPTION
Refactors the `BlockIndex` into an in-memory attribute of the `HistoryNetwork` class.

1. Removes async blockIndex getter/setter from `BaseNetwork`
2. Adds `this.blockHashIndex` to `HistoryNetwork`
3. Moves `hashToNumber` and `numberToHash` helpers to `HistoryNetwork`
4. Makes helper functions syncronous
5. In `history.indexBlockHash(...)`, updated index is *also* stored in DB
6. Stored block index is retrieved from DB during client.start() to set `history.blockHashIndex`

`history.blockHashIndex` is type `Map<string,string>`

Map index entries stored in both directions (`num > hash` / `hash > num`)

`blockNumber` is **0x prefixed hex** 
`blockHash` is **0x prefixed hex**

e.g.

```
 Map {
   "0x1" => "0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
   "0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6" => "0x1",
 }
```