### PR TITLE
Remove bigint-buffer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9898,7 +9898,6 @@
         "@multiformats/multiaddr": "^12.1.10",
         "@thi.ng/leb128": "^2.1.11",
         "abstract-level": "^1.0.3",
-        "bigint-buffer": "^1.1.5",
         "debug": "^4.3.2",
         "ethereum-cryptography": "^3.0.0",
         "ethers": "^6.8.0",

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -46,7 +46,6 @@
     "@multiformats/multiaddr": "^12.1.10",
     "@thi.ng/leb128": "^2.1.11",
     "abstract-level": "^1.0.3",
-    "bigint-buffer": "^1.1.5",
     "debug": "^4.3.2",
     "ethereum-cryptography": "^3.0.0",
     "ethers": "^6.8.0",

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -1,7 +1,11 @@
 import { digest } from '@chainsafe/as-sha256'
-import { fromHex, toHex } from '@chainsafe/discv5'
-import { bytesToUnprefixedHex, bytesToUtf8 } from '@ethereumjs/util'
-import { toBigIntBE, toBufferBE } from 'bigint-buffer'
+import {
+  bigIntToBytes,
+  bytesToBigInt,
+  bytesToUnprefixedHex,
+  bytesToUtf8,
+  unprefixedHexToBytes,
+} from '@ethereumjs/util'
 import { promises as fs } from 'fs'
 import * as path from 'path'
 
@@ -43,7 +47,9 @@ export const generateRandomNodeIdAtDistance = (nodeId: NodeId, targetDistance: n
     binaryDistance.push(Math.random() >= 0.5 ? 1 : 0)
   }
   const xorNumericDistance = BigInt(parseInt(binaryDistance.join(''), 2))
-  return toHex(toBufferBE(toBigIntBE(fromHex(nodeId)) ^ xorNumericDistance, 32))
+  return bytesToUnprefixedHex(
+    bigIntToBytes(bytesToBigInt(unprefixedHexToBytes(nodeId), false) ^ xorNumericDistance),
+  ).padStart(64, '0')
 }
 
 /**

--- a/packages/portalnetwork/test/util/util.spec.ts
+++ b/packages/portalnetwork/test/util/util.spec.ts
@@ -1,4 +1,5 @@
 import { log2Distance } from '@chainsafe/discv5'
+import { unprefixedHexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import {
@@ -16,20 +17,18 @@ describe('utility method tests', async () => {
     assert.ok(short === '82418...b2c41', 'correctly shortened node id')
   })
 
-  let randomNodeId: string
-  it('should correctly generate random node id at distance', async () => {
-    randomNodeId = generateRandomNodeIdAtDistance(nodeId, 255)
-    assert.equal(
-      log2Distance(nodeId, randomNodeId),
-      255,
-      'calculated random node ID at distance 255',
-    )
-  })
-
-  it('should correctly generate random node id at distance', async () => {
-    randomNodeId = generateRandomNodeIdAtDistance(nodeId, 25)
-    assert.equal(log2Distance(nodeId, randomNodeId), 25, 'calculated random node id at distance 25')
-  })
+  for (let i = 1; i < 256; i++) {
+    it(`should correctly generate random node id at distance ${i}`, async () => {
+      const randomNodeId = generateRandomNodeIdAtDistance(nodeId, i)
+      const array = unprefixedHexToBytes(randomNodeId)
+      assert.equal(array.length, 32, 'generated random node ID has correct length')
+      assert.equal(
+        log2Distance(nodeId, randomNodeId),
+        i,
+        `calculated random node ID at distance ${i}`,
+      )
+    })
+  }
 
   const arrayOfUint8Arrays = [Uint8Array.from([1, 2, 3]), Uint8Array.from([1, 2])]
   it('should correctly compute byte length of array of Uint8Arrays', async () => {


### PR DESCRIPTION
Removes `bigint-buffer` package from `portalnetwork` dependencies.

Replaces `bigIntToBuffer` and `bufferToBigInt` functions with **ethereumjs/util** equivalents


`bigint-buffer` is mentioned in the CI integration test error message.

this will not necessarily fix the error, since `bigint-buffer` is also a dependency of **chainsafe** packages, which are likely the source of that error (bcrypto...blah blah blah...)