### PR TITLE
Utp packet heap

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -14,7 +14,7 @@ import {
   SyncStrategy,
 } from '../networks/index.js'
 import { CapacitorUDPTransportService, WebSocketTransportService } from '../transports/index.js'
-import { MEGABYTE, dirSize } from '../util/index.js'
+import { MEGABYTE, dirSize, shortId } from '../util/index.js'
 import { PortalNetworkUTP } from '../wire/utp/PortalNetworkUtp/index.js'
 
 import { DBManager } from './dbManager.js'
@@ -414,7 +414,10 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
       await this.uTP.handleUtpPacket(packetBuffer, src.nodeId)
     } catch (err: any) {
       this.logger.extend('error')(
-        `handleUTP error: ${err.message}.  SrcId: ${src.nodeId} MultiAddr: ${src.socketAddr.toString()}`,
+        
+        `handleUTP error: ${err.message}.  SrcId: ${
+          src.nodeId
+        } MultiAddr: ${src.socketAddr.toString()}`,
       )
     }
   }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -14,7 +14,7 @@ import {
   SyncStrategy,
 } from '../networks/index.js'
 import { CapacitorUDPTransportService, WebSocketTransportService } from '../transports/index.js'
-import { MEGABYTE, dirSize, shortId } from '../util/index.js'
+import { MEGABYTE, dirSize } from '../util/index.js'
 import { PortalNetworkUTP } from '../wire/utp/PortalNetworkUtp/index.js'
 
 import { DBManager } from './dbManager.js'
@@ -414,9 +414,8 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
       await this.uTP.handleUtpPacket(packetBuffer, src.nodeId)
     } catch (err: any) {
       this.logger.extend('error')(
-        
-        `handleUTP error: ${err.message}.  SrcId: ${
-          src.nodeId
+
+        `handleUTP error: ${err.message}.  SrcId: ${src.nodeId
         } MultiAddr: ${src.socketAddr.toString()}`,
       )
     }

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -2,6 +2,7 @@ import { KademliaRoutingTable } from '@chainsafe/discv5'
 
 import type { ENR, NodeId } from '@chainsafe/enr'
 import type { Debugger } from 'debug'
+import { shortId } from '../index.js'
 export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   public logger?: Debugger
   private radiusMap: Map<NodeId, bigint>
@@ -67,7 +68,7 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
    * @param nodeId nodeId of peer to be evicted
    */
   public evictNode = (nodeId: NodeId) => {
-    this.logger?.extend('EVICT')(nodeId)
+    this.logger?.extend('EVICT')(shortId(nodeId))
     let enr: ENR | undefined = this.getValue(nodeId)
     this.ignoreNode(nodeId)
     if (enr) {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -671,7 +671,7 @@ export abstract class BaseNetwork extends EventEmitter {
       return enr.encode()
     })
     if (encodedEnrs.length > 0) {
-      this.logger(`Found ${encodedEnrs.length} closer to content than us`)
+      this.logger.extend('FINDCONTENT')(`Found ${encodedEnrs.length} closer to content`)
       // TODO: Add capability to send multiple TALKRESP messages if # ENRs exceeds packet size
       while (encodedEnrs.length > 0 && arrayByteLength(encodedEnrs) > MAX_PACKET_SIZE) {
         // Remove ENRs until total ENRs less than 1200 bytes
@@ -691,7 +691,7 @@ export abstract class BaseNetwork extends EventEmitter {
         selector: FoundContent.ENRS,
         value: [],
       })
-      this.logger(`Found no ENRs closer to content than us`)
+      this.logger(`Found no ENRs closer to content`)
       await this.sendResponse(
         src,
         requestId,
@@ -712,7 +712,7 @@ export abstract class BaseNetwork extends EventEmitter {
       const nodeId = enr.nodeId
       // Only add node to the routing table if we have an ENR
       this.routingTable.getWithPending(enr.nodeId)?.value === undefined &&
-        this.logger(`adding ${nodeId} to ${this.networkName} routing table`)
+        this.logger.extend('RoutingTable')(`adding ${shortId(nodeId)}`)
       this.routingTable.insertOrUpdate(enr, EntryStatus.Connected)
       if (customPayload !== undefined) {
         const decodedPayload = PingPongCustomDataType.deserialize(Uint8Array.from(customPayload))

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -242,7 +242,7 @@ export class FoundContentWriteRequest extends ContentWriteRequest {
   async _handleStatePacket(packet: StatePacket): Promise<void> {
     await this.socket.handleStatePacket(packet.header.ackNr, packet.header.timestampMicroseconds)
     if (this.socket.state === ConnectionState.Closed) {
-      await this.requestManager.closeRequest(packet.header.connectionId)
+      this.requestManager.closeRequest(packet.header.connectionId)
     }
   }
 }
@@ -305,7 +305,7 @@ export class OfferWriteRequest extends ContentWriteRequest {
     }
     await this.socket.handleStatePacket(packet.header.ackNr, packet.header.timestampMicroseconds)
     if (this.socket.state === ConnectionState.Closed) {
-      await this.requestManager.closeRequest(packet.header.connectionId)
+       this.requestManager.closeRequest(packet.header.connectionId)
     }
   }
 }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -88,13 +88,7 @@ export abstract class ContentRequest {
     this.socket._clearTimeout()
     this.socket.updateDelay(timeReceived, packet.header.timestampMicroseconds)
     this.logger.extend('RECEIVED').extend(PacketType[packet.header.pType])(
-      `|| pktId: ${packet.header.connectionId}     ||`,
-    )
-    this.logger.extend('RECEIVED').extend(PacketType[packet.header.pType])(
-      `|| seqNr: ${packet.header.seqNr}     ||`,
-    )
-    this.logger.extend('RECEIVED').extend(PacketType[packet.header.pType])(
-      `|| ackNr: ${packet.header.ackNr}     ||`,
+      `|| pid: ${packet.header.connectionId} sNr: ${packet.header.seqNr} aNr: ${packet.header.ackNr} t: ${packet.header.timestampMicroseconds}`,
     )
     switch (packet.header.pType) {
       case PacketType.ST_SYN:

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -39,6 +39,12 @@ export class PortalNetworkUTP {
     return this.requestManagers[nodeId] !== undefined && Object.keys(this.requestManagers[nodeId].requestMap).length > 0
   }
 
+  openRequests(): number {
+    return Object.keys(this.requestManagers).reduce((acc, nodeId) => {
+      return acc + Object.keys(this.requestManagers[nodeId].requestMap).length
+    }, 0)
+  }
+
   createPortalNetworkUTPSocket(
     networkId: NetworkId,
     requestCode: RequestCode,
@@ -106,9 +112,9 @@ export class PortalNetworkUTP {
       content,
       contentKeys,
     })
-    this.logger.extend('utpRequest')(`New ${RequestCode[requestCode]} Request with ${enr.nodeId} -- ConnectionId: ${connectionId}`)
-    this.logger.extend('utpRequest')(`ConnectionId: ${connectionId} -- { socket.sndId: ${sndId}, socket.rcvId: ${rcvId} }`)
     await this.requestManagers[enr.nodeId].handleNewRequest(connectionId, newRequest)
+    this.logger.extend('utpRequest')(`New ${RequestCode[requestCode]} Request with ${enr.nodeId} -- ConnectionId: ${connectionId}`)
+    this.logger.extend('utpRequest')(`Open Requests: ${this.openRequests()}`)
     return newRequest
   }
 
@@ -125,6 +131,7 @@ export class PortalNetworkUTP {
     } catch (err) {
       this.logger.extend('error')(`Error sending message to ${enr.nodeId}: ${err}`)
       this.closeAllPeerRequests(enr.nodeId)
+      this.logger.extend('utpRequest')(`Open Requests: ${this.openRequests()}`)
       throw err
     }
   }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
@@ -23,3 +23,8 @@ export interface INewRequest {
   requestCode: RequestCode
   contents?: Uint8Array
 }
+
+
+export const MAX_IN_FLIGHT_PACKETS = 3
+
+export type RequestId = number

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -84,13 +84,7 @@ export abstract class UtpSocket {
   async sendPacket<T extends PacketType>(packet: Packet<T>): Promise<Buffer> {
     const msg = packet.encode()
     this.logger.extend('SEND').extend(PacketType[packet.header.pType])(
-      `|| pktId: ${packet.header.connectionId}`,
-    )
-    this.logger.extend('SEND').extend(PacketType[packet.header.pType])(
-      `|| seqNr: ${packet.header.seqNr}`,
-    )
-    this.logger.extend('SEND').extend(PacketType[packet.header.pType])(
-      `|| ackNr: ${packet.header.ackNr}`,
+      `pid: ${packet.header.connectionId} sNr: ${packet.header.seqNr} aNr: ${packet.header.ackNr}`,
     )
     try {
       await this.utp.send(this.remoteAddress, msg, this.networkId)

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -280,10 +280,10 @@ describe('RequestManager', () => {
       },
     })
     void mgr.handleNewRequest(req1.connectionId, req1)
-    mgr.masterPacketQueue.push(packet2)
+    mgr.packetHeap.push(packet2)
     mgr.currentPacket = packet3
     void mgr.handlePacket(packet1.encode())
-    assert.equal(mgr.masterPacketQueue.length, 2)
-    assert.deepEqual(mgr.masterPacketQueue[0], packet2)
+    assert.equal(mgr.packetHeap.size(), 2)
+    assert.deepEqual(mgr.packetHeap.peek(), packet2)
   })
 })


### PR DESCRIPTION
Replaces uTP Packet Queue array with `Heap` from `heap-js`.

Heap will sort packets waiting in queue so that out-of-order packets are reordered.  This will cut back on unnecessary `Selective Ack` responses.

When receiving streams, especially from `Trin` nodes, we often receive pairs of packets with identical timestamps, and regularly end up processing them in the wrong order.  
  - For example, we receive packets 1 and 2 simultaneously, but process packet 2 then packet 1.  Next we recieve 3 and 4, but process 4 before 3.
  - This results in a lot of extra packets being exchanged due the the `Selective Ack` function.  We report every other packet at missing, even though it isn't.  So We get multiples of every other packet and send extra `ACK` packets.

The `processCurrentPacket` method was updated to skip repeat packets, and to requeue packets that arrive ahead of the current reader position.  This update allows the packet-pair phenomenon to self correct.


Also updated and improved some logs, and added a method to report the total number of open uTP streams.