### PR TITLE
Improve Node Lookup

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -288,12 +288,8 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       if (network instanceof HistoryNetwork) {
         network.blockHashIndex = storedIndex
       }
+      network.startRefresh()
       await network.prune()
-      // Start kbucket refresh on 30 second interval
-      this.refreshListeners.set(
-        network.networkId,
-        setInterval(() => network.bucketRefresh(), 30000),
-      )
     }
     void this.bootstrap()
   }
@@ -322,8 +318,8 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     this.discv5.removeAllListeners()
     await this.removeAllListeners()
     await this.db.close()
-    for (const network of this.refreshListeners) {
-      clearInterval(network[1])
+    for (const network of this.networks.values()) {
+      network.stopRefresh()
     }
   }
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -781,11 +781,11 @@ export abstract class BaseNetwork extends EventEmitter {
 
   /**
    * Follows below algorithm to refresh a bucket in the routing table
-   * 1: Look at your routing table and select all buckets at distance greater than 239 that are not full.
-   * 2: Select a number of buckets to refresh using this logic (48+ nodes known, refresh 1 bucket, 24+ nodes known,
-   * refresh half of not full buckets, <25 nodes known, refresh all not empty buckets
-   * 3: Randomly generate a NodeID that falls within each bucket to be refreshed.
-   * Do the random lookup on this node-id.
+   * 1. Select 4 closest non-full buckets to refresh
+   * 2. Select a random node at the distance of each bucket
+   * 3. Perform a NodeLookup for the random node
+   * 4. NodeLookup will recursively query peers for new nodes at the distance of the bucket
+   * 5. New nodes will be added to the routing table
    */
   public bucketRefresh = async () => {
     const now = Date.now()

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -343,7 +343,7 @@ export abstract class BaseNetwork extends EventEmitter {
           // Ping node if not currently ignored by subnetwork routing table
           await Promise.allSettled(
             notIgnored.map((e) => {
-            const decodedEnr = ENR.decode(e)
+              const decodedEnr = ENR.decode(e)
               return this.sendPing(decodedEnr)
             }),
           )

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -800,14 +800,15 @@ export abstract class BaseNetwork extends EventEmitter {
       .map((bucket, idx) => {
         return { bucket, distance: idx }
       })
-      .filter((pair) => pair.bucket.size() < 16)
       .reverse()
+      .slice(0, 16)
+      .filter((pair) => pair.bucket.size() < MAX_NODES_PER_BUCKET)
       .slice(0, 4)
     this.logger.extend('bucketRefresh')(
       `Refreshing buckets: ${bucketsToRefresh.map((b) => b.distance).join(', ')}`,
     )
 
-    await Promise.all(
+    await Promise.allSettled(
       bucketsToRefresh.map(async (bucket) => {
         const randomNodeId = generateRandomNodeIdAtDistance(this.enr.nodeId, bucket.distance)
         const lookup = new NodeLookup(this, randomNodeId)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -936,7 +936,7 @@ export abstract class BaseNetwork extends EventEmitter {
     if (tableHealth > 0.8) {
       return 60000 // Healthy table = longer interval
     } else if (tableHealth < 0.3) {
-      return 15000 // Unhealthy table = shorter interval
+      return 10000 // Unhealthy table = shorter interval
     }
     return 30000
   }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -96,7 +96,7 @@ export abstract class BaseNetwork extends EventEmitter {
   public routingTableInfo = async () => {
     return {
       nodeId: this.enr.nodeId,
-      buckets: this.routingTable.buckets.map((bucket) => bucket.values().map((enr) => enr.nodeId)),
+      buckets: this.routingTable.buckets,
     }
   }
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -1,5 +1,5 @@
 import { digest } from '@chainsafe/as-sha256'
-import { EntryStatus, distance } from '@chainsafe/discv5'
+import { EntryStatus, MAX_NODES_PER_BUCKET, distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
 import { BitArray } from '@chainsafe/ssz'
 import {

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -50,12 +50,12 @@ export class NodeLookup {
     await Promise.allSettled(addPromises)
   }
 
-  private selectClosestPending(pendingNodes: Map<string, ENR>, count: number): ENR[] {
-    return Array.from(pendingNodes.values())
+  private selectClosestPending(): ENR[] {
+    return Array.from(this.pendingNodes.values())
       .sort((a, b) =>
         Number(distance(a.nodeId, this.nodeSought) - distance(b.nodeId, this.nodeSought)),
       )
-      .slice(0, count)
+      .slice(0, NodeLookup.CONCURRENT_LOOKUPS)
   }
 
   private async queryPeer(

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -1,4 +1,4 @@
-import { EntryStatus, distance, log2Distance } from '@chainsafe/discv5'
+import { EntryStatus, MAX_NODES_PER_BUCKET, distance, log2Distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
 
 import type { BaseNetwork } from './network.js'

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -9,13 +9,15 @@ import type { Debugger } from 'debug'
 // This class implements a version of the the lookup algorithm defined in the Kademlia paper
 // https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf.
 
-const k = 16 // Kademlia constant for max nodes to be retrieved by `nodeLookup`
-const a = 3 // Concurrency parameter defined in Kademlia paper
-
 export class NodeLookup {
   private network: BaseNetwork
   private nodeSought: string
   private log: Debugger
+
+  // Configuration constants
+  private static readonly CONCURRENT_LOOKUPS = 3 // Alpha (a) parameter from Kademlia
+  private static readonly LOOKUP_TIMEOUT = 3000 // 3 seconds per peer
+  private static readonly MAX_PEERS = 16 // k parameter from Kademlia
 
   constructor(network: BaseNetwork, nodeId: string) {
     this.network = network

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -58,11 +58,7 @@ export class NodeLookup {
       .slice(0, NodeLookup.CONCURRENT_LOOKUPS)
   }
 
-  private async queryPeer(
-    peer: ENR,
-    queriedNodes: Set<string>,
-    pendingNodes: Map<string, ENR>,
-  ): Promise<void> {
+  private async queryPeer(peer: ENR): Promise<void> {
     const distanceToTarget = log2Distance(peer.nodeId, this.nodeSought)
 
     try {


### PR DESCRIPTION
This PR refactors and improves the `NodeLookup` class, as well as the `network.bucketRefresh` method.

We remove the `setInterval` code from the `PortalNetwork` class that sets a 30 seconds interval for `bucketRefresh`.  Instead, networks will manage their own `refreshInterval`, and reset this interval whenever `bucketRefresh` is called.  The interval is dynamically set based on current network conditions.  An empty routing table will refresh every 10 seconds.  Once the table is 30% full, we increase the interval to 30 seconds.  When the table is > 80% full, we increase the interval to 60 seconds.  This results in faster routing table population on startup.

Instead of `setInterval`, `PortalNetwork` will call `network.startRefresh()` on startup and `network.stopRefresh()` on close.

`NodeLookup` class was significanly refactored.  Many of the changes were organizational, breaking down the longer methods into shorter, more focused functions.  Other changes include removing the calls to `sendPing` on new enrs, since this already happens in `sendFindNodes`, and was therefor extraneous.   

`NodeLookup` also monitors the actual bucket size as the process continues, and aborts early when the bucket is full.

A `LOOKUP_TIMEOUT` was implemented for each individual  query.  This eliminated an issue with promises hanging open when peers failed to respond, and ensures the process continues quickly.


`network.sendFindNodes` was refactored as well.  `sendPing` already performs `evictNode` on unresponsive peers, so it was unnecessary to also call `evictNode` in `sendFindNodes`.  The conditional to only PING unkonwn nodes was also removed, as PINGing all the nodes received in a NODES message also acts as another `livenessCheck` and helps purge disconnected peers.