### PR TITLE
Add `shouldRefresh` flag

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -45,6 +45,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   private refreshListeners: Map<NetworkId, ReturnType<typeof setInterval>>
   private supportsRendezvous: boolean
   private unverifiedSessionCache: LRUCache<NodeId, Multiaddr>
+  shouldRefresh: boolean = true
 
   public static create = async (opts: Partial<PortalNetworkOpts>) => {
     const defaultConfig: IDiscv5CreateOptions = {
@@ -268,6 +269,8 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
         this.metrics?.currentDBSize.set(await this.db.currentSize())
       }
     }
+    // Should refresh by default but can be disabled (e.g. in tests)
+    opts.shouldRefresh === false && (this.shouldRefresh = false)
   }
 
   /**
@@ -288,7 +291,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       if (network instanceof HistoryNetwork) {
         network.blockHashIndex = storedIndex
       }
-      network.startRefresh()
+      this.shouldRefresh && network.startRefresh()
       await network.prune()
     }
     void this.bootstrap()

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -45,6 +45,7 @@ export interface PortalNetworkOpts {
   trustedBlockRoot?: string
   eventLog?: boolean
   utpTimeout?: number
+  shouldRefresh?: boolean
 }
 
 export type PortalNetworkEventEmitter = StrictEventEmitter<EventEmitter, PortalNetworkEvents>

--- a/packages/portalnetwork/test/integration/state.spec.ts
+++ b/packages/portalnetwork/test/integration/state.spec.ts
@@ -63,8 +63,6 @@ describe('AccountTrieNode Gossip / Request', async () => {
 
   const network1 = node1.networks.get(NetworkId.StateNetwork) as StateNetwork
   const network2 = node2.networks.get(NetworkId.StateNetwork) as StateNetwork
-  network1.startRefresh = () => {} // Disable for test since causes occasional timeouts
-  network2.startRefresh = () => {} // Disable for test since causes occasional timeouts
   await node1.start()
   await node2.start()
   network1.nodeRadius = 2n ** 254n - 1n


### PR DESCRIPTION
WIP PR to add a `shouldRefresh` flag to the client so we can turn off the bucket refresh as needed (mainly in hive tests where too much activity can cause the test to timeout)