### PR TITLE
Fix PONG radius return value

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -256,18 +256,6 @@ export class portal {
     ])
   }
 
-  async sendPortalNetworkResponse(
-enr: ENR,
-    requestId: bigint,
-    payload: Uint8Array,
-  ) {
-    void this._client.sendPortalNetworkResponse(
-      enr,
-      BigInt(requestId),
-      payload,
-    )
-  }
-
   async methods() {
     return methods
   }

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -6,6 +6,7 @@ import {
   FoundContent,
   NetworkId,
   NodeLookup,
+  PingPongCustomDataType,
   shortId,
 } from 'portalnetwork'
 
@@ -542,15 +543,17 @@ export class portal {
     const pong = await this._history.sendPing(encodedENR)
     if (pong) {
       this.logger(`PING/PONG successful with ${encodedENR.nodeId}`)
+      const decoded = PingPongCustomDataType.deserialize(pong.customPayload)
+      return (
+         {
+          enrSeq: Number(pong.enrSeq),
+          dataRadius: bigIntToHex(decoded.radius),
+        }
+      )
     } else {
       this.logger(`PING/PONG with ${encodedENR.nodeId} was unsuccessful`)
+      return false
     }
-    return (
-      pong && {
-        enrSeq: Number(pong.enrSeq),
-        dataRadius: bytesToHex(pong.customPayload),
-      }
-    )
   }
   async statePing(params: [string]) {
     const [enr] = params
@@ -559,15 +562,17 @@ export class portal {
     const pong = await this._state.sendPing(encodedENR)
     if (pong) {
       this.logger(`PING/PONG successful with ${encodedENR.nodeId}`)
+      const decoded = PingPongCustomDataType.deserialize(pong.customPayload)
+      return (
+        {
+          enrSeq: Number(pong.enrSeq),
+          dataRadius: bigIntToHex(decoded.radius),
+        }
+      ) 
     } else {
       this.logger(`PING/PONG with ${encodedENR.nodeId} was unsuccessful`)
+      return false
     }
-    return (
-      pong && {
-        enrSeq: Number(pong.enrSeq),
-        dataRadius: bytesToHex(pong.customPayload),
-      }
-    )
   }
   async beaconPing(params: [string]) {
     const [enr] = params
@@ -576,16 +581,19 @@ export class portal {
     const pong = await this._beacon.sendPing(encodedENR)
     if (pong) {
       this.logger(`PING/PONG successful with ${encodedENR.nodeId}`)
+     const decoded = PingPongCustomDataType.deserialize(pong.customPayload)
+      return (
+        {
+          enrSeq: Number(pong.enrSeq),
+          dataRadius: bigIntToHex(decoded.radius),
+        }
+      )
     } else {
       this.logger(`PING/PONG with ${encodedENR.nodeId} was unsuccessful`)
+      return false
     }
-    return (
-      pong && {
-        enrSeq: Number(pong.enrSeq),
-        dataRadius: bytesToHex(pong.customPayload),
-      }
-    )
   }
+
 
   // portal_*FindNodes
   async historyFindNodes(params: [string, number[]]) {


### PR DESCRIPTION
Fixes the `radius` value in RPC PING result.  

PONG mesage contains the node radius serialzied into SSZ object.  

Instead of deserializing this SSZ object and returning the radius value, we returned the serialized SSZ object as the radius.

This fixes the return value for portal_*Ping to include the correct node radius.