### PR TITLE
Add `traceGetContent` error conditions

### DIFF
--- a/packages/cli/src/rpc/error-code.ts
+++ b/packages/cli/src/rpc/error-code.ts
@@ -5,3 +5,4 @@ export const INVALID_REQUEST = -32600
 export const METHOD_NOT_FOUND = -32601
 export const INVALID_PARAMS = -32602
 export const INTERNAL_ERROR = -32603
+export const CONTENT_NOT_FOUND = -39002

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -148,7 +148,7 @@ export type ContentLookupResponse =
       utp: boolean
       trace?: ContentTrace
     }
-  | { enrs: Uint8Array[] }
+  | { enrs: Uint8Array[]; trace?: ContentTrace }
   | undefined
 
 export interface ContentTrace extends Partial<TraceObject> {}

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -37,9 +37,9 @@ const enr1 = SignableENR.createFromPrivateKey(pk1)
 const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
 const enr2 = SignableENR.createFromPrivateKey(pk2)
 describe('gossip test', async () => {
-  const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5000`)
+  const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5034`)
   enr1.setLocationMultiaddr(initMa)
-  const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/5001`)
+  const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/5035`)
   enr2.setLocationMultiaddr(initMa2)
   const node1 = await PortalNetwork.create({
     transport: TransportLayer.NODE,

--- a/packages/portalnetwork/test/integration/recursiveContentLookup.spec.ts
+++ b/packages/portalnetwork/test/integration/recursiveContentLookup.spec.ts
@@ -59,9 +59,6 @@ describe('Recursive Content Lookup Test', () => {
       },
     })
 
-    node1.enableLog('*Portal*')
-    node2.enableLog('*Portal*')
-    node3.enableLog('*Portal*')
     await node1.start()
     await node2.start()
     await node3.start()
@@ -106,4 +103,4 @@ describe('Recursive Content Lookup Test', () => {
     const res = await contentLookup.startLookup()
     assert.equal(Object.keys(res!.trace!.metadata!).length, 2)
   })
-}, 10000)
+}, 30000)

--- a/packages/portalnetwork/test/integration/recursiveContentLookup.spec.ts
+++ b/packages/portalnetwork/test/integration/recursiveContentLookup.spec.ts
@@ -3,7 +3,7 @@ import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { keys } from '@libp2p/crypto'
 import { multiaddr } from '@multiformats/multiaddr'
 import { readFileSync } from 'fs'
-import { assert, describe, it } from 'vitest'
+import { assert, beforeAll, describe, it } from 'vitest'
 
 import { ContentLookup, NetworkId, PortalNetwork, TransportLayer } from '../../src/index.js'
 
@@ -16,14 +16,16 @@ const enr2 = SignableENR.createFromPrivateKey(pk2)
 const pk3 = await keys.generateKeyPair('secp256k1')
 const enr3 = SignableENR.createFromPrivateKey(pk3)
 describe('Recursive Content Lookup Test', () => {
-  it('should retrieve the block from node1 via node3', async () => {
+  let node1: PortalNetwork, node2: PortalNetwork, node3: PortalNetwork
+  let network1: HistoryNetwork, network2: HistoryNetwork, network3: HistoryNetwork
+  beforeAll(async () => {
     const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5000`)
     enr1.setLocationMultiaddr(initMa)
     const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/5001`)
     enr2.setLocationMultiaddr(initMa2)
     const initMa3: any = multiaddr(`/ip4/127.0.0.1/udp/5002`)
     enr3.setLocationMultiaddr(initMa3)
-    const node1 = await PortalNetwork.create({
+    node1 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
       config: {
@@ -34,7 +36,7 @@ describe('Recursive Content Lookup Test', () => {
         privateKey: pk1,
       },
     })
-    const node2 = await PortalNetwork.create({
+    node2 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
       config: {
@@ -45,7 +47,7 @@ describe('Recursive Content Lookup Test', () => {
         privateKey: pk2,
       },
     })
-    const node3 = await PortalNetwork.create({
+    node3 = await PortalNetwork.create({
       transport: TransportLayer.NODE,
       supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
       config: {
@@ -57,14 +59,20 @@ describe('Recursive Content Lookup Test', () => {
       },
     })
 
+    node1.enableLog('*Portal*')
+    node2.enableLog('*Portal*')
+    node3.enableLog('*Portal*')
     await node1.start()
     await node2.start()
     await node3.start()
 
-    const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-    const network3 = node3.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-
+    network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    network3 = node3.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    await network1!.sendPing(node2.discv5.enr.toENR())
+    await network2!.sendPing(node3.discv5.enr.toENR())
+  })
+  it('should retrieve the block from node1 via node3', async () => {
     const headersWithProofs: [string, string][] = JSON.parse(
       readFileSync('./test/testData/headersWithProofs.json', 'utf8'),
     )
@@ -89,8 +97,13 @@ describe('Recursive Content Lookup Test', () => {
     assert.exists(res?.trace)
     assert.equal(bytesToHex(res?.content), headersWithProofs[0][1])
     assert.equal(res?.trace.receivedFrom, node1.discv5.enr.nodeId)
-    await node1.stop()
-    await node2.stop()
-    await node3.stop()
   })
-})
+  it('should get no content and 2 nodes with trace info', async () => {
+    const contentKey = hexToBytes(
+      '0x00a6f23da625dc9c17792f4d8d8a6ee8b42274f73739768d50335db878ad54acd7',
+    )
+    const contentLookup = new ContentLookup(network3, contentKey!, true)
+    const res = await contentLookup.startLookup()
+    assert.equal(Object.keys(res!.trace!.metadata!).length, 2)
+  })
+}, 10000)


### PR DESCRIPTION
Renames `traceRecursiveFindContent` to `traceGetContent` matching the spec and also adds the error condition for the RPC.