### PR TITLE
Beacon: fix Enr Response

### DIFF
--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -569,10 +569,9 @@ export class BeaconLightClientNetwork extends BaseNetwork {
         decodedContentMessage.contentKey,
       )}`,
     )
-
     const value = await this.findContentLocally(decodedContentMessage.contentKey)
-    if (!value || value.length === 0) {
-      await this.sendResponse(src, requestId, new Uint8Array())
+    if (!value) {
+      await this.enrResponse(decodedContentMessage.contentKey, src, requestId)
     } else if (value !== undefined && value.length < MAX_PACKET_SIZE) {
       this.logger(
         'Found value for requested content ' +


### PR DESCRIPTION
Fixes Beacon Network `handleFindContent`

Beacon Network implementation of `handleFindContent` did not repond with ENR's when content was not found.  Instead it would reply with an empty byte array.

This PR extracts the ENR response code from `network.handleFindContent` into a separate method `enrResponse`, and replaces the code within `handleFindContent` with the new method.

We also fix Beacon by injecting this new method into `beacon.handleFindContent`

This fixes `Beacon-Interop` hive tests **Find Content - content not found**