### PR TITLE
PortalNetwork:  Outgoing message queue with priority

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -429,25 +429,44 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     networkId: NetworkId,
     utpMessage?: boolean,
   ): Promise<Uint8Array> => {
-    const messageNetwork = utpMessage !== undefined ? NetworkId.UTPNetwork : networkId
-    const remote = enr instanceof ENR ? enr : this.discv5.findEnr(enr.nodeId) ?? fromNodeAddress(enr.socketAddr.nodeAddress(), 'udp')
-    try {
-      this.metrics?.totalBytesSent.inc(payload.length)
-      const res = await this.discv5.sendTalkReq(
-        remote,
-        Buffer.from(payload),
-        hexToBytes(messageNetwork),
-      )
-      this.eventLog && this.emit('SendTalkReq', enr.nodeId, bytesToHex(res), bytesToHex(payload))
-      return res
-    } catch (err: any) {
-      if (networkId === NetworkId.UTPNetwork || utpMessage === true) {
-        throw new Error(`Error sending uTP TALKREQ message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err.message}`)
-      } else {
-        const messageType = PortalWireMessageType.deserialize(payload).selector
-        throw new Error(`Error sending TALKREQ ${MessageCodes[messageType]} message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err}.  NetworkId: ${networkId} NodeId: ${enr.nodeId} MultiAddr: ${enr instanceof ENR ? enr.getLocationMultiaddr('udp')?.toString() : enr.socketAddr.toString()}`)
+    // Queue requests with normal priority (0 is default)
+    return this.messageQueue.add(async () => {
+      const messageNetwork = utpMessage !== undefined ? NetworkId.UTPNetwork : networkId
+      const remote =
+        enr instanceof ENR
+          ? enr
+          : (this.discv5.findEnr(enr.nodeId) ??
+            fromNodeAddress(enr.socketAddr.nodeAddress(), 'udp'))
+      try {
+        this.metrics?.totalBytesSent.inc(payload.length)
+        const res = await this.discv5.sendTalkReq(
+          remote,
+          Buffer.from(payload),
+          hexToBytes(messageNetwork),
+        )
+        this.eventLog && this.emit('SendTalkReq', enr.nodeId, bytesToHex(res), bytesToHex(payload))
+        return res
+      } catch (err: any) {
+        if (networkId === NetworkId.UTPNetwork || utpMessage === true) {
+          throw new Error(
+            `Error sending uTP TALKREQ message using ${
+              enr instanceof ENR ? 'ENR' : 'MultiAddr'
+            }: ${err.message}`,
+          )
+        } else {
+          const messageType = PortalWireMessageType.deserialize(payload).selector
+          throw new Error(
+            `Error sending TALKREQ ${MessageCodes[messageType]} message using ${
+              enr instanceof ENR ? 'ENR' : 'MultiAddr'
+            }: ${err}.  NetworkId: ${networkId} NodeId: ${enr.nodeId} MultiAddr: ${
+              enr instanceof ENR
+                ? enr.getLocationMultiaddr('udp')?.toString()
+                : enr.socketAddr.toString()
+            }`,
+          )
+        }
       }
-    }
+    }) as Promise<Uint8Array>
   }
 
   public sendPortalNetworkResponse = async (
@@ -455,12 +474,22 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     requestId: bigint,
     payload: Uint8Array,
   ) => {
-    this.eventLog &&
-      this.emit('SendTalkResp', src.nodeId, requestId.toString(16), bytesToHex(payload))
-    try {
-      await this.discv5.sendTalkResp(src, requestId, payload)
-    } catch (err: any) {
-      this.logger.extend('error')(`Error sending TALKRESP message: ${err}.  SrcId: ${src.nodeId} MultiAddr: ${src.socketAddr.toString()}`)
-    }
+    // Queue responses with higher priority (1)
+    return this.messageQueue.add(
+      async () => {
+        this.eventLog &&
+          this.emit('SendTalkResp', src.nodeId, requestId.toString(16), bytesToHex(payload))
+        try {
+          await this.discv5.sendTalkResp(src, requestId, payload)
+        } catch (err: any) {
+          this.logger.extend('error')(
+            `Error sending TALKRESP message: ${err}.  SrcId: ${
+              src.nodeId
+            } MultiAddr: ${src.socketAddr.toString()}`,
+          )
+        }
+      },
+      { priority: 1 },
+    )
   }
 }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -5,6 +5,7 @@ import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { keys } from '@libp2p/crypto'
 import { fromNodeAddress, multiaddr } from '@multiformats/multiaddr'
 import debug from 'debug'
+import PQueue from 'p-queue'
 
 import { HistoryNetwork } from '../networks/history/history.js'
 import {
@@ -41,6 +42,7 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
   ETH: ETH
 
   shouldRefresh: boolean = true
+  private messageQueue: PQueue
 
   public static create = async (opts: Partial<PortalNetworkOpts>) => {
     const defaultConfig: IDiscv5CreateOptions = {
@@ -253,6 +255,8 @@ export class PortalNetwork extends (EventEmitter as { new (): PortalNetworkEvent
     }
     // Should refresh by default but can be disabled (e.g. in tests)
     opts.shouldRefresh === false && (this.shouldRefresh = false)
+
+    this.messageQueue = new PQueue({ concurrency: 10 })
   }
 
   /**


### PR DESCRIPTION
WIP

----

**Issue:**

BootNodes often fail to respond to census PING.  A possible cause is a heavy stream of outgoing messages creating a delay in responding to new requests.


**Solution:**

An outoing message queue that prioritizes sending `TalkResp`.  Using the `p-queue` package, we can queue both outgoing `talkReq` and `talkResp` messages, and give priority to `talkResp`

This should allow `talkResp` messages to skip the line when the queue starts to get backed up.