### PR TITLE
Reduce bytes / hex conversions of content keys

### DIFF
--- a/packages/cli/src/rpc/modules/beacon.ts
+++ b/packages/cli/src/rpc/modules/beacon.ts
@@ -100,11 +100,9 @@ export class beacon {
     }
     const lookup = new ContentLookup(
       this._beacon,
-      fromHexString(
-        getBeaconContentKey(
-          BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
-          LightClientUpdatesByRangeKey.serialize({ startPeriod: BigInt(params[0]), count: 1n }),
-        ),
+      getBeaconContentKey(
+        BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
+        LightClientUpdatesByRangeKey.serialize({ startPeriod: BigInt(params[0]), count: 1n }),
       ),
     )
     const res = await lookup.startLookup()

--- a/packages/cli/src/rpc/modules/eth.ts
+++ b/packages/cli/src/rpc/modules/eth.ts
@@ -1,4 +1,4 @@
-import { bigIntToHex, intToHex, toBytes } from '@ethereumjs/util'
+import { bigIntToHex, hexToBytes, intToHex, toBytes } from '@ethereumjs/util'
 import { GET_LOGS_BLOCK_RANGE_LIMIT, NetworkId, getLogs } from 'portalnetwork'
 
 import { INTERNAL_ERROR, INVALID_PARAMS } from '../error-code.js'
@@ -137,7 +137,7 @@ export class eth {
     this._client.logger(
       `eth_getBlockByHash request received. blockHash: ${blockHash} includeTransactions: ${includeTransactions}`,
     )
-    const block = await this._client.ETH.getBlockByHash(blockHash, includeTransactions)
+    const block = await this._client.ETH.getBlockByHash(hexToBytes(blockHash), includeTransactions)
     //@ts-ignore @ethereumjs/block has some weird typing discrepancy
     if (block !== undefined) return block
     throw new Error('Block not found')

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -892,7 +892,7 @@ export class portal {
   async historyStore(params: [string, string]) {
     const [contentKey, content] = params.map((param) => fromHexString(param))
     try {
-      await this._history.store(toHexString(contentKey), content)
+      await this._history.store(contentKey, content)
       return true
     } catch {
       return false
@@ -902,7 +902,7 @@ export class portal {
     const [contentKey, content] = params
     try {
       const contentKeyBytes = fromHexString(contentKey)
-      await this._state.store(toHexString(contentKeyBytes), fromHexString(content))
+      await this._state.store(contentKeyBytes, fromHexString(content))
       this.logger(`stored ${contentKey} in state network db`)
       return true
     } catch {
@@ -922,7 +922,7 @@ export class portal {
   async beaconStore(params: [string, string]) {
     const [contentKey, content] = params.map((param) => fromHexString(param))
     try {
-      await this._beacon.store(toHexString(contentKey), content)
+      await this._beacon.store(contentKey, content)
       return true
     } catch (e) {
       console.log(e)

--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -1,9 +1,5 @@
-import {
-  HistoryNetworkContentType,
-  NetworkId,
-  addRLPSerializedBlock,
-  fromHexString,
-} from 'portalnetwork'
+import { hexToBytes } from '@ethereumjs/util'
+import { HistoryNetworkContentType, NetworkId, addRLPSerializedBlock } from 'portalnetwork'
 
 import { INTERNAL_ERROR } from '../error-code.js'
 import { middleware, validators } from '../validators.js'
@@ -98,7 +94,7 @@ export class ultralight {
       `ultralight_addContentToDB request received for ${HistoryNetworkContentType[type]} ${contentKey}`,
     )
     try {
-      await this._history!.store(contentKey, fromHexString(value))
+      await this._history!.store(hexToBytes(contentKey), hexToBytes(value))
       this.logger(`${type} value for ${contentKey} added to content DB`)
       return `${type} value for ${contentKey} added to content DB`
     } catch (err: any) {

--- a/packages/cli/test/rpc/beacon/getLightClientUpdate.spec.ts
+++ b/packages/cli/test/rpc/beacon/getLightClientUpdate.spec.ts
@@ -1,3 +1,4 @@
+import { bytesToHex } from '@ethereumjs/util'
 import { computeSyncPeriodAtSlot } from '@lodestar/light-client/utils'
 import { ssz } from '@lodestar/types'
 import {
@@ -28,7 +29,7 @@ describe(`${method} tests`, () => {
         ssz.capella.LightClientUpdate.fromJson(rangeJson.data),
       ),
     )
-    await rpc.request('portal_beaconStore', [rangeKey, rangeHex])
+    await rpc.request('portal_beaconStore', [bytesToHex(rangeKey), rangeHex])
 
     const period =
       '0x' +

--- a/packages/cli/test/rpc/portal/beaconLocalContent.spec.ts
+++ b/packages/cli/test/rpc/portal/beaconLocalContent.spec.ts
@@ -1,3 +1,4 @@
+import { bytesToHex } from '@ethereumjs/util'
 import {
   BeaconLightClientNetworkContentType,
   LightClientOptimisticUpdateKey,
@@ -12,7 +13,9 @@ describe(`${method} tests`, () => {
     const { ultralight, rpc } = await startRpc()
     const key = LightClientOptimisticUpdateKey.serialize({ signatureSlot: 7807053n })
     const res = await rpc.request(method, [
-      getBeaconContentKey(BeaconLightClientNetworkContentType.LightClientOptimisticUpdate, key),
+      bytesToHex(
+        getBeaconContentKey(BeaconLightClientNetworkContentType.LightClientOptimisticUpdate, key),
+      ),
     ])
     assert.equal(res.result, '0x')
     ultralight.kill(9)

--- a/packages/portalnetwork/src/client/provider.ts
+++ b/packages/portalnetwork/src/client/provider.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@ethereumjs/util'
 import { ethers } from 'ethers'
 
 import { addRLPSerializedBlock } from '../networks/index.js'
@@ -43,7 +44,8 @@ export class UltralightProvider extends ethers.JsonRpcProvider {
   getBlock = async (blockTag: ethers.BlockTag): Promise<ethers.Block | null> => {
     let block
     if (typeof blockTag === 'string' && blockTag.length === 66) {
-      block = await this.portal.ETH.getBlockByHash(blockTag, false)
+      const blockHash = hexToBytes(blockTag)
+      block = await this.portal.ETH.getBlockByHash(blockHash, false)
       if (block !== undefined) {
         return ethJsBlockToEthersBlock(block, this.provider)
       }
@@ -63,7 +65,8 @@ export class UltralightProvider extends ethers.JsonRpcProvider {
     const isBlockHash =
       ethers.isHexString(blockTag) && typeof blockTag === 'string' && blockTag.length === 66
     if (isBlockHash) {
-      block = await this.portal.ETH.getBlockByHash(blockTag, true)
+      const blockHash = hexToBytes(blockTag)
+      block = await this.portal.ETH.getBlockByHash(blockHash, true)
       if (block !== undefined) {
         return ethJsBlockToEthersBlockWithTxs(block, this.provider)
       }

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -5,7 +5,7 @@ import type { Debugger } from 'debug'
 export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   public logger?: Debugger
   private radiusMap: Map<NodeId, bigint>
-  private gossipMap: Map<NodeId, Set<string>>
+  private gossipMap: Map<NodeId, Set<Uint8Array>>
   private ignored: [number, NodeId][]
   constructor(nodeId: NodeId) {
     super(nodeId)
@@ -43,11 +43,11 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
    * @param contentKey hex prefixed string representation of content key
    * @returns boolean indicating if node has already been OFFERed `contentKey` already
    */
-  public contentKeyKnownToPeer = (nodeId: NodeId, contentKey: string) => {
+  public contentKeyKnownToPeer = (nodeId: NodeId, contentKey: Uint8Array) => {
     let gossipList = this.gossipMap.get(nodeId)
     if (!gossipList) {
       // If no gossipList exists, create new one for `nodeId` and add contentKey to it
-      gossipList = new Set<string>()
+      gossipList = new Set<Uint8Array>()
       gossipList.add(contentKey)
       this.gossipMap.set(nodeId, gossipList)
       return false

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -9,8 +9,8 @@ import type StrictEventEmitter from 'strict-event-emitter-types/types/src'
 export interface PortalNetworkEvents {
   NodeAdded: (nodeId: NodeId, networkId: NetworkId) => void
   NodeRemoved: (nodeId: NodeId, networkId: NetworkId) => void
-  ContentAdded: (key: string, contentType: number, content: string) => void
-  Verified: (key: string, verified: boolean) => void
+  ContentAdded: (key: Uint8Array, contentType: number, content: string) => void
+  Verified: (key: Uint8Array, verified: boolean) => void
   SendTalkReq: (nodeId: string, requestId: string, payload: string) => void
   SendTalkResp: (nodeId: string, requestId: string, payload: string) => void
 }

--- a/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
+++ b/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
@@ -1,4 +1,3 @@
-import { fromHexString } from '@chainsafe/ssz'
 import { bytesToHex, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { genesisData } from '@lodestar/config/networks'
 import { getCurrentSlot } from '@lodestar/light-client/utils'
@@ -42,14 +41,12 @@ export class UltralightTransport implements LightClientTransport {
       `requesting lightClientUpdatesByRange starting with period ${startPeriod} and count ${count}`,
     )
     while (range.length === 0) {
-      const rangeKey = hexToBytes(
-        getBeaconContentKey(
-          BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
-          LightClientUpdatesByRangeKey.serialize({
-            startPeriod: BigInt(startPeriod),
-            count: BigInt(count),
-          }),
-        ),
+      const rangeKey = getBeaconContentKey(
+        BeaconLightClientNetworkContentType.LightClientUpdatesByRange,
+        LightClientUpdatesByRangeKey.serialize({
+          startPeriod: BigInt(startPeriod),
+          count: BigInt(count),
+        }),
       )
       let decoded
       decoded = await this.network.findContentLocally(rangeKey)
@@ -89,13 +86,11 @@ export class UltralightTransport implements LightClientTransport {
 
     // Try to get optimistic update locally
     const localUpdate = await this.network.findContentLocally(
-      hexToBytes(
-        getBeaconContentKey(
-          BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
-          LightClientOptimisticUpdateKey.serialize({
-            signatureSlot: currentSlot,
-          }),
-        ),
+      getBeaconContentKey(
+        BeaconLightClientNetworkContentType.LightClientOptimisticUpdate,
+        LightClientOptimisticUpdateKey.serialize({
+          signatureSlot: currentSlot,
+        }),
       ),
     )
 
@@ -159,13 +154,11 @@ export class UltralightTransport implements LightClientTransport {
 
     // Try retrieving finality update locally
     const localUpdate = await this.network.findContentLocally(
-      hexToBytes(
-        getBeaconContentKey(
-          BeaconLightClientNetworkContentType.LightClientFinalityUpdate,
-          LightClientFinalityUpdateKey.serialize({
-            finalitySlot: nextFinalitySlot,
-          }),
-        ),
+      getBeaconContentKey(
+        BeaconLightClientNetworkContentType.LightClientFinalityUpdate,
+        LightClientFinalityUpdateKey.serialize({
+          finalitySlot: nextFinalitySlot,
+        }),
       ),
     )
 
@@ -207,11 +200,9 @@ export class UltralightTransport implements LightClientTransport {
   ): Promise<{ version: ForkName; data: LightClientBootstrap }> {
     let forkname, bootstrap
     const localBootstrap = await this.network.findContentLocally(
-      hexToBytes(
-        getBeaconContentKey(
-          BeaconLightClientNetworkContentType.LightClientBootstrap,
-          LightClientBootstrapKey.serialize({ blockHash: hexToBytes(blockRoot) }),
-        ),
+      getBeaconContentKey(
+        BeaconLightClientNetworkContentType.LightClientBootstrap,
+        LightClientBootstrapKey.serialize({ blockHash: hexToBytes(blockRoot) }),
       ),
     )
     if (localBootstrap !== undefined && localBootstrap.length !== 0) {
@@ -262,8 +253,8 @@ export class UltralightTransport implements LightClientTransport {
   }
 
   onOptimisticUpdate(handler: (optimisticUpdate: LightClientOptimisticUpdate) => void): void {
-    this.network.on('ContentAdded', (_contentKey, content: Uint8Array) => {
-      const contentType = fromHexString(_contentKey)[0]
+    this.network.on('ContentAdded', (_contentKey: Uint8Array, content: Uint8Array) => {
+      const contentType = _contentKey[0]
       if (contentType === BeaconLightClientNetworkContentType.LightClientOptimisticUpdate) {
         const forkhash = content.slice(0, 4)
         const forkname = this.network.beaconConfig.forkDigest2ForkName(
@@ -279,8 +270,8 @@ export class UltralightTransport implements LightClientTransport {
     })
   }
   onFinalityUpdate(handler: (finalityUpdate: LightClientFinalityUpdate) => void): void {
-    this.network.on('ContentAdded', (_contentKey, content: Uint8Array) => {
-      const contentType = fromHexString(_contentKey)[0]
+    this.network.on('ContentAdded', (_contentKey: Uint8Array, content: Uint8Array) => {
+      const contentType = _contentKey[0]
       if (contentType === BeaconLightClientNetworkContentType.LightClientFinalityUpdate) {
         const forkhash = content.slice(0, 4)
         const forkname = this.network.beaconConfig.forkDigest2ForkName(

--- a/packages/portalnetwork/src/networks/beacon/util.ts
+++ b/packages/portalnetwork/src/networks/beacon/util.ts
@@ -1,4 +1,3 @@
-import { toHexString } from '@chainsafe/ssz'
 import { padToEven } from '@ethereumjs/util'
 
 import {
@@ -19,7 +18,7 @@ export const getBeaconContentKey = (
   contentType: BeaconLightClientNetworkContentType,
   serializedKey: Uint8Array,
 ) => {
-  return toHexString(Uint8Array.from([contentType, ...serializedKey]))
+  return Uint8Array.from([contentType, ...serializedKey])
 }
 
 /**

--- a/packages/portalnetwork/src/networks/history/gossip.ts
+++ b/packages/portalnetwork/src/networks/history/gossip.ts
@@ -1,5 +1,3 @@
-import { toHexString } from '@chainsafe/ssz'
-
 import { getContentId, getContentKey } from './util.js'
 
 import type { HistoryNetwork } from './history.js'
@@ -39,7 +37,7 @@ export class GossipManager {
     if (this.gossipQueues[peer] === undefined) {
       this.gossipQueues[peer] = []
     }
-    if (!this.history.routingTable.contentKeyKnownToPeer(peer, toHexString(key))) {
+    if (!this.history.routingTable.contentKeyKnownToPeer(peer, key)) {
       this.gossipQueues[peer].push(key)
     }
     return this.gossipQueues[peer].length

--- a/packages/portalnetwork/src/networks/history/gossip.ts
+++ b/packages/portalnetwork/src/networks/history/gossip.ts
@@ -1,5 +1,4 @@
 import { toHexString } from '@chainsafe/ssz'
-import { hexToBytes } from '@ethereumjs/util'
 
 import { getContentId, getContentKey } from './util.js'
 
@@ -66,7 +65,7 @@ export class GossipManager {
     const key = getContentKey(contentType, keyOpt)
     const peers = this.history.routingTable.nearest(id, 5)
     for (const peer of peers) {
-      const size = this.enqueue(peer.nodeId, hexToBytes(key))
+      const size = this.enqueue(peer.nodeId, key)
       if (size >= this.pulse) {
         this.gossip(peer.nodeId)
       }

--- a/packages/portalnetwork/src/networks/history/headerAccumulator.ts
+++ b/packages/portalnetwork/src/networks/history/headerAccumulator.ts
@@ -1,5 +1,4 @@
 import { ProofType, createProof } from '@chainsafe/persistent-merkle-tree'
-import { toHexString } from '@chainsafe/ssz'
 import { BlockHeader } from '@ethereumjs/block'
 import { hexToBytes } from '@ethereumjs/util'
 
@@ -135,11 +134,7 @@ export class AccumulatorManager {
     const epoch =
       this.headerAccumulator.historicalEpochs.length < epochIdx
         ? EpochAccumulator.serialize(this.headerAccumulator.currentEpoch.slice(0, listIdx))
-        : hexToBytes(
-            await this._history.get(
-              toHexString(this.headerAccumulator.historicalEpochs[epochIdx - 1]),
-            ),
-          )
+        : hexToBytes(await this._history.get(this.headerAccumulator.historicalEpochs[epochIdx - 1]))
     const epochView = EpochAccumulator.deserializeToView(epoch)
     const proof = createProof(epochView.node, {
       type: ProofType.single,

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -830,7 +830,7 @@ export abstract class BaseNetwork extends EventEmitter {
   public async gossipContent(contentKey: Uint8Array, content: Uint8Array): Promise<number> {
     const peers = this.routingTable
       .values()
-      .filter((e) => !this.routingTable.contentKeyKnownToPeer(e.nodeId, toHexString(contentKey)))
+      .filter((e) => !this.routingTable.contentKeyKnownToPeer(e.nodeId, contentKey))
     const offerMsg: OfferMessage = {
       contentKeys: [contentKey],
     }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -110,15 +110,15 @@ export abstract class BaseNetwork extends EventEmitter {
     return this.portal.discv5.findEnr(nodeId)
   }
 
-  public async put(contentKey: string, content: string) {
+  public async put(contentKey: Uint8Array, content: string) {
     await this.db.put(contentKey, content)
   }
 
-  public async del(contentKey: string) {
+  public async del(contentKey: Uint8Array) {
     await this.db.del(contentKey)
   }
 
-  public async get(key: string) {
+  public async get(key: Uint8Array) {
     return this.db.get(key)
   }
 
@@ -152,15 +152,15 @@ export abstract class BaseNetwork extends EventEmitter {
     return this.db.size()
   }
 
-  public streamingKey(contentKey: string) {
+  public streamingKey(contentKey: Uint8Array) {
     this.db.addToStreaming(contentKey)
   }
 
-  public contentKeyToId(contentKey: string): string {
-    return bytesToUnprefixedHex(digest(fromHexString(contentKey)))
+  public contentKeyToId(contentKey: Uint8Array): string {
+    return bytesToUnprefixedHex(digest(contentKey))
   }
 
-  abstract store(contentKey: string, value: Uint8Array): Promise<void>
+  abstract store(contentKey: Uint8Array, value: Uint8Array): Promise<void>
 
   public async handle(message: ITalkReqMessage, src: INodeAddress) {
     const id = message.id
@@ -462,7 +462,7 @@ export abstract class BaseNetwork extends EventEmitter {
               for await (const key of requestedKeys) {
                 let value = Uint8Array.from([])
                 try {
-                  value = hexToBytes(await this.get(toHexString(key)))
+                  value = hexToBytes(await this.get(key))
                   requestedData.push(value)
                 } catch (err: any) {
                   this.logger(`Error retrieving content -- ${err.toString()}`)
@@ -502,7 +502,7 @@ export abstract class BaseNetwork extends EventEmitter {
           const contentIds: boolean[] = Array(msg.contentKeys.length).fill(false)
 
           for (let x = 0; x < msg.contentKeys.length; x++) {
-            const cid = this.contentKeyToId(toHexString(msg.contentKeys[x]))
+            const cid = this.contentKeyToId(msg.contentKeys[x])
             const d = distance(cid, this.enr.nodeId)
             if (d >= this.nodeRadius) {
               this.logger.extend('OFFER')(
@@ -511,7 +511,7 @@ export abstract class BaseNetwork extends EventEmitter {
               continue
             }
             try {
-              await this.get(toHexString(msg.contentKeys[x]))
+              await this.get(msg.contentKeys[x])
               this.logger.extend('OFFER')(`Already have this content ${msg.contentKeys[x]}`)
             } catch (err) {
               offerAccepted = true
@@ -526,7 +526,7 @@ export abstract class BaseNetwork extends EventEmitter {
             const desiredKeys = msg.contentKeys.filter((k, i) => contentIds[i] === true)
             this.logger(toHexString(msg.contentKeys[0]))
             for (const k of desiredKeys) {
-              this.streamingKey(toHexString(k))
+              this.streamingKey(k)
             }
             await this.sendAccept(src, requestId, contentIds, desiredKeys)
           } else {
@@ -883,7 +883,7 @@ export abstract class BaseNetwork extends EventEmitter {
     return accepted
   }
 
-  public async retrieve(contentKey: string): Promise<string | undefined> {
+  public async retrieve(contentKey: Uint8Array): Promise<string | undefined> {
     try {
       const content = await this.get(contentKey)
       return content

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -46,8 +46,8 @@ export class StateNetwork extends BaseNetwork {
     this.routingTable.setLogger(this.logger)
   }
 
-  public contentKeyToId = (contentKey: string): string => {
-    return bytesToUnprefixedHex(StateNetworkContentId.fromBytes(fromHexString(contentKey)))
+  public contentKeyToId = (contentKey: Uint8Array): string => {
+    return bytesToUnprefixedHex(StateNetworkContentId.fromBytes(contentKey))
   }
 
   /**
@@ -133,14 +133,13 @@ export class StateNetwork extends BaseNetwork {
     }
   }
 
-  public store = async (contentKey: string, content: Uint8Array) => {
-    const _contentKey = fromHexString(contentKey)
-    const contentType = _contentKey[0]
+  public store = async (contentKey: Uint8Array, content: Uint8Array) => {
+    const contentType = contentKey[0]
     try {
       if (contentType === StateNetworkContentType.AccountTrieNode) {
-        await this.receiveAccountTrieNodeOffer(_contentKey, content)
+        await this.receiveAccountTrieNodeOffer(contentKey, content)
       } else {
-        await this.stateDB.storeContent(_contentKey, content)
+        await this.stateDB.storeContent(contentKey, content)
       }
       this.logger(`content added for: ${contentKey}`)
       this.emit('ContentAdded', contentKey, content)

--- a/packages/portalnetwork/src/networks/state/util.ts
+++ b/packages/portalnetwork/src/networks/state/util.ts
@@ -2,7 +2,7 @@ import { digest as sha256 } from '@chainsafe/as-sha256'
 import { distance } from '@chainsafe/discv5'
 import { fromHexString, toHexString } from '@chainsafe/ssz'
 import { BranchNode, ExtensionNode, decodeNode } from '@ethereumjs/trie'
-import { MapDB, bytesToUnprefixedHex, equalsBytes } from '@ethereumjs/util'
+import { MapDB, bytesToHex, bytesToUnprefixedHex, equalsBytes } from '@ethereumjs/util'
 
 import { unpackNibbles } from './nibbleEncoding.js'
 import {
@@ -154,10 +154,16 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
     this.db = db
     this.temp = new Map()
   }
-  async put(key: string, value: string) {
+  async put(key: string | Uint8Array, value: string) {
+    if (key instanceof Uint8Array) {
+      key = bytesToHex(key)
+    }
     await this.db.put(key, value)
   }
-  async get(key: string, _opts?: EncodingOpts) {
+  async get(key: string | Uint8Array, _opts?: EncodingOpts) {
+    if (key instanceof Uint8Array) {
+      key = bytesToHex(key)
+    }
     try {
       const value = await this.db.get(key)
       return value
@@ -166,7 +172,10 @@ export class PortalTrieDB extends MapDB<string, string> implements DB<string, st
       return found
     }
   }
-  async del(key: string) {
+  async del(key: string | Uint8Array) {
+    if (key instanceof Uint8Array) {
+      key = bytesToHex(key)
+    }
     await this.db.del(key)
   }
   async keys() {

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -1,7 +1,6 @@
 import { digest } from '@chainsafe/as-sha256'
 import { fromHex, toHex } from '@chainsafe/discv5'
-import { toHexString } from '@chainsafe/ssz'
-import { bytesToUtf8 } from '@ethereumjs/util'
+import { bytesToUnprefixedHex, bytesToUtf8 } from '@ethereumjs/util'
 import { toBigIntBE, toBufferBE } from 'bigint-buffer'
 import { promises as fs } from 'fs'
 import * as path from 'path'
@@ -53,7 +52,7 @@ export const generateRandomNodeIdAtDistance = (nodeId: NodeId, targetDistance: n
  * @returns the hex encoded string representation of the SHA256 hash of the serialized contentKey
  */
 export const serializedContentKeyToContentId = (contentKey: Uint8Array) => {
-  return toHexString(digest(contentKey))
+  return bytesToUnprefixedHex(digest(contentKey))
 }
 
 export const dirSize = async (directory: string) => {

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -329,7 +329,7 @@ export class PortalNetworkUTP {
       this.logger.extend(`FINISHED`)(
         `${idx + 1}/${keys.length} -- (${_content.length} bytes) sending content type: ${k[0]} to database`,
       )
-      await network.store(toHexString(k), _content)
+      await network.store(k, _content)
     }
   }
 }

--- a/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
@@ -66,7 +66,10 @@ describe('API tests', async () => {
 
   it('stores and retrieves finality update', async () => {
     const finalityUpdate = specTestVectors.finalityUpdate['6718368']
-    await network.store(finalityUpdate.content_key, hexToBytes(finalityUpdate.content_value))
+    await network.store(
+      hexToBytes(finalityUpdate.content_key),
+      hexToBytes(finalityUpdate.content_value),
+    )
 
     network.lightClient = {
       //@ts-ignore
@@ -97,7 +100,10 @@ describe('API tests', async () => {
 
   it('stores and retrieves optimistic update', async () => {
     const optimisticUpdate = specTestVectors.optimisticUpdate['6718463']
-    await network.store(optimisticUpdate.content_key, hexToBytes(optimisticUpdate.content_value))
+    await network.store(
+      hexToBytes(optimisticUpdate.content_key),
+      hexToBytes(optimisticUpdate.content_value),
+    )
 
     network.lightClient = {
       //@ts-ignore
@@ -115,6 +121,7 @@ describe('API tests', async () => {
         LightClientOptimisticUpdateKey.serialize({ signatureSlot: 6718464n }),
       ),
     )
+    console.log({ retrievedOptimisticUpdate })
 
     assert.equal(
       ssz.capella.LightClientOptimisticUpdate.deserialize(retrievedOptimisticUpdate!.slice(4))
@@ -202,7 +209,7 @@ describe('API tests', async () => {
       }),
     )
     const res = HistoricalSummariesWithProof.deserialize(
-      (await network.findContentLocally(hexToBytes(historicalSummariesKey))) as Uint8Array,
+      (await network.findContentLocally(historicalSummariesKey)) as Uint8Array,
     )
     assert.equal(res.epoch, 1169n)
   })

--- a/packages/portalnetwork/test/networks/history/blockHeaderByNumber.spec.ts
+++ b/packages/portalnetwork/test/networks/history/blockHeaderByNumber.spec.ts
@@ -1,3 +1,4 @@
+import { hexToBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { assert, describe, it } from 'vitest'
 
@@ -10,7 +11,6 @@ import {
   PortalNetwork,
   decodeHistoryNetworkContentKey,
   fromHexString,
-  toHexString,
 } from '../../../src/index.js'
 
 import testdata from './testData/headerWithProof.json'
@@ -45,8 +45,8 @@ describe('Retrieve Block Header By Number', async () => {
   client.networks.set(NetworkId.HistoryNetwork, history)
   client.ETH.history = history
 
-  await history.store(toHexString(contentKey100001), HWP1000001)
-  await history.store(toHexString(contentKey100002), HWP1000002)
+  await history.store(contentKey100001, HWP1000001)
+  await history.store(contentKey100002, HWP1000002)
 
   it('Should retrieve block header by number', async () => {
     const header = await history.getBlockHeaderFromDB({ blockNumber: 1000001n })
@@ -99,12 +99,12 @@ describe('Retrieve Block Header By Number', async () => {
   })
 
   it('Should retrieve locally via eth_getBlockByHash', async () => {
-    const block = await client.ETH.getBlockByHash(hash100001, false)
+    const block = await client.ETH.getBlockByHash(hexToBytes(hash100001), false)
     assert.isDefined(block)
     assert.deepEqual(block!.header.serialize(), header100001)
   })
   it('Should retrieve locally via eth_getBlockByHash', async () => {
-    const block = await client.ETH.getBlockByHash(hash100002, false)
+    const block = await client.ETH.getBlockByHash(hexToBytes(hash100002), false)
     assert.isDefined(block)
     assert.deepEqual(block!.header.serialize(), header100002)
   })

--- a/packages/portalnetwork/test/networks/history/contentKeys.spec.ts
+++ b/packages/portalnetwork/test/networks/history/contentKeys.spec.ts
@@ -1,4 +1,4 @@
-import { hexToBytes } from '@ethereumjs/util'
+import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { createRequire } from 'module'
 import { assert, describe, it } from 'vitest'
 
@@ -18,9 +18,9 @@ describe('ContentKey and ContentId', () => {
     const { blockHash, contentKeyHex, contentIdHex } = testVectors.blockHeader
     const contentKey = getContentKey(HistoryNetworkContentType.BlockHeader, hexToBytes(blockHash))
     const contentId = getContentId(HistoryNetworkContentType.BlockHeader, fromHexString(blockHash))
-    const decoded = decodeHistoryNetworkContentKey(fromHexString(contentKey))
+    const decoded = decodeHistoryNetworkContentKey(contentKey)
 
-    assert.equal(contentKey, contentKeyHex, 'encoded content key')
+    assert.equal(bytesToHex(contentKey), contentKeyHex, 'encoded content key')
     assert.equal(contentId, contentIdHex, 'encoded content id')
     assert.deepEqual(decoded.keyOpt, fromHexString(blockHash), 'decoded hash from content key')
     assert.equal(
@@ -33,9 +33,9 @@ describe('ContentKey and ContentId', () => {
     const { blockHash, contentKeyHex, contentIdHex } = testVectors.blockBody
     const contentKey = getContentKey(HistoryNetworkContentType.BlockBody, hexToBytes(blockHash))
     const contentId = getContentId(HistoryNetworkContentType.BlockBody, fromHexString(blockHash))
-    const decoded = decodeHistoryNetworkContentKey(fromHexString(contentKey))
+    const decoded = decodeHistoryNetworkContentKey(contentKey)
 
-    assert.equal(contentKey, contentKeyHex, 'encoded content key')
+    assert.equal(bytesToHex(contentKey), contentKeyHex, 'encoded content key')
     assert.equal(contentId, contentIdHex, 'encoded content id')
     assert.deepEqual(decoded.keyOpt, fromHexString(blockHash), 'decoded hash from content key')
     assert.equal(
@@ -48,9 +48,9 @@ describe('ContentKey and ContentId', () => {
     const { blockHash, contentKeyHex, contentIdHex } = testVectors.receipts
     const contentKey = getContentKey(HistoryNetworkContentType.Receipt, hexToBytes(blockHash))
     const contentId = getContentId(HistoryNetworkContentType.Receipt, fromHexString(blockHash))
-    const decoded = decodeHistoryNetworkContentKey(fromHexString(contentKey))
+    const decoded = decodeHistoryNetworkContentKey(contentKey)
 
-    assert.equal(contentKey, contentKeyHex, 'encoded content key')
+    assert.equal(bytesToHex(contentKey), contentKeyHex, 'encoded content key')
     assert.equal(contentId, contentIdHex, 'encoded content id')
     assert.deepEqual(decoded.keyOpt, fromHexString(blockHash), 'decoded hash from content key')
     assert.equal(
@@ -63,8 +63,8 @@ describe('ContentKey and ContentId', () => {
     const { blockNumber, contentKeyHex, contentIdHex } = testVectors.blockHeaderByNumber
     const contentKey = getContentKey(HistoryNetworkContentType.BlockHeaderByNumber, 1000n)
     const contentId = getContentId(HistoryNetworkContentType.BlockHeaderByNumber, 1000n)
-    const decoded = decodeHistoryNetworkContentKey(fromHexString(contentKey))
-    assert.equal(contentKey, contentKeyHex, 'encoded content key')
+    const decoded = decodeHistoryNetworkContentKey(contentKey)
+    assert.equal(bytesToHex(contentKey), contentKeyHex, 'encoded content key')
     assert.equal(contentId, contentIdHex, 'encoded content id')
     assert.deepEqual(decoded.keyOpt, BigInt(blockNumber), 'decoded block number from content key')
     assert.equal(

--- a/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
+++ b/packages/portalnetwork/test/networks/history/historyNetwork.spec.ts
@@ -57,7 +57,7 @@ describe('history Network FINDCONTENT/FOUNDCONTENT message handlers', async () =
   td.when(
     network.sendMessage(td.matchers.anything(), td.matchers.anything(), td.matchers.anything()),
   ).thenResolve(findContentResponse)
-  const res = await network.sendFindContent(decodedEnr.nodeId, hexToBytes(key))
+  const res = await network.sendFindContent(decodedEnr.nodeId, key)
   it('should send a FINDCONTENT message', () => {
     assert.deepEqual(
       res?.value,

--- a/packages/portalnetwork/test/networks/history/types.spec.ts
+++ b/packages/portalnetwork/test/networks/history/types.spec.ts
@@ -1,7 +1,7 @@
 import { ProofType } from '@chainsafe/persistent-merkle-tree'
 import { ContainerType, UintBigintType, fromHexString, toHexString } from '@chainsafe/ssz'
 import { BlockHeader } from '@ethereumjs/block'
-import { concatBytes, hexToBytes, randomBytes } from '@ethereumjs/util'
+import { bytesToHex, concatBytes, hexToBytes, randomBytes } from '@ethereumjs/util'
 import { readFileSync } from 'fs'
 import { assert, describe, it } from 'vitest'
 
@@ -38,7 +38,7 @@ describe('History Subnetwork contentKey serialization/deserialization', () => {
     )
     assert.equal(
       contentId,
-      '0x3e86b3767b57402ea72e369ae0496ce47cc15be685bec3b4726b9f316e3895fe',
+      '3e86b3767b57402ea72e369ae0496ce47cc15be685bec3b4726b9f316e3895fe',
       'block header content ID matches',
     )
     blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
@@ -53,7 +53,7 @@ describe('History Subnetwork contentKey serialization/deserialization', () => {
     )
     assert.equal(
       contentId,
-      '0xebe414854629d60c58ddd5bf60fd72e41760a5f7a463fdcb169f13ee4a26786b',
+      'ebe414854629d60c58ddd5bf60fd72e41760a5f7a463fdcb169f13ee4a26786b',
       'block body content ID matches',
     )
     blockHash = '0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'
@@ -68,7 +68,7 @@ describe('History Subnetwork contentKey serialization/deserialization', () => {
     )
     assert.equal(
       contentId,
-      '0xa888f4aafe9109d495ac4d4774a6277c1ada42035e3da5e10a04cc93247c04a4',
+      'a888f4aafe9109d495ac4d4774a6277c1ada42035e3da5e10a04cc93247c04a4',
       'receipt content ID matches',
     )
   })
@@ -303,7 +303,11 @@ describe('Header With Proof serialization/deserialization tests', async () => {
       1000001n,
       'deserialized header number matches test vector',
     )
-    assert.equal(contentKey, testData[1000001].content_key, 'generated expected content key')
+    assert.equal(
+      bytesToHex(contentKey),
+      testData[1000001].content_key,
+      'generated expected content key',
+    )
     assert.ok(
       history.validateHeader(serializedBlock1, {
         blockHash: toHexString(deserializedHeader.hash()),

--- a/packages/portalnetwork/test/testData/testVectors.json
+++ b/packages/portalnetwork/test/testData/testVectors.json
@@ -2,21 +2,21 @@
     "blockHeader": {
       "blockHash": "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d",
       "contentKeyHex": "0x00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d",
-      "contentIdHex": "0x3e86b3767b57402ea72e369ae0496ce47cc15be685bec3b4726b9f316e3895fe"
+      "contentIdHex": "3e86b3767b57402ea72e369ae0496ce47cc15be685bec3b4726b9f316e3895fe"
     },
     "blockBody": {
       "blockHash": "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d",
       "contentKeyHex": "0x01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d",
-      "contentIdHex": "0xebe414854629d60c58ddd5bf60fd72e41760a5f7a463fdcb169f13ee4a26786b"
+      "contentIdHex": "ebe414854629d60c58ddd5bf60fd72e41760a5f7a463fdcb169f13ee4a26786b"
     },
     "receipts": {
       "blockHash": "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d",
       "contentKeyHex": "0x02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d",
-      "contentIdHex": "0xa888f4aafe9109d495ac4d4774a6277c1ada42035e3da5e10a04cc93247c04a4"
+      "contentIdHex": "a888f4aafe9109d495ac4d4774a6277c1ada42035e3da5e10a04cc93247c04a4"
     },
     "blockHeaderByNumber": {
       "blockNumber": 1000,
       "contentKeyHex": "0x03e803000000000000",
-      "contentIdHex": "0x7a926654dc84b198013eb6a0e795fe15de09b4b1c83c88c6cd98f61ab6baeb8d"
+      "contentIdHex": "7a926654dc84b198013eb6a0e795fe15de09b4b1c83c88c6cd98f61ab6baeb8d"
     }
   }

--- a/packages/portalnetwork/test/util/db.spec.ts
+++ b/packages/portalnetwork/test/util/db.spec.ts
@@ -1,5 +1,5 @@
 import { distance } from '@chainsafe/discv5'
-import { bytesToHex, randomBytes } from '@ethereumjs/util'
+import { hexToBytes, randomBytes } from '@ethereumjs/util'
 import debug from 'debug'
 import { assert, describe, expect, it } from 'vitest'
 
@@ -10,7 +10,10 @@ const nodeId = '80'.repeat(32)
 
 const length = 20
 
-const keyVals = Array.from({ length }, () => {
+const keyVals: {
+  key: Uint8Array
+  value: Uint8Array
+}[] = Array.from({ length }, () => {
   return {
     key: randomBytes(33),
     value: randomBytes(1000),
@@ -31,7 +34,7 @@ describe('networkdb', () => {
 
   it('should correctly put/prune', async () => {
     for (const { key, value } of keyVals) {
-      await historyDB.put(bytesToHex(key), bytesToHex(value))
+      await historyDB.put(key, value)
     }
     let j = 0
     for await (const _ of historyDB.db.iterator()) {
@@ -41,8 +44,8 @@ describe('networkdb', () => {
 
     const r = 2n ** 255n - 1n
     let i = 0
-    for await (const [key] of historyDB.db.keys()) {
-      const d = distance(nodeId, historyDB.contentId(key))
+    for await (const key of historyDB.db.keys()) {
+      const d = distance(nodeId, historyDB.contentId(hexToBytes(key)))
       if (d > r) {
         i++
       }


### PR DESCRIPTION
### Issue:
Excessive need to use `hexToBytes` and `bytesToHex` conversion methods on `contentKey`, `contentId`, `blockHash`, and more.

### Cause:
Inconsistent design of functions.  Some functions expected keys to be strings, others expected Uint8Arrays.

### Solution:
Internally, `contentKeys` should always be `Uint8Array`, with the only conversion to and from strings happening in the DB manager.



`contentId` should always be an **unprefixed hex string**, matching the type of `enr.nodeId`, and the expected input of the imported **distance** function `distance(nodeId, contentId)`