### PR TITLE
Update docker config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
-node_modules
+packages/archived-browser-client
 packages/browser-client
+packages/era
+packages/portal-spec-tests
 packages/proxy
+packages/ui
 .github
 .vscode
+build
+config
+scripts

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,20 @@
+FROM node:20-alpine
+
+RUN apk update && apk add --no-cache bash g++ make git python3 && rm -rf /var/cache/apk/*
+RUN apk add --virtual .build-deps alpine-sdk jq
+
+RUN ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+
+WORKDIR /ultralight
+
+COPY node_modules node_modules
+COPY packages/portalnetwork/dist packages/portalnetwork/dist
+COPY packages/cli/dist packages/cli/dist
+COPY packages/cli/package.json packages/cli
+COPY packages/portalnetwork/package.json packages/portalnetwork
+
+ENV BINDADDRESS=
+ENV RPCPORT=
+ENV PK=
+
+ENTRYPOINT node ultralight/packages/cli/dist/index.js --bindAddress=BINDADDRESS --rpcPort=RPCPORT


### PR DESCRIPTION
Adds a new docker file that build significantly faster than our current version.  Assumes that you have already compiled the code locally and just copies that built code into the docker image while skipping all source/test code.

Can be built with this command
`docker buildx build -f Dockerfile.slim .  --tag ultralight:latest`

Can then be used with hive for relatively quick rebuild times.