### PR TITLE
Fix overflow issues in `seqNr` and `ackNr`

### DIFF
--- a/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
@@ -2,7 +2,7 @@ import { VERSION } from '../Utils/constants.js'
 
 import { SelectiveAckHeaderExtension } from './Extensions.js'
 
-import type { Uint8, Uint16, Uint32 } from '../index.js'
+import type { Uint16, Uint32, Uint8 } from '../index.js'
 import type {
   HeaderInput,
   ISelectiveAckHeaderInput,

--- a/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
@@ -64,9 +64,8 @@ export class ContentReader {
   }
 
   readPacket(payload: Uint8Array) {
-    this.nextDataNr!++
-    // Reset to 0 since ackNr and seqNr are 16 bit unsigned integers
-    if (this.nextDataNr! > 65535) this.nextDataNr! = 0
+    // Wrap seqNr back to 0 when it exceeds 16-bit max integer
+    this.nextDataNr! = (this.nextDataNr! + 1) % 65536
     this.bytes.push(...payload)
     this.logger.extend('BYTES')(
       `Current stream: ${this.bytes.length} / ${this.bytesExpected} bytes. ${this.bytesExpected - this.bytes.length} bytes till end of content.`,

--- a/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/ContentReader.ts
@@ -65,6 +65,8 @@ export class ContentReader {
 
   readPacket(payload: Uint8Array) {
     this.nextDataNr!++
+    // Reset to 0 since ackNr and seqNr are 16 bit unsigned integers
+    if (this.nextDataNr! > 65535) this.nextDataNr! = 0
     this.bytes.push(...payload)
     this.logger.extend('BYTES')(
       `Current stream: ${this.bytes.length} / ${this.bytesExpected} bytes. ${this.bytesExpected - this.bytes.length} bytes till end of content.`,

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -106,6 +106,9 @@ export abstract class UtpSocket {
       extension,
     }
     opts.pType === PacketType.ST_DATA && this.seqNr++
+    if (this.seqNr > 65535) {
+      this.seqNr = 0
+    }
     return this.packetManager.createPacket<T>(params)
   }
 

--- a/packages/portalnetwork/src/wire/utp/Socket/WriteSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/WriteSocket.ts
@@ -60,7 +60,7 @@ export class WriteSocket extends UtpSocket {
     this.close()
   }
   compare(): boolean {
-    if (!this.ackNrs.includes(undefined) && this.ackNrs.length === this.writer!.dataNrs.length) {
+    if (!this.ackNrs.includes(undefined) && this.ackNrs.length === this.writer!.dataChunks.length) {
       return true
     }
     return false
@@ -71,7 +71,7 @@ export class WriteSocket extends UtpSocket {
     this._clearTimeout()
   }
   logProgress() {
-    const needed = this.writer!.dataNrs.filter((n) => !this.ackNrs.includes(n))
+    const needed = this.writer!.dataChunks.filter((n) => !this.ackNrs.includes(n[0]))
     this.logger(
       `AckNr's received (${this.ackNrs.length}/${
         this.writer!.sentChunks.length
@@ -89,9 +89,7 @@ export class WriteSocket extends UtpSocket {
         `)
   }
   updateAckNrs(ackNr: number) {
-    this.ackNrs = Object.keys(this.writer!.dataChunks)
-      .filter((n) => parseInt(n) <= ackNr)
-      .map((n) => parseInt(n))
+    this.ackNrs = this.writer!.dataChunks.filter((n) => n[0] <= ackNr).map((n) => n[0])
   }
   async sendDataPacket(bytes: Uint8Array): Promise<void> {
     this.state = ConnectionState.Connected

--- a/packages/portalnetwork/test/wire/utp/socket.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/socket.spec.ts
@@ -325,7 +325,7 @@ describe('uTP Socket Tests', async () => {
   s.logger = debug('test')
   s.content = Uint8Array.from([111, 222])
   s.setWriter(s.getSeqNr())
-  it.only('socket.compare()', () => {
+  it('socket.compare()', () => {
     s.ackNrs = [0, 1, 2, 3, 4, 5]
     s.writer!.dataChunks = [
       [0, Uint8Array.from([111])],

--- a/packages/portalnetwork/test/wire/utp/socket.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/socket.spec.ts
@@ -342,7 +342,8 @@ describe('uTP Socket Tests', async () => {
       [2, Uint8Array.from([333])],
       [3, Uint8Array.from([444])],
       [4, Uint8Array.from([555])],
-      [6, Uint8Array.from([666])],
+      [5, Uint8Array.from([666])],
+      [6, Uint8Array.from([777])],
     ]
     assert.notOk(s.compare(), 'socket.compare() returns false for mismatched ackNrs and dataNrs')
     s.ackNrs = [0, 1, 2, 3, 4, 6, 5]

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -44,9 +44,9 @@ describe('uTP Reader/Writer tests', async () => {
       Math.ceil(sampleSize / 512),
       'ContentWriter chunked',
     )
-    const totalLength = Object.values(contentChunks).reduce((acc, chunk) => acc + chunk.length, 0)
+    const totalLength = contentChunks.reduce((acc, chunk) => acc + chunk[1].length, 0)
     assert.equal(totalLength, sampleSize, 'ContentWriter chunked all bytes')
-    const packets = Object.values(contentChunks).map((chunk, i) => {
+    const packets = contentChunks.map((chunk, i) => {
       return Packet.fromOpts({
         header: {
           seqNr: i,
@@ -59,10 +59,10 @@ describe('uTP Reader/Writer tests', async () => {
           timestampMicroseconds: 0,
           wndSize: 0,
         },
-        payload: chunk,
+        payload: chunk[1],
       })
     })
-    assert.equal(packets.length, Object.values(contentChunks).length, 'Packets created')
+    assert.equal(packets.length, contentChunks.length, 'Packets created')
     let sent = 0
     for (const [i, packet] of packets.entries()) {
       reader.addPacket(packet)
@@ -87,9 +87,9 @@ describe('uTP Reader/Writer tests', async () => {
       Math.ceil(content.length / 512),
       'ContentWriter chunked',
     )
-    const totalLength = Object.values(contentChunks).reduce((acc, chunk) => acc + chunk.length, 0)
+    const totalLength = contentChunks.reduce((acc, chunk) => acc + chunk[1].length, 0)
     assert.equal(totalLength, content.length, 'ContentWriter chunked all bytes')
-    const packets = Object.values(contentChunks).map((chunk, i) => {
+    const packets = contentChunks.map((chunk, i) => {
       return Packet.fromOpts({
         header: {
           seqNr: i,
@@ -102,10 +102,10 @@ describe('uTP Reader/Writer tests', async () => {
           timestampMicroseconds: 0,
           wndSize: 0,
         },
-        payload: chunk,
+        payload: chunk[1],
       })
     })
-    assert.equal(packets.length, Object.values(contentChunks).length, 'Packets created')
+    assert.equal(packets.length, contentChunks.length, 'Packets created')
     let sent = 0
     for (const [i, packet] of packets.entries()) {
       reader.addPacket(packet)


### PR DESCRIPTION
This addresses #691. 

## The Problem
uTP sequence numbers are 16 bit unsigned integers so have a range of 0-65535.  When a sequence number reaches the maximum value, we would expect the next sequence number to be 0.  Ultralight was not checking for overflow and blithely continuing on in the sequence since we are using native Javascript `numbers` in our code rather than true 16-bit intengers.

## Solution
- Revise `contentWriter` so`dataChunks` are stored in an array of tuples of the form `[seqNr, bytes]` rather than an object keyed by the `seqNr` 
- Check for overflow in all sequence and ack number checks and updates
- Convert some `Object.keys` code to simple Array accesses (which should provide some small performance boost)
- Removes `writeSocket.dataNrs` as unnecessary