### PR TITLE
BaseNetwork: unbind client methods

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -450,9 +450,9 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   /**
    *
    * @param dstId `NodeId` of message recipient
-   * @param payload `Buffer` serialized payload of message
+   * @param payload `Uint8Array` serialized payload of message
    * @param networkId subnetwork ID of subnetwork message is being sent on
-   * @returns response from `dstId` as `Buffer` or null `Buffer`
+   * @returns response from `dstId` as `Uint8Array` or empty array
    */
   public sendPortalNetworkMessage = async (
     enr: ENR | string,

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -59,24 +59,11 @@ export abstract class BaseNetwork extends EventEmitter {
   public enr: SignableENR
   public blockIndex: () => Promise<Map<string, string>>
   public setBlockIndex: (blockIndex: Map<string, string>) => Promise<void>
-  handleNewRequest: (request: INewRequest) => Promise<ContentRequest>
-  sendMessage: (
-    enr: ENR | string,
-    payload: Uint8Array,
-    networkId: NetworkId,
-    utpMessage?: boolean,
-  ) => Promise<Uint8Array>
-  sendResponse: (src: INodeAddress, requestId: bigint, payload: Uint8Array) => Promise<void>
-  findEnr: (nodeId: string) => ENR | undefined
   portal: PortalNetwork
   constructor({ client, networkId, db, radius, maxStorage }: BaseNetworkConfig) {
     super()
     this.networkId = networkId
     this.logger = client.logger.extend(this.constructor.name)
-    this.sendMessage = client.sendPortalNetworkMessage.bind(client)
-    this.sendResponse = client.sendPortalNetworkResponse.bind(client)
-    this.findEnr = client.discv5.findEnr.bind(client.discv5)
-    this.handleNewRequest = client.uTP.handleNewRequest.bind(client.uTP)
     this.blockIndex = () => {
       return client.db.getBlockIndex()
     }
@@ -101,6 +88,24 @@ export abstract class BaseNetwork extends EventEmitter {
         this.portal.metrics?.knownHistoryNodes.set(this.routingTable.size)
       }
     }
+  }
+
+  async handleNewRequest(request: INewRequest): Promise<ContentRequest> {
+    return this.portal.uTP.handleNewRequest(request)
+  }
+  async sendMessage(
+    enr: ENR | string,
+    payload: Uint8Array,
+    networkId: NetworkId,
+    utpMessage?: boolean,
+  ): Promise<Uint8Array> {
+    return this.portal.sendPortalNetworkMessage(enr, payload, networkId, utpMessage)
+  }
+  sendResponse(src: INodeAddress, requestId: bigint, payload: Uint8Array): Promise<void> {
+    return this.portal.sendPortalNetworkResponse(src, requestId, payload)
+  }
+  findEnr(nodeId: string): ENR | undefined {
+    return this.portal.discv5.findEnr(nodeId)
   }
 
   public async blockNumberToHash(blockNumber: bigint): Promise<string | undefined> {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -93,6 +93,14 @@ export abstract class BaseNetwork extends EventEmitter {
   async handleNewRequest(request: INewRequest): Promise<ContentRequest> {
     return this.portal.uTP.handleNewRequest(request)
   }
+
+  /**
+   * Send a properly formatted Portal Network message to another node
+   * @param dstId `NodeId` of message recipient
+   * @param payload `Uint8Array` serialized payload of message
+   * @param networkId subnetwork ID of subnetwork message is being sent on
+   * @returns response from `dstId` as `Buffer` or null `Buffer`
+   */
   async sendMessage(
     enr: ENR | string,
     payload: Uint8Array,
@@ -101,6 +109,7 @@ export abstract class BaseNetwork extends EventEmitter {
   ): Promise<Uint8Array> {
     return this.portal.sendPortalNetworkMessage(enr, payload, networkId, utpMessage)
   }
+
   sendResponse(src: INodeAddress, requestId: bigint, payload: Uint8Array): Promise<void> {
     return this.portal.sendPortalNetworkResponse(src, requestId, payload)
   }


### PR DESCRIPTION
Removes final remaining `bind` instances from `BaseNetwork` constructor.

`bind` was used to connect `PortalNetwork` class methods to `BaseNetwork` methods efficiently, but is an undesirable approach for various reasons, including the ability to read and navigate the codebase in Visual Studio Code using hyperlinks.

The `bind` approach was replaced by wrapper methods in the `BaseNetwork` class.  No downstream changes were needed, as the names and API of the methods remain the same.  The change is purely aesthetic.