### PR TITLE
RPC: update portal_*Offer

### DIFF
--- a/packages/cli/scripts/seeder.ts
+++ b/packages/cli/scripts/seeder.ts
@@ -171,16 +171,20 @@ const main = async () => {
       [
         clientInfo.peer1.enr,
         getContentKey(HistoryNetworkContentType.BlockHeader, fromHexString(block[0])),
-        toHexString(
-          Block.fromRLPSerializedBlock(hexToBytes((block[1] as any).rlp), {
-            setHardfork: true,
-          }).header.serialize(),
-        ),
-        toHexString(
-          Block.fromRLPSerializedBlock(hexToBytes((block[1] as any).rlp), {
-            setHardfork: true,
-          }).header.serialize(),
-        ),
+        [
+          [
+            toHexString(
+              Block.fromRLPSerializedBlock(hexToBytes((block[1] as any).rlp), {
+                setHardfork: true,
+              }).header.serialize(),
+            ),
+            toHexString(
+              Block.fromRLPSerializedBlock(hexToBytes((block[1] as any).rlp), {
+                setHardfork: true,
+              }).header.serialize(),
+            ),
+          ],
+        ],
       ],
     ])
   }

--- a/packages/cli/scripts/sendOffer.ts
+++ b/packages/cli/scripts/sendOffer.ts
@@ -46,8 +46,7 @@ const main = async () => {
 
   const offer = await nodeA.request('portal_historyOffer', [
     nodeBEnr.result.enr,
-    blockBodyContent_key,
-    blockBodyContent_value,
+    [[blockBodyContent_key, blockBodyContent_value]],
   ])
 
   console.log(offer)

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -1,7 +1,7 @@
 import { EntryStatus } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
 import { BitArray } from '@chainsafe/ssz'
-import { bytesToHex, short } from '@ethereumjs/util'
+import { hexToBytes, short } from '@ethereumjs/util'
 import {
   ContentLookup,
   ContentMessageType,
@@ -17,6 +17,7 @@ import {
 } from 'portalnetwork'
 
 import { INVALID_PARAMS } from '../error-code.js'
+import { content_params } from '../schema/index.js'
 import { isValidId } from '../util.js'
 import { middleware, validators } from '../validators.js'
 
@@ -186,8 +187,7 @@ export class portal {
     ])
     this.historyOffer = middleware(this.historyOffer.bind(this), 3, [
       [validators.enr],
-      [validators.hex],
-      [validators.hex],
+      [content_params.ContentItems],
     ])
     this.historySendOffer = middleware(this.historySendOffer.bind(this), 2, [
       [validators.dstId],
@@ -195,8 +195,7 @@ export class portal {
     ])
     this.stateOffer = middleware(this.stateOffer.bind(this), 3, [
       [validators.enr],
-      [validators.hex],
-      [validators.hex],
+      [content_params.ContentItems],
     ])
     this.stateSendOffer = middleware(this.stateSendOffer.bind(this), 2, [
       [validators.dstId],
@@ -802,8 +801,10 @@ export class portal {
       }
     }
   }
-  async historyOffer(params: [string, string, string]) {
-    const [enrHex, contentKeyHex, contentValueHex] = params
+  async historyOffer(params: [string, [string, string][]]) {
+    const [enrHex, contentItems] = params
+    const contentKeys = contentItems.map((item) => hexToBytes(item[0]))
+    const contentValues = contentItems.map((item) => hexToBytes(item[1]))
     const enr = ENR.decodeTxt(enrHex)
     if (this._history.routingTable.getWithPending(enr.nodeId)?.value === undefined) {
       const res = await this._history.sendPing(enr)
@@ -811,11 +812,7 @@ export class portal {
         return '0x'
       }
     }
-    const res = await this._history.sendOffer(
-      enr.nodeId,
-      [fromHexString(contentKeyHex)],
-      [fromHexString(contentValueHex)],
-    )
+    const res = await this._history.sendOffer(enr.nodeId, contentKeys, contentValues)
     return res
   }
   async historySendOffer(params: [string, string[]]) {
@@ -825,8 +822,10 @@ export class portal {
     const enr = this._history.routingTable.getWithPending(dstId)?.value
     return res && enr && '0x' + enr.seq.toString(16)
   }
-  async stateOffer(params: [string, string, string]) {
-    const [enrHex, contentKeyHex, contentValueHex] = params
+  async stateOffer(params: [string, [string, string][]]) {
+    const [enrHex, contentItems] = params
+    const contentKeys = contentItems.map((item) => fromHexString(item[0]))
+    const contentValues = contentItems.map((item) => fromHexString(item[1]))
     const enr = ENR.decodeTxt(enrHex)
     if (this._state.routingTable.getWithPending(enr.nodeId)?.value === undefined) {
       const res = await this._state.sendPing(enr)
@@ -834,11 +833,7 @@ export class portal {
         return '0x'
       }
     }
-    const res = await this._state.sendOffer(
-      enr.nodeId,
-      [fromHexString(contentKeyHex)],
-      [fromHexString(contentValueHex)],
-    )
+    const res = await this._state.sendOffer(enr.nodeId, contentKeys, contentValues)
     return res
   }
   async stateSendOffer(params: [string, string[]]) {

--- a/packages/cli/src/rpc/schema/baseTypes.ts
+++ b/packages/cli/src/rpc/schema/baseTypes.ts
@@ -126,13 +126,13 @@ export const baseTypes = {
     }
   },
   /**
-   * bytes2 validator to ensure has `0x` prefix and 66 bytes length
+   * hex string validator to ensure has `0x` prefix
    * @param params parameters of method
    * @param index index of parameter
    */
   get hexString() {
     return (params: any[], index: number) => {
-      return validateByteString(params[index], index, 66)
+      return validateByteString(params[index], index)
     }
   },
 }

--- a/packages/cli/src/rpc/schema/content/params.ts
+++ b/packages/cli/src/rpc/schema/content/params.ts
@@ -145,4 +145,50 @@ export const content_params = {
       if (result !== undefined) return result
     }
   },
+  get ContentItem() {
+    return (params: any[], index: number) => {
+      if (!Array.isArray(params[index])) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument is not an array`,
+        }
+      }
+      if (params[index].length !== 2) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: array length is not 2`,
+        }
+      }
+      const [key, value] = params[index]
+      const keyResult = content_params.ContentKey([key], 0)
+      const valueResult = content_params.ContentValue([value], 1)
+      if (keyResult !== undefined && valueResult !== undefined) return [keyResult, valueResult]
+    }
+  },
+  get ContentItems() {
+    return (params: any[], index: number) => {
+      if (!Array.isArray(params[index])) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument is not an array`,
+        }
+      }
+      if (params[index].length < 1) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: array is empty`,
+        }
+      }
+      if (params[index].length > 64) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: array is too long`,
+        }
+      }
+      for (const value of params[index]) {
+        const result = content_params.ContentItem([value], 0)
+        if (result !== undefined) return result
+      }
+    }
+  },
 }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -414,6 +414,9 @@ export abstract class BaseNetwork extends EventEmitter {
    * @param networkId network ID of subnetwork being used
    */
   public sendOffer = async (dstId: string, contentKeys: Uint8Array[], content?: Uint8Array[]) => {
+    if (content && content.length !== contentKeys.length) {
+      throw new Error('Must provide all content or none')
+    }
     if (contentKeys.length > 0) {
       this.portal.metrics?.offerMessagesSent.inc()
       const offerMsg: OfferMessage = {


### PR DESCRIPTION
Updates Ultralight with changes from https://github.com/ethereum/portal-network-specs/pull/342

Modifies RPC calls `portal_*Offer` to accept multiple key/value `ContentItems`.  Previously these methods accepted only 1 ContentItem (key/value pair).

New parameters: 

- ENR: string
- ContentItems: [string, string][]
  - Array
  - ContentItem
    - Tuple (Array)
    - [contentKey, contentValue]