### PR TITLE
uTP Packet Queue

### DIFF
--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -73,6 +73,10 @@ export class ContentLookup {
     // Sort known peers by distance to the content
     const nearest = this.network.routingTable.values()
     for (const enr of nearest) {
+      // // Skip if the node has an active uTP request
+      if (this.network.portal.uTP.hasRequests(enr.nodeId) === true) {
+        continue
+      }
       const dist = distance(enr.nodeId, this.contentId)
       this.lookupPeers.push({ enr, distance: Number(dist) })
       this.meta.set(enr.nodeId, { enr: enr.encodeTxt(), distance: bigIntToHex(dist) })
@@ -189,6 +193,10 @@ export class ContentLookup {
         this.logger(`received ${res.enrs.length} ENRs for closer nodes`)
         for (const enr of res.enrs) {
           const decodedEnr = ENR.decode(enr as Uint8Array)
+          // // Skip if the node has an active uTP request
+          if (this.network.portal.uTP.hasRequests(decodedEnr.nodeId) === true) {
+            continue
+          }
           if (!this.meta.has(decodedEnr.nodeId)) {
             const dist = distance(decodedEnr.nodeId, this.contentId)
             this.lookupPeers.push({ enr: decodedEnr, distance: Number(dist) })

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -570,15 +570,7 @@ export abstract class BaseNetwork extends EventEmitter {
     this.logger.extend('ACCEPT')(
       `Accepting: ${desiredContentKeys.length} pieces of content.  connectionId: ${id}`,
     )
-    const enr = this.findEnr(src.nodeId) ?? src
     this.portal.metrics?.acceptMessagesSent.inc()
-      await this.handleNewRequest({
-      networkId: this.networkId,
-      contentKeys: desiredContentKeys,
-      enr,
-      connectionId: id,
-      requestCode: RequestCode.ACCEPT_READ,
-    })
     const idBuffer = new Uint8Array(2)
     new DataView(idBuffer.buffer).setUint16(0, id, false)
 
@@ -596,6 +588,14 @@ export abstract class BaseNetwork extends EventEmitter {
         desiredContentKeys.length
       } pieces of content.  connectionId: ${id}`,
     )
+    const enr = this.findEnr(src.nodeId) ?? src
+    await this.handleNewRequest({
+      networkId: this.networkId,
+      contentKeys: desiredContentKeys,
+      enr,
+      connectionId: id,
+      requestCode: RequestCode.ACCEPT_READ,
+    })
   }
 
   protected handleFindContent = async (

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -59,6 +59,8 @@ export class NodeLookup {
 
   private selectClosestPending(): ENR[] {
     return Array.from(this.pendingNodes.values())
+      // Skip nodes with active uTP requests
+      .filter((peer) => this.network.portal.uTP.hasRequests(peer.nodeId) === false)
       .sort((a, b) =>
         Number(distance(a.nodeId, this.nodeSought) - distance(b.nodeId, this.nodeSought)),
       )
@@ -88,6 +90,11 @@ export class NodeLookup {
 
             // Skip if the node is ignored
             if (this.network.routingTable.isIgnored(nodeId)) {
+              continue
+            }
+
+            // Skip if the node has an active uTP request
+            if (this.network.portal.uTP.hasRequests(nodeId) === true) {
               continue
             }
 

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
@@ -104,6 +104,7 @@ export interface UtpSocketOptions {
   utp: PortalNetworkUTP
   networkId: NetworkId
   enr: ENR | INodeAddress
+  connectionId: number
   sndId: number
   rcvId: number
   seqNr: number

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
@@ -1,0 +1,116 @@
+import type { ContentRequest } from "./ContentRequest.js";
+import { Packet , PacketType } from "../Packets/index.js";
+import type { Debugger } from "debug";
+
+type RequestId = number
+
+export class RequestManager {
+    peerId: string
+    requestMap: Record<RequestId, ContentRequest>
+    logger: Debugger
+    masterPacketQueue: Array<Packet<PacketType>>
+    currentPacket: Packet<PacketType> | undefined
+
+    constructor(peerId: string, logger: Debugger) {
+        this.peerId = peerId
+        this.requestMap = {}
+        this.logger = logger.extend(`RequestManager`).extend(peerId.slice(0, 4))
+        this.masterPacketQueue = []
+        this.currentPacket = undefined
+    }
+
+    /**
+     *  Due to the variations in uTP configurations, the connectionId field in an incoming packet may be equal to, +1, or -1 of the corresponding requestId.
+     *  This function will return the corresponding requestId for the given connectionId.
+     * @param connectionId connectionId field from incoming packet header
+     * @returns corresponding requestId
+     */
+    lookupRequest(connectionId: number): ContentRequest | undefined {
+        return this.requestMap[connectionId] ?? this.requestMap[connectionId - 1] ?? this.requestMap[connectionId + 1]
+    }
+
+    /**
+     * Adds a new uTP request to the peer's request manager.
+     * @param connectionId connectionId from uTP initialization 
+     * @param request new ContentRequest
+     */
+    async handleNewRequest(connectionId: number,request: ContentRequest) {
+        this.requestMap[connectionId] = request
+        await request.init()
+    }
+
+    /**
+     * Handles an incoming uTP packet.
+     * @param packetBuffer buffer containing the incoming packet
+     */
+    async handlePacket(packetBuffer: Buffer) {
+        const packet = Packet.fromBuffer(packetBuffer)
+        const request = this.lookupRequest(packet.header.connectionId)
+        if (request === undefined) {
+            this.logger.extend('HANDLE_PACKET')(`Request not found for packet - connectionId: ${packet.header.connectionId}`)
+            return
+        }
+        if (this.masterPacketQueue.length === 0) {
+            this.currentPacket = packet
+            return this.processCurrentPacket()
+        }
+        if (packet.header.pType === PacketType.ST_SYN || packet.header.pType === PacketType.ST_RESET) {
+            this.masterPacketQueue.unshift(packet)
+        } else {
+            this.masterPacketQueue.push(packet)
+        }
+        this.logger.extend('HANDLE_PACKET')(`Adding ${PacketType[packet.header.pType]} packet for request ${packet.header.connectionId} to packet queue (size: ${this.masterPacketQueue.length} packets)`)
+        if (this.currentPacket === undefined) {
+            this.currentPacket = this.masterPacketQueue.shift()
+            await this.processCurrentPacket()
+        }
+    }
+
+    async processCurrentPacket() {
+        this.logger.extend('PROCESS_CURRENT_PACKET')(`Packet Queue Size: ${this.masterPacketQueue.length}`)
+        if (this.currentPacket === undefined) {
+            if (this.masterPacketQueue.length === 0) {
+                this.logger.extend('PROCESS_CURRENT_PACKET')(`No packets to process`)
+                return
+            }
+            this.currentPacket = this.masterPacketQueue.shift()
+            await this.processCurrentPacket()
+            return
+        }
+        this.logger.extend('PROCESS_CURRENT_PACKET')(`Processing ${PacketType[this.currentPacket.header.pType]} packet for request ${this.currentPacket.header.connectionId}`)
+        const request = this.lookupRequest(this.currentPacket.header.connectionId)
+        if (request === undefined) {
+            this.logger.extend('PROCESS_CURRENT_PACKET')(`Request not found for current packet - connectionId: ${this.currentPacket.header.connectionId}`)
+            this.currentPacket = this.masterPacketQueue.shift()
+            await this.processCurrentPacket()
+            return
+        }
+        await request.handleUtpPacket(this.currentPacket)
+        this.currentPacket = this.masterPacketQueue.shift()
+        await this.processCurrentPacket()
+    }
+
+    /**
+     * Closes a uTP request and processes the next request in the queue.
+     * @param connectionId connectionId of the request to close
+     */
+    async closeRequest(connectionId: number) {
+        const request = this.lookupRequest(connectionId)
+        if (request === undefined) {
+            return
+        }
+        this.logger.extend('CLOSE_REQUEST')(`Closing request ${connectionId}`)
+        delete this.requestMap[connectionId]
+    }
+    
+    closeAllRequests() {
+        this.logger.extend('CLOSE_REQUEST')(`Closing all requests for peer ${this.peerId}`)
+        for (const id of Object.keys(this.requestMap)) {
+            delete this.requestMap[Number(id)]
+        }
+        this.masterPacketQueue = []
+    }
+
+
+}
+

--- a/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
@@ -68,7 +68,7 @@ export class ContentReader {
     this.nextDataNr! = (this.nextDataNr! + 1) % 65536
     this.bytes.push(...payload)
     this.logger.extend('BYTES')(
-      `Current stream: ${this.bytes.length} / ${this.bytesExpected} bytes. ${this.bytesExpected - this.bytes.length} bytes till end of content.`,
+      `Current stream: ${this.bytes.length}${this.bytesExpected === Infinity ? '' : `/ ${this.bytesExpected}`} bytes. ${this.bytesExpected === Infinity ? 'Unknown' : this.bytesExpected - this.bytes.length} bytes till end of content.`,
     )
   }
 

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -21,6 +21,7 @@ export abstract class UtpSocket {
   type: UtpSocketType
   content: Uint8Array
   remoteAddress: ENR | INodeAddress
+  connectionId: number
   protected seqNr: number
   ackNr: number
   finNr: number | undefined
@@ -38,6 +39,7 @@ export abstract class UtpSocket {
     this.networkId = options.networkId
     this.content = options.content ?? Uint8Array.from([])
     this.remoteAddress = options.enr
+    this.connectionId = options.connectionId
     this.rcvConnectionId = options.rcvId
     this.sndConnectionId = options.sndId
     this.seqNr = options.seqNr

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -92,7 +92,11 @@ export abstract class UtpSocket {
     this.logger.extend('SEND').extend(PacketType[packet.header.pType])(
       `|| ackNr: ${packet.header.ackNr}`,
     )
-    await this.utp.send(this.remoteAddress, msg, this.networkId)
+    try {
+      await this.utp.send(this.remoteAddress, msg, this.networkId)
+    } catch (err) {
+      this.logger.extend('error')(`Error sending packet: ${err}.`)
+    }
     return msg
   }
 

--- a/packages/portalnetwork/src/wire/utp/Socket/congestionControl.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/congestionControl.ts
@@ -47,7 +47,7 @@ export class CongestionControl extends EventEmitter {
       this.logger(`cur_window full.  waiting for in-flight packets to be acked`)
       return new Promise((resolve, reject) => {
         // Abort canSend promise if DATA packets not acked in a timely manner
-        const abort = setTimeout(() => reject(false), 3000)
+        const abort = setTimeout(() => reject(false), 10000)
         this.once('canSend', () => {
           clearTimeout(abort)
           resolve(true)


### PR DESCRIPTION
## uTP Packet Queue / Request Manager

### Issue: 
- Many `uTP` streams may be opened at once with a given peer
- This means as many different `uTP` **sockets** trying to send packets to the same peer at the same time.
- `discv5` talkReq buffer ends up too full -- most `talkRequests` timeout while in the buffer

### Solution:
- #### RequestManager
  -  `PortalNetworkUtp` maintains map of `PeerId > RequestManager`
    - client.utp.requestManagers[peerId]
  - Manages all open requests **per peer**
    - `client.utp.requestManagers[peerId].requestMap: Record<RequestId, ContentRequest>`
  - Handles all packets sent to **PEER**
    - `client.utp.requestManagers[peerId].handlePacket`
  - Maintains `PacketQueue` for each **peer**
    - `client.utp.requestManagers[peerId].packetQueue: Array<Packet>`
- ### PacketQueue
  - Attribute of `RequestManager`  
  - Array of all packets sent to any open requests with a given peer
  - In order of arrival
    - SYN and RESET packets jump to front of the line
  - Processes packets 1 at a time, in order, through `ContentRequest` handlers
    - `this.requestMap[requestId].handleUtpPacket(packet)`

----

### Avoid sending other requests peers with active uTP transfers

- Code added to check if peers have active uTP transfers before including them in other operations.
  - NodeLookup
  - ContentLookup
  - BucketRefresh