### PR TITLE
State gossip behavior

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -55,10 +55,12 @@ export abstract class BaseNetwork extends EventEmitter {
   public networkId: NetworkId
   abstract networkName: string
   public enr: SignableENR
+  public bridge: boolean
 
   portal: PortalNetwork
-  constructor({ client, networkId, db, radius, maxStorage }: BaseNetworkConfig) {
+  constructor({ client, networkId, db, radius, maxStorage, bridge }: BaseNetworkConfig) {
     super()
+    this.bridge = bridge ?? false
     this.networkId = networkId
     this.logger = client.logger.extend(this.constructor.name)
     this.enr = client.discv5.enr

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -154,11 +154,17 @@ export class StateNetwork extends BaseNetwork {
     try {
       if (offer) {
         if (contentType === StateNetworkContentType.AccountTrieNode) {
-          await this.storeAccountTrieNode(contentKey, content)
-          // await this.receiveAccountTrieNodeOffer(contentKey, content)
+          if (this.bridge) {
+            await this.receiveAccountTrieNodeOffer(contentKey, content)
+          } else {
+            await this.storeAccountTrieNode(contentKey, content)
+          }
         } else if (contentType === StateNetworkContentType.ContractTrieNode) {
-          await this.storeStorageTrieNode(contentKey, content)
-          // await this.receiveStorageTrieNodeOffer(contentKey, content)
+          if (this.bridge) {
+            await this.receiveStorageTrieNodeOffer(contentKey, content)
+          } else {
+            await this.storeStorageTrieNode(contentKey, content)
+          }
         } else {
           await this.receiveContractCodeOffer(contentKey, content)
         }

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -154,12 +154,15 @@ export class StateNetwork extends BaseNetwork {
     try {
       if (offer) {
         if (contentType === StateNetworkContentType.AccountTrieNode) {
-          await this.receiveAccountTrieNodeOffer(contentKey, content)
+          await this.storeAccountTrieNode(contentKey, content)
+          // await this.receiveAccountTrieNodeOffer(contentKey, content)
         } else if (contentType === StateNetworkContentType.ContractTrieNode) {
-          await this.receiveStorageTrieNodeOffer(contentKey, content)
+          await this.storeStorageTrieNode(contentKey, content)
+          // await this.receiveStorageTrieNodeOffer(contentKey, content)
         } else {
           await this.receiveContractCodeOffer(contentKey, content)
         }
+        await this.gossipContent(contentKey, content)
       } else {
         if (contentType === StateNetworkContentType.AccountTrieNode) {
           const { nodeHash } = AccountTrieNodeContentKey.decode(contentKey)
@@ -249,6 +252,24 @@ export class StateNetwork extends BaseNetwork {
     })
     await this.gossipContent(contentKey, content)
     return { content, contentKey }
+  }
+
+  async storeAccountTrieNode(contentKey: Uint8Array, content: Uint8Array) {
+    const { proof } = AccountTrieNodeOffer.deserialize(content)
+    const curRlp = proof.pop()!
+    const dbContent = StorageTrieNodeRetrieval.serialize({
+      node: curRlp,
+    })
+    await this.db.put(contentKey, dbContent)
+  }
+
+  async storeStorageTrieNode(contentKey: Uint8Array, content: Uint8Array) {
+    const { storageProof } = StorageTrieNodeOffer.deserialize(content)
+    const curRlp = storageProof.pop()!
+    const dbContent = StorageTrieNodeRetrieval.serialize({
+      node: curRlp,
+    })
+    await this.db.put(contentKey, dbContent)
   }
 
   async receiveStorageTrieNodeOffer(

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -14,6 +14,7 @@ export interface BaseNetworkConfig {
   db?: { db: AbstractLevel<string, string>; path: string }
   radius?: bigint
   maxStorage?: number
+  bridge?: boolean
 }
 
 const BYTE_SIZE = 256


### PR DESCRIPTION
This PR fixes the `GOSSIP` tests in `state-interop` hive tests.

Hive tests assume that we are only storing the target node when sent an OFFER with a proof.

`Ultralight` state network implementation assumed a more active role in gossiping the internal nodes of the proof, storing the intermediate nodes if interested, and gossiping the rest of the proof with new content keys.

The fine details of state network gossip may still need to be worked out among portal client teams.  To satisfy the expectations of the hive `GOSSIP` tests, we restrict normal bahavior to only storing and gossiping the node for which we were sent the full proof.

In order to preserve the gossiping methods designed in the ultralight implementation, we separate what we'll call "bridge behavior" from "normal behavior" by adding an attribute to `BaseNetwork` called `this.bridge`.  `this.bridge` is a boolean that defaults to `false`.

while `this.bridge` is false, ultralight will behave the way the tests expect.  while there is currently no mechanism to set `this.bridge` to `true`, this lays the foundation for such updates in the future as we develop and deploy bridge nodes on state network.