### PR TITLE
use actions/setup-node@v4

### DIFF
--- a/.github/workflows/portalnetwork-build.yml
+++ b/.github/workflows/portalnetwork-build.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: recursive
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
           submodules: recursive
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
Fixes this error in the CI:
![Screenshot from 2024-10-23 17-05-56](https://github.com/user-attachments/assets/de23e88d-eb30-44e1-9dc3-ab072300aab0)

now using `actions/setup-node@v4`
