### PR TITLE
RPC: fix recursiveNodeLookup

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -195,6 +195,12 @@ export class portal {
     this.historyRecursiveFindNodes = middleware(this.historyRecursiveFindNodes.bind(this), 1, [
       [validators.dstId],
     ])
+    this.stateRecursiveFindNodes = middleware(this.stateRecursiveFindNodes.bind(this), 1, [
+      [validators.dstId],
+    ])
+    this.beaconRecursiveFindNodes = middleware(this.beaconRecursiveFindNodes.bind(this), 1, [
+      [validators.dstId],
+    ])
 
     // portal_*SendNodes
     this.historySendNodes = middleware(this.historySendNodes.bind(this), 2, [
@@ -766,6 +772,24 @@ export class portal {
     const lookup = new NodeLookup(this._history, target)
     const res = await lookup.startLookup()
     this.logger(`historyRecursiveFindNodes request returned ${res}`)
+    return res ?? ''
+  }
+  async stateRecursiveFindNodes(params: [string]) {
+    const [dstId] = params
+    this.logger(`stateRecursiveFindNodes request received for ${dstId}`)
+    const target = dstId.startsWith('0x') ? dstId.slice(2) : dstId
+    const lookup = new NodeLookup(this._state, target)
+    const res = await lookup.startLookup()
+    this.logger(`stateRecursiveFindNodes request returned ${res}`)
+    return res ?? ''
+  }
+  async beaconRecursiveFindNodes(params: [string]) {
+    const [dstId] = params
+    this.logger(`beaconRecursiveFindNodes request received for ${dstId}`)
+    const target = dstId.startsWith('0x') ? dstId.slice(2) : dstId
+    const lookup = new NodeLookup(this._beacon, target)
+    const res = await lookup.startLookup()
+    this.logger(`beaconRecursiveFindNodes request returned ${res}`)
     return res ?? ''
   }
 

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -1,4 +1,4 @@
-import { EntryStatus, distance } from '@chainsafe/discv5'
+import { EntryStatus } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
 import { BitArray } from '@chainsafe/ssz'
 import { bigIntToHex, bytesToHex, hexToBytes, short } from '@ethereumjs/util'
@@ -718,8 +718,7 @@ export class portal {
       return []
     }
     const enrs = res?.enrs.map((v) => ENR.decode(v).encodeTxt())
-    this.logger(`findNodes request returned ${res?.total} enrs:`)
-    this.logger(enrs)
+    this.logger(`findNodes request returned ${enrs.length} enrs:`)
     return res?.enrs.map((v) => ENR.decode(v).encodeTxt())
   }
   async stateFindNodes(params: [string, number[]]) {
@@ -738,8 +737,7 @@ export class portal {
       return []
     }
     const enrs = res?.enrs.map((v) => ENR.decode(v).encodeTxt())
-    this.logger(`stateFindNodes request returned ${res?.total} enrs:`)
-    this.logger(enrs)
+    this.logger(`stateFindNodes request returned ${enrs.length} enrs:`)
     return res?.enrs.map((v) => ENR.decode(v).encodeTxt())
   }
   async beaconFindNodes(params: [string, number[]]) {
@@ -758,8 +756,7 @@ export class portal {
       return []
     }
     const enrs = res?.enrs.map((v) => ENR.decode(v).encodeTxt())
-    this.logger(`beaconFindNodes request returned ${res?.total} enrs:`)
-    this.logger(enrs)
+    this.logger(`beaconFindNodes request returned ${enrs.length} enrs:`)
     return res?.enrs.map((v) => ENR.decode(v).encodeTxt())
   }
 
@@ -785,12 +782,8 @@ export class portal {
     this.logger(`historyRecursiveFindNodes request received for ${dstId}`)
     const target = dstId.startsWith('0x') ? dstId.slice(2) : dstId
     const lookup = new NodeLookup(this._history, target)
-    await lookup.startLookup()
-    const enrs = this._history.routingTable
-      .nearest(target, 16)
-      .sort((a, b) => Number(distance(target, a.nodeId) - distance(target, b.nodeId)))
-      .map((v) => v.encodeTxt())
-    this.logger(`historyRecursiveFindNodes request returned ${enrs}`)
+    const enrs = await lookup.startLookup()
+    this.logger(`historyRecursiveFindNodes request returned ${enrs.length} enrs`)
     return enrs
   }
   async stateRecursiveFindNodes(params: [string]) {
@@ -798,12 +791,8 @@ export class portal {
     this.logger(`stateRecursiveFindNodes request received for ${dstId}`)
     const target = dstId.startsWith('0x') ? dstId.slice(2) : dstId
     const lookup = new NodeLookup(this._state, target)
-    await lookup.startLookup()
-    const enrs = this._state.routingTable
-      .nearest(target, 16)
-      .sort((a, b) => Number(distance(target, a.nodeId) - distance(target, b.nodeId)))
-      .map((v) => v.encodeTxt())
-    this.logger(`stateRecursiveFindNodes request returned ${enrs}`)
+    const enrs = await lookup.startLookup()
+    this.logger(`stateRecursiveFindNodes request returned ${enrs.length} enrs`)
     return enrs
   }
   async beaconRecursiveFindNodes(params: [string]) {
@@ -811,12 +800,8 @@ export class portal {
     this.logger(`beaconRecursiveFindNodes request received for ${dstId}`)
     const target = dstId.startsWith('0x') ? dstId.slice(2) : dstId
     const lookup = new NodeLookup(this._beacon, target)
-    await lookup.startLookup()
-    const enrs = this._beacon.routingTable
-      .nearest(target, 16)
-      .sort((a, b) => Number(distance(target, a.nodeId) - distance(target, b.nodeId)))
-      .map((v) => v.encodeTxt())
-    this.logger(`beaconRecursiveFindNodes request returned ${enrs}`)
+    const enrs = await lookup.startLookup()
+    this.logger(`beaconRecursiveFindNodes request returned ${enrs.length} enrs`)
     return enrs
   }
 

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -762,7 +762,8 @@ export class portal {
   async historyRecursiveFindNodes(params: [string]) {
     const [dstId] = params
     this.logger(`historyRecursiveFindNodes request received for ${dstId}`)
-    const lookup = new NodeLookup(this._history, dstId)
+    const target = dstId.startsWith('0x') ? dstId.slice(2) : dstId
+    const lookup = new NodeLookup(this._history, target)
     const res = await lookup.startLookup()
     this.logger(`historyRecursiveFindNodes request returned ${res}`)
     return res ?? ''

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -41,7 +41,7 @@ export class ContentLookup {
     this.contentTrace = trace
       ? {
           origin: this.network.portal.discv5.enr.nodeId as PrefixedHexString,
-          targetId: bytesToHex(this.contentKey),
+          targetId: this.contentId,
           metadata: {},
         }
       : undefined

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -1,6 +1,6 @@
 import { distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
-import { bigIntToHex, bytesToHex, short } from '@ethereumjs/util'
+import { bigIntToHex, bytesToHex, hexToBytes, short } from '@ethereumjs/util'
 import { Heap } from 'heap-js'
 
 import { serializedContentKeyToContentId, shortId } from '../util/index.js'
@@ -40,8 +40,8 @@ export class ContentLookup {
     this.completedRequests = trace ? new Map() : undefined
     this.contentTrace = trace
       ? {
-          origin: this.network.portal.discv5.enr.nodeId as PrefixedHexString,
-          targetId: this.contentId,
+          origin: ('0x' + this.network.portal.discv5.enr.nodeId) as PrefixedHexString,
+          targetId: Array.from(hexToBytes('0x' + this.contentId)) as any,
           metadata: {},
         }
       : undefined
@@ -54,7 +54,11 @@ export class ContentLookup {
   public startLookup = async (): Promise<ContentLookupResponse> => {
     // Don't support content lookups for networks that don't implement it (i.e. Canonical Indices)
     if (!this.network.sendFindContent) return
-    this.contentTrace && (this.contentTrace.startedAtMs = Date.now())
+    this.contentTrace &&
+      (this.contentTrace.startedAtMs = {
+        secs_since_epoch: Math.floor(Date.now() / 1000),
+        nanos_since_epoch: 0, // TODO: figure out what this is
+      })
     this.logger(`starting recursive content lookup for ${bytesToHex(this.contentKey)}`)
     this.network.portal.metrics?.totalContentLookups.inc()
     try {
@@ -123,20 +127,20 @@ export class ContentLookup {
     // Add cancelled/metadata elements to trace
     if (this.contentTrace !== undefined) {
       this.contentTrace.cancelled = Array.from(this.pending.values()).map(
-        (enr) => ENR.decodeTxt(enr).nodeId,
+        (enr) => '0x' + ENR.decodeTxt(enr).nodeId,
       )
       this.contentTrace.responses = Object.fromEntries(this.completedRequests!.entries()) as Record<
         NodeId,
         NodeId[]
       >
       for (const nodeId of Object.keys(this.contentTrace.responses!)) {
-        this.contentTrace.metadata![nodeId] = this.meta.get(nodeId)! as {
+        this.contentTrace.metadata!['0x' + nodeId] = this.meta.get('0x' + nodeId)! as {
           enr: `enr:${string}`
           distance: `0x${string}`
         }
       }
       for (const nodeId of this.contentTrace.cancelled!) {
-        this.contentTrace.metadata![nodeId] = this.meta.get(nodeId)! as {
+        this.contentTrace.metadata!['0x' + nodeId] = this.meta.get('0x' + nodeId)! as {
           enr: `enr:${string}`
           distance: `0x${string}`
         }
@@ -179,8 +183,8 @@ export class ContentLookup {
         this.network.routingTable.contentKeyKnownToPeer(peer.enr.nodeId, this.contentKey)
         this.network.portal.metrics?.successfulContentLookups.inc()
         if (this.contentTrace !== undefined) {
-          this.completedRequests!.set(peer.enr.nodeId, [])
-          this.contentTrace.receivedFrom = peer.enr.nodeId
+          this.completedRequests!.set('0x' + peer.enr.nodeId, [])
+          this.contentTrace.receivedFrom = '0x' + peer.enr.nodeId
         }
         return res
       } else {
@@ -191,7 +195,7 @@ export class ContentLookup {
           if (!this.meta.has(decodedEnr.nodeId)) {
             const dist = distance(decodedEnr.nodeId, this.contentId)
             this.lookupPeers.push({ enr: decodedEnr, distance: Number(dist) })
-            this.meta.set(decodedEnr.nodeId, {
+            this.meta.set('0x' + decodedEnr.nodeId, {
               enr: decodedEnr.encodeTxt(),
               distance: bigIntToHex(dist),
             })
@@ -202,8 +206,8 @@ export class ContentLookup {
         }
         this.completedRequests &&
           this.completedRequests.set(
-            peer.enr.nodeId,
-            res.enrs.map((enr) => ENR.decode(enr).nodeId),
+            '0x' + peer.enr.nodeId,
+            res.enrs.map((enr) => '0x' + ENR.decode(enr).nodeId),
           )
         throw new Error('Continue')
       }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -792,6 +792,9 @@ export abstract class BaseNetwork extends EventEmitter {
     this.lastRefreshTime = now
     await this.livenessCheck()
     const size = this.routingTable.size
+    if (size === 0) {
+      return
+    }
     this.logger.extend('bucketRefresh')(`Starting bucket refresh with ${size} peers`)
     const bucketsToRefresh = this.routingTable.buckets
       .map((bucket, idx) => {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -811,7 +811,7 @@ export abstract class BaseNetwork extends EventEmitter {
     await Promise.allSettled(
       bucketsToRefresh.map(async (bucket) => {
         const randomNodeId = generateRandomNodeIdAtDistance(this.enr.nodeId, bucket.distance)
-        const lookup = new NodeLookup(this, randomNodeId)
+        const lookup = new NodeLookup(this, randomNodeId, true)
         return lookup.startLookup()
       }),
     )

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -1,5 +1,6 @@
 import { EntryStatus, MAX_NODES_PER_BUCKET, distance, log2Distance } from '@chainsafe/discv5'
 import { ENR } from '@chainsafe/enr'
+import { Heap } from 'heap-js'
 
 import type { BaseNetwork } from './network.js'
 import type { Debugger } from 'debug'
@@ -16,22 +17,28 @@ export class NodeLookup {
   private static readonly CONCURRENT_LOOKUPS = 3 // Alpha (a) parameter from Kademlia
   private static readonly LOOKUP_TIMEOUT = 5000 // 5 seconds per peer
 
+  private foundNodes: Heap<ENR> // Heap of ENRs sorted by distance to target
   private queriedNodes: Set<string>
   private pendingNodes: Map<string, ENR> // nodeId -> ENR
+  private refresh: boolean
 
-  constructor(network: BaseNetwork, nodeId: string) {
+  constructor(network: BaseNetwork, nodeId: string, refresh: boolean = false) {
     this.network = network
     this.nodeSought = nodeId
+    this.refresh = refresh
     this.log = this.network.logger
       .extend('nodeLookup')
       .extend(log2Distance(this.network.enr.nodeId, this.nodeSought).toString())
     this.queriedNodes = new Set<string>()
     this.pendingNodes = new Map<string, ENR>() // nodeId -> ENR
-
+    this.foundNodes = new Heap<ENR>((a, b) =>
+      Number(distance(a.nodeId, this.nodeSought) - distance(b.nodeId, this.nodeSought)),
+    )
     // Initialize with closest known peers
     const initialPeers = this.network.routingTable.nearest(this.nodeSought, 16)
     for (const peer of initialPeers) {
       this.pendingNodes.set(peer.nodeId, peer)
+      this.foundNodes.push(peer)
     }
   }
 
@@ -73,6 +80,7 @@ export class NodeLookup {
 
         for (const enr of response.enrs) {
           const decodedEnr = ENR.decode(enr)
+          this.foundNodes.push(decodedEnr)
           const nodeId = decodedEnr.nodeId
           try {
             // Skip if we've already queried this node
@@ -100,20 +108,15 @@ export class NodeLookup {
     }
   }
 
-  public async startLookup(): Promise<string | undefined> {
+  public async startLookup(): Promise<string[]> {
     const bucket = log2Distance(this.network.enr.nodeId, this.nodeSought)
     const startingSize = this.network.routingTable.buckets[bucket].size()
     this.log(`Starting lookup in bucket ${bucket} (${startingSize}/${MAX_NODES_PER_BUCKET} peers)`)
 
     while (this.pendingNodes.size > 0) {
-      const full = this.network.routingTable.buckets[bucket].size() >= MAX_NODES_PER_BUCKET
-
-      if (full) {
+      if (this.refresh === true && startingSize >= MAX_NODES_PER_BUCKET) {
         this.log(`Bucket is full, stopping lookup`)
-        this.log(
-          `Finished lookup in bucket ${bucket} (${MAX_NODES_PER_BUCKET}/${MAX_NODES_PER_BUCKET} peers) +${MAX_NODES_PER_BUCKET - startingSize}`,
-        )
-        return
+        break
       }
 
       // Select closest α nodes we haven't queried yet
@@ -146,5 +149,10 @@ export class NodeLookup {
     this.log(
       `Finished lookup in bucket ${bucket} (${finalSize}/${MAX_NODES_PER_BUCKET} peers) +${finalSize - startingSize}`,
     )
+    const foundPeers: Set<string> = new Set()
+    while (this.foundNodes.peek() && foundPeers.size < 16) {
+      foundPeers.add(this.foundNodes.pop()!.encodeTxt())
+    }
+    return Array.from(foundPeers)
   }
 }

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -106,10 +106,7 @@ export class NodeLookup {
     this.log(`Starting lookup in bucket ${bucket} (${startingSize}/${MAX_NODES_PER_BUCKET} peers)`)
 
     while (this.pendingNodes.size > 0) {
-      const full =
-        this.network.routingTable.buckets[
-          log2Distance(this.network.enr.nodeId, this.nodeSought)
-        ].size() >= MAX_NODES_PER_BUCKET
+      const full = this.network.routingTable.buckets[bucket].size() >= MAX_NODES_PER_BUCKET
 
       if (full) {
         this.log(`Bucket is full, stopping lookup`)

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -165,6 +165,10 @@ export interface TraceObject {
       distance: PrefixedHexString
     }
   }
-  startedAtMs: number
+  startedAtMs: {
+    secs_since_epoch: number
+    nanos_since_epoch: number
+  }
+
   cancelled?: NodeId[]
 }

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -154,7 +154,7 @@ export type ContentLookupResponse =
 export interface ContentTrace extends Partial<TraceObject> {}
 export interface TraceObject {
   origin: NodeId
-  targetId: PrefixedHexString
+  targetId: string
   receivedFrom: NodeId
   responses: {
     [nodeId: NodeId]: NodeId[]


### PR DESCRIPTION
Bug unconvered through use of `glados-cartographer`

`portal_*RecursiveFindContent` was not returning the expected array of ENRs. 

Changes: 
1. NodeLookup now takes an optional `refresh` parameter
  - if true, `NodeLookup` will exit early when the target bucket is full
  - set to true in `bucketRefresh`
2. `NodeLookup` now tracks all found ENRs in a `Heap` called `this.foundNodes`
  - `Heap` is automatically sorted by distance to target 
3. `NodeLookup.startLookup()` now returns the closest 16 ENRs from `foundNodes` heap
  - As `ENR` string array (sorted)
4. RPC methods `portal_*RecursiveFindNodes` now returns ENR list from `NodeLookup.startLookup()`


This PR also implements the same method for `state` and `beacon` networks, which were previously without this method. 