### PR TITLE
client: fix config object issue

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,8 @@ const main = async () => {
 
   const portal = await PortalNetwork.create(portalConfig)
 
+  log(`discv5Config: ${JSON.stringify(portal.discv5['config'], null, 2)}`)
+
   const rpcAddr = args.rpcAddr ?? ip // Set RPC address (used by metrics server and rpc server)
   let metricsServer: http.Server | undefined
 

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -143,6 +143,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       eventLog: opts.eventLog,
       utpTimeout: opts.utpTimeout,
       gossipCount: opts.gossipCount,
+      shouldRefresh: opts.shouldRefresh,
     })
     for (const network of portal.networks.values()) {
       try {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -61,6 +61,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
       },
     }
     const config = { ...defaultConfig, ...opts.config }
+    config.config = { ...defaultConfig.config, ...opts.config?.config }
     let bootnodes = opts.bootnodes
     if (opts.rebuildFromMemory === true && opts.db) {
       const prevEnrString = await opts.db.get('enr')


### PR DESCRIPTION
This fixes an issue where `discv5` was not being instantiated with configuration options set during `PortalNetwork.create`.

We define a `defaultConfig` object for `PortalNetwork.create`, and modify it using args passed to the function like this:

`const config = { ...defaultConfig, ...opts.config }`

However, this was not effectively combining configuration options set specifically for discv5 which were in nested object `config.config`.

To fix this, we add this line after the one above: 

`config.config = { ...defaultConfig.config, ...opts.config.config }`

This solves the issue, and now `discv5` starts with the expected configuration.