### PR TITLE
RPC: implement portal_*PutContent

### DIFF
--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -45,22 +45,12 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
    * @returns boolean indicating if node has previously been OFFERed `contentKey` already
    */
   public contentKeyKnownToPeer = (nodeId: NodeId, contentKey: Uint8Array) => {
-    let gossipList = this.gossipMap.get(nodeId)
-    if (!gossipList) {
-      // If no gossipList exists, create new one for `nodeId` and add contentKey to it
-      gossipList = new Set<Uint8Array>()
-      gossipList.add(contentKey)
-      this.gossipMap.set(nodeId, gossipList)
-      return false
+    const gossipList = this.gossipMap.get(nodeId)
+    if (gossipList !== undefined) {
+      const alreadyKnownToPeer = gossipList.has(contentKey)
+      if (alreadyKnownToPeer) return true
     }
-    const alreadyKnownToPeer = gossipList.has(contentKey)
-    if (alreadyKnownToPeer) return true
-    else {
-      // If contentKey has not been shared with peer, add contentKey to gossipList
-      gossipList.add(contentKey)
-      this.gossipMap.set(nodeId, gossipList)
-      return false
-    }
+    return false
   }
 
   /**

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -53,6 +53,15 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
     return false
   }
 
+  public markContentKeyAsKnownToPeer = (nodeId: NodeId, contentKey: Uint8Array) => {
+    let gossipList = this.gossipMap.get(nodeId)
+    if (!gossipList) {
+      gossipList = new Set<Uint8Array>()
+      this.gossipMap.set(nodeId, gossipList)
+    }
+    gossipList.add(contentKey)
+  }
+
   /**
    * Evict a node from the routing table and ignore
    * @param nodeId nodeId of peer to be evicted

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -854,6 +854,7 @@ export abstract class BaseNetwork extends EventEmitter {
           `Offering ${bytesToHex(contentKey)} to ${shortId(peer.nodeId)}`,
         )
         const res = await this.sendMessage(peer, payload, this.networkId)
+        this.routingTable.markContentKeyAsKnownToPeer(peer.nodeId, contentKey)
         return [peer, res]
       }),
     )


### PR DESCRIPTION
Implements RPC methods `portal_[subnetwork]PutContent`

This method "puts" content into a network by gossiping and local storage (if in radius).  The method returns a results object with a `peerCount` of the number of peers who accepted the gossip, and a boolean for `storedLocally`.

Included in this PR is a refactor of a routing table method which was the source of some bugs in testing.   `routingTable.contentKeyKnownToPeer` was simplified, and a new method: `routingTable.markContentKeyAsKnownToPeer` was added.