### PR TITLE
Use INodeAddress type in message handling

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -406,7 +406,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     try {
       await this.uTP.handleUtpPacket(packetBuffer, src.nodeId)
     } catch (err: any) {
-      this.logger(err.message)
+      this.logger.extend('error')(`handleUTP error: ${err.message}.  SrcId: ${src.nodeId} MultiAddr: ${src.socketAddr.toString()}`)
     }
   }
 

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -5,6 +5,15 @@ import type { AbstractLevel } from 'abstract-level'
 import type StrictEventEmitter from 'strict-event-emitter-types/types/src'
 import type { NetworkId } from '../index.js'
 import type { PortalNetworkRoutingTable } from './routingTable.js'
+import type { Multiaddr } from '@multiformats/multiaddr'
+
+/** A representation of an unsigned contactable node. */
+export interface INodeAddress {
+  /** The destination socket address. */
+  socketAddr: Multiaddr;
+  /** The destination Node Id. */
+  nodeId: NodeId;
+}
 
 export interface PortalNetworkEvents {
   NodeAdded: (nodeId: NodeId, networkId: NetworkId) => void

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -449,7 +449,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
       let response: ContentLookupResponse
       if (bytesToInt(res.subarray(0, 1)) === MessageCodes.CONTENT) {
         this.portal.metrics?.contentMessagesReceived.inc()
-        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
+        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr.nodeId)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         switch (decoded.selector) {
           case FoundContent.UTP: {
@@ -487,7 +487,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
                       (decoded.value as Uint8Array).slice(4),
                     )
                   } catch (err) {
-                    this.logger(`received invalid content from ${shortId(enr)}`)
+                    this.logger(`received invalid content from ${shortId(enr.nodeId)}`)
                     break
                   }
                   this.logger(
@@ -501,7 +501,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
                       (decoded.value as Uint8Array).slice(4),
                     )
                   } catch (err) {
-                    this.logger(`received invalid content from ${shortId(enr)}`)
+                    this.logger(`received invalid content from ${shortId(enr.nodeId)}`)
                     break
                   }
                   this.logger(
@@ -515,7 +515,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
                       (decoded.value as Uint8Array).slice(4),
                     )
                   } catch (err) {
-                    this.logger(`received invalid content from ${shortId(enr)}`)
+                    this.logger(`received invalid content from ${shortId(enr.nodeId)}`)
                     break
                   }
                   this.logger(
@@ -527,7 +527,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
                   try {
                     LightClientUpdatesByRange.deserialize((decoded.value as Uint8Array).slice(4))
                   } catch (err) {
-                    this.logger(`received invalid content from ${shortId(enr)}`)
+                    this.logger(`received invalid content from ${shortId(enr.nodeId)}`)
                     break
                   }
                   this.logger(
@@ -554,7 +554,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
       }
       // TODO Should we do anything other than ignore responses to FINDCONTENT messages that isn't a CONTENT response?
     } catch (err: any) {
-      this.logger(`Error sending FINDCONTENT to ${shortId(enr)} - ${err.message}`)
+      this.logger(`Error sending FINDCONTENT to ${shortId(enr.nodeId)} - ${err.message}`)
     }
   }
 
@@ -797,7 +797,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
         value: offerMsg,
       })
       this.logger.extend(`OFFER`)(
-        `Sent to ${shortId(enr)} with ${contentKeys.length} pieces of content`,
+        `Sent to ${shortId(enr.nodeId)} with ${contentKeys.length} pieces of content`,
       )
       const res = await this.sendMessage(enr, payload, this.networkId)
       if (res.length > 0) {
@@ -813,7 +813,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
             )
             if (requestedKeys.length === 0) {
               // Don't start uTP stream if no content ACCEPTed
-              this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr)}`)
+              this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr.nodeId)}`)
               return []
             }
             this.logger.extend(`ACCEPT`)(`ACCEPT message received with uTP id: ${id}`)
@@ -853,7 +853,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
             return msg.contentKeys
           }
         } catch (err: any) {
-          this.logger(`Error sending to ${shortId(enr)} - ${err.message}`)
+            this.logger(`Error sending to ${shortId(enr.nodeId)} - ${err.message}`)
         }
       }
     }

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -51,6 +51,7 @@ import type { Debugger } from 'debug'
 import type { AcceptMessage, FindContentMessage, OfferMessage } from '../../wire/types.js'
 import type { ContentLookupResponse } from '../types.js'
 import type { BeaconChainNetworkConfig, HistoricalSummaries, LightClientForkName } from './types.js'
+import type { INodeAddress } from '../../index.js';
 
 export class BeaconLightClientNetwork extends BaseNetwork {
   networkId: NetworkId.BeaconChainNetwork
@@ -558,7 +559,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
   }
 
   protected override handleFindContent = async (
-    src: ENR,
+    src: INodeAddress,
     requestId: bigint,
     network: Uint8Array,
     decodedContentMessage: FindContentMessage,
@@ -596,10 +597,11 @@ export class BeaconLightClientNetwork extends BaseNetwork {
         'Found value for requested content.  Larger than 1 packet.  uTP stream needed.',
       )
       const _id = randUint16()
+      const enr = this.findEnr(src.nodeId) ?? src
       await this.handleNewRequest({
         networkId: this.networkId,
         contentKeys: [decodedContentMessage.contentKey],
-        enr: src,
+        enr,
         connectionId: _id,
         requestCode: RequestCode.FOUNDCONTENT_WRITE,
         contents: value,
@@ -864,7 +866,7 @@ export class BeaconLightClientNetwork extends BaseNetwork {
    * @param requestId request ID passed in OFFER message
    * @param msg OFFER message containing a list of offered content keys
    */
-  override handleOffer = async (src: ENR, requestId: bigint, msg: OfferMessage) => {
+  override handleOffer = async (src: INodeAddress, requestId: bigint, msg: OfferMessage) => {
     this.logger.extend('OFFER')(
       `Received from ${shortId(src.nodeId, this.routingTable)} with ${
         msg.contentKeys.length

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -200,13 +200,13 @@ export class HistoryNetwork extends BaseNetwork {
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })
-    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr)}`)
+    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr.nodeId)}`)
     const res = await this.sendMessage(enr, payload, this.networkId)
 
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
         this.portal.metrics?.contentMessagesReceived.inc()
-        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
+        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr.nodeId)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         const contentKey = decodeHistoryNetworkContentKey(key)
         const contentType = contentKey.contentType
@@ -254,7 +254,7 @@ export class HistoryNetwork extends BaseNetwork {
         return response
       }
     } catch (err: any) {
-      this.logger(`Error sending FINDCONTENT to ${shortId(enr)} - ${err.message}`)
+      this.logger(`Error sending FINDCONTENT to ${shortId(enr.nodeId)} - ${err.message}`)
     }
   }
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -333,7 +333,7 @@ export abstract class BaseNetwork extends EventEmitter {
             }),
           )
 
-          this.logger.extend(`NODES`)(`Received ${enrs.length} ENRs from ${shortId(enr)}`)
+          this.logger.extend(`NODES`)(`Received ${enrs.length} ENRs from ${shortId(enr.nodeId)}`)
         }
       } catch (err: any) {
         this.logger(`Error processing NODES message: ${err.toString()}`)
@@ -416,10 +416,10 @@ export abstract class BaseNetwork extends EventEmitter {
         value: offerMsg,
       })
       this.logger.extend(`OFFER`)(
-        `Sent to ${shortId(enr)} with ${contentKeys.length} pieces of content`,
+        `Sent to ${shortId(enr.nodeId)} with ${contentKeys.length} pieces of content`,
       )
       const res = await this.sendMessage(enr, payload, this.networkId)
-      this.logger.extend(`OFFER`)(`Response from ${shortId(enr)}`)
+      this.logger.extend(`OFFER`)(`Response from ${shortId(enr.nodeId)}`)
       if (res.length > 0) {
         try {
           const decoded = PortalWireMessageType.deserialize(res)
@@ -433,7 +433,7 @@ export abstract class BaseNetwork extends EventEmitter {
             )
             if (requestedKeys.length === 0) {
               // Don't start uTP stream if no content ACCEPTed
-              this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr)}`)
+              this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr.nodeId)}`)
               return []
             }
             this.logger.extend(`OFFER`)(`ACCEPT message received with uTP id: ${id}`)
@@ -470,7 +470,7 @@ export abstract class BaseNetwork extends EventEmitter {
             return msg.contentKeys
           }
         } catch (err: any) {
-          this.logger(`Error sending to ${shortId(enr)} - ${err.message}`)
+          this.logger(`Error sending to ${shortId(enr.nodeId)} - ${err.message}`)
         }
       }
     }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -127,14 +127,20 @@ export abstract class BaseNetwork extends EventEmitter {
     networkId: NetworkId,
     utpMessage?: boolean,
   ): Promise<Uint8Array> {
-    return this.portal.sendPortalNetworkMessage(enr, payload, networkId, utpMessage)
+    try {
+      const res = await this.portal.sendPortalNetworkMessage(enr, payload, networkId, utpMessage)
+      return res
+    } catch (err: any) {
+      this.logger.extend('error')(`${err.message}`)
+      return new Uint8Array()
+    }
   }
 
   sendResponse(src: INodeAddress, requestId: bigint, payload: Uint8Array): Promise<void> {
     return this.portal.sendPortalNetworkResponse(src, requestId, payload)
   }
   findEnr(nodeId: string): ENR | undefined {
-    return this.portal.discv5.findEnr(nodeId)
+    return this.portal.discv5.findEnr(nodeId) ?? this.routingTable.getWithPending(nodeId)?.value
   }
 
   public async put(contentKey: Uint8Array, content: string) {

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -78,7 +78,7 @@ export class StateNetwork extends BaseNetwork {
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })
-    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr)}`)
+    this.logger.extend('FINDCONTENT')(`Sending to ${shortId(enr.nodeId)}`)
     const res = await this.sendMessage(enr, payload, this.networkId)
     if (res.length === 0) {
       return undefined
@@ -87,7 +87,7 @@ export class StateNetwork extends BaseNetwork {
     try {
       if (bytesToInt(res.slice(0, 1)) === MessageCodes.CONTENT) {
         this.portal.metrics?.contentMessagesReceived.inc()
-        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr)}`)
+        this.logger.extend('FOUNDCONTENT')(`Received from ${shortId(enr.nodeId)}`)
         const decoded = ContentMessageType.deserialize(res.subarray(1))
         const contentType = key[0]
         let response: ContentLookupResponse
@@ -133,7 +133,7 @@ export class StateNetwork extends BaseNetwork {
         return response
       }
     } catch (err: any) {
-      this.logger(`Error sending FINDCONTENT to ${shortId(enr)} - ${err.message}`)
+      this.logger(`Error sending FINDCONTENT to ${shortId(enr.nodeId)} - ${err.message}`)
     }
   }
 

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -6,7 +6,6 @@ import {
   bigIntToBytes,
   bytesToBigInt,
   bytesToUnprefixedHex,
-  bytesToUtf8,
   unprefixedHexToBytes,
 } from '@ethereumjs/util'
 
@@ -30,7 +29,7 @@ export const shortId = (nodeId: string | ENR, routingTable?: PortalNetworkRoutin
 
   const nodeType = enr.kvs.get('c')
   const nodeTypeString =
-    nodeType !== undefined && nodeType.length > 0 ? `${bytesToUtf8(nodeType)}:` : ''
+    nodeType !== undefined && nodeType.length > 0 ? `${nodeType.toString().split(/[ :,]/)[0]}:` : ''
   return nodeTypeString + enr.nodeId.slice(0, 5) + '...' + enr.nodeId.slice(enr.nodeId.length - 5)
 }
 

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketTyping.ts
@@ -4,6 +4,7 @@ import type { NetworkId } from '../../../networks/types.js'
 import type { PortalNetworkUTP } from '../index.js'
 import type { BasicPacketHeader, SelectiveAckHeader } from './PacketHeader.js'
 import type { Packet } from './index.js'
+import type { INodeAddress } from '../../../index.js'
 
 export const BUFFER_SIZE = 512
 export enum PacketType {
@@ -102,7 +103,7 @@ export type ICreate<T extends PacketType> = IBasic<T> | ISelectiveAck | IData
 export interface UtpSocketOptions {
   utp: PortalNetworkUTP
   networkId: NetworkId
-  enr: ENR
+  enr: ENR | INodeAddress
   sndId: number
   rcvId: number
   seqNr: number

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -139,7 +139,11 @@ export class PortalNetworkUTP {
     try {
       await this.client.sendPortalNetworkMessage(enr, msg, networkId, true)
     } catch {
-      this.closeRequest(msg.readUInt16BE(2), enr.nodeId)
+      try {
+        this.closeRequest(msg.readUInt16BE(2), enr.nodeId)
+      } catch {
+        //
+      }
     }
   }
 }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
@@ -1,6 +1,7 @@
 import type { ENR } from '@chainsafe/enr'
 
 import type { NetworkId } from '../../../networks/types.js'
+import type { INodeAddress } from '@chainsafe/discv5/lib/session/nodeInfo.js'
 
 export type UtpSocketKey = string
 
@@ -17,7 +18,7 @@ export function createSocketKey(nodeId: string, id: number) {
 export interface INewRequest {
   networkId: NetworkId
   contentKeys: Uint8Array[]
-  enr: ENR
+  enr: ENR | INodeAddress
   connectionId: number
   requestCode: RequestCode
   contents?: Uint8Array

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -6,7 +6,7 @@ import { ConnectionState, PacketType } from '../index.js'
 
 import type { ENR } from '@chainsafe/enr'
 import type { Debugger } from 'debug'
-import type { NetworkId } from '../../../index.js'
+import type { INodeAddress , NetworkId } from '../../../index.js'
 import type {
   ICreatePacketOpts,
   Packet,
@@ -20,7 +20,7 @@ export abstract class UtpSocket {
   networkId: NetworkId
   type: UtpSocketType
   content: Uint8Array
-  remoteAddress: ENR
+  remoteAddress: ENR | INodeAddress
   protected seqNr: number
   ackNr: number
   finNr: number | undefined


### PR DESCRIPTION
Fixes issue caused by #682 / #684 

Message handling must use `INodeAddress` type, since `onTalkRequest` events from `discv5` do not always contain an `ENR`.

All network message handlers were updated to use `INodeAddress`, which is all that is needed for `sendTalkResponse`.
 
----

This gets a little tricky when a new `uTP` request is created.  All `uTP` messages happen via `talkReq`, which requires an `ENR` to send.  However, there are times when the `uTP` request needs to be instantiated before the peer's `ENR` has become available.  So a new `uTP` request can be created using either `INodeAddress` or `ENR`.  In cases where we use the `INodeAddress`, we optimistically hope that by the time we need to send the first `uTP` packet, the peer's `ENR` has become available.