### PR TITLE
ContentLookup followup: fix uTP dstId value

### DIFF
--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -467,7 +467,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
               void this.handleNewRequest({
                 networkId: this.networkId,
                 contentKeys: [key],
-                peerId: dstId,
+                peerId: enr.nodeId,
                 connectionId: id,
                 requestCode: RequestCode.FINDCONTENT_READ,
               })

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -234,7 +234,7 @@ export class HistoryNetwork extends BaseNetwork {
               void this.handleNewRequest({
                 networkId: this.networkId,
                 contentKeys: [key],
-                peerId: dstId,
+                peerId: enr.nodeId,
                 connectionId: id,
                 requestCode: RequestCode.FINDCONTENT_READ,
               })

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -109,7 +109,7 @@ export class StateNetwork extends BaseNetwork {
               void this.handleNewRequest({
                 networkId: this.networkId,
                 contentKeys: [key],
-                peerId: dstId,
+                peerId: enr.nodeId,
                 connectionId: id,
                 requestCode: RequestCode.FINDCONTENT_READ,
               })


### PR DESCRIPTION
Fixes `uTP` response to `sendFindContent`

`sendFindContent` can work with either a `nodeId` or `ENR` string.

However, `uTP.handleNewRequest` requires a `nodeId`, and not an `ENR` string.

This updates the call to `.handleNewRequest` by ensuring that `enr.nodeId` is passed, instead of passing the same string passed to `sendFindContent`