### PR TITLE
network.addBootNode: Check for pong before follup requests

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -823,11 +823,13 @@ export abstract class BaseNetwork extends EventEmitter {
       // Disregard attempts to add oneself as a bootnode
       return
     }
-    await this.sendPing(enr)
-    for (let x = 239; x < 256; x++) {
-      // Ask for nodes in all log2distances 239 - 256
-      if (this.routingTable.valuesOfDistance(x).length === 0) {
-        await this.sendFindNodes(enr, [x])
+    const pong = await this.sendPing(enr)
+    if (pong !== undefined) {
+      for (let x = 239; x < 256; x++) {
+        // Ask for nodes in all log2distances 239 - 256
+        if (this.routingTable.valuesOfDistance(x).length === 0) {
+          await this.sendFindNodes(enr, [x])
+        }
       }
     }
   }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -827,7 +827,7 @@ export abstract class BaseNetwork extends EventEmitter {
     if (pong !== undefined) {
       for (let x = 239; x < 256; x++) {
         // Ask for nodes in all log2distances 239 - 256
-        if (this.routingTable.valuesOfDistance(x).length === 0) {
+        if (this.routingTable.valuesOfDistance(x).length < 16 ) {
           await this.sendFindNodes(enr, [x])
         }
       }


### PR DESCRIPTION
`BaseNetwork` method `addBootNode` first Pings a boodnode, then sends FindNodes request for non-full buckets.

This method was missing a conditional which first checked if the PING was successful or not (PONG received).  This led to many unnecessary requests being sent towards peers we already knew to be unresponsive.

This adds the necessary conditional `(if pong !== undefined) {...}`, and also corrects the requests to seek nodes from non-full buckets, not just empty buckets.