### PR TITLE
uTP:  concurrent request limit

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -490,13 +490,13 @@ export abstract class BaseNetwork extends EventEmitter {
         msg.contentKeys.length
       } pieces of content.`,
     )
+    const contentIds: boolean[] = Array(msg.contentKeys.length).fill(false)
     if (this.portal.uTP.openRequests() > BaseNetwork.MAX_CONCURRENT_UTP_STREAMS) {
       this.logger.extend('OFFER')(`Too many open UTP streams - rejecting offer`)
-      return this.sendAccept(src, requestId, [], [])
+      return this.sendAccept(src, requestId, contentIds, [])
 
     }
     try {
-      const contentIds: boolean[] = Array(msg.contentKeys.length).fill(false)
       let offerAccepted = false
       try {
         for (let x = 0; x < msg.contentKeys.length; x++) {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -54,6 +54,7 @@ import type {
 import { GossipManager } from './gossip.js'
 
 export abstract class BaseNetwork extends EventEmitter {
+  static MAX_CONCURRENT_UTP_STREAMS = 50
   public routingTable: PortalNetworkRoutingTable
   public nodeRadius: bigint
   public db: NetworkDB
@@ -489,6 +490,11 @@ export abstract class BaseNetwork extends EventEmitter {
         msg.contentKeys.length
       } pieces of content.`,
     )
+    if (this.portal.uTP.openRequests() > BaseNetwork.MAX_CONCURRENT_UTP_STREAMS) {
+      this.logger.extend('OFFER')(`Too many open UTP streams - rejecting offer`)
+      return this.sendAccept(src, requestId, [], [])
+
+    }
     try {
       const contentIds: boolean[] = Array(msg.contentKeys.length).fill(false)
       let offerAccepted = false

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -39,6 +39,12 @@ export class PortalNetworkUTP {
     return this.requestManagers[nodeId] !== undefined && Object.keys(this.requestManagers[nodeId].requestMap).length > 0
   }
 
+  openRequests(): number {
+    return Object.keys(this.requestManagers).reduce((acc, nodeId) => {
+      return acc + Object.keys(this.requestManagers[nodeId].requestMap).length
+    }, 0)
+  }
+
   createPortalNetworkUTPSocket(
     networkId: NetworkId,
     requestCode: RequestCode,
@@ -106,9 +112,9 @@ export class PortalNetworkUTP {
       content,
       contentKeys,
     })
-    this.logger.extend('utpRequest')(`New ${RequestCode[requestCode]} Request with ${enr.nodeId} -- ConnectionId: ${connectionId}`)
-    this.logger.extend('utpRequest')(`ConnectionId: ${connectionId} -- { socket.sndId: ${sndId}, socket.rcvId: ${rcvId} }`)
     await this.requestManagers[enr.nodeId].handleNewRequest(connectionId, newRequest)
+    this.logger.extend('utpRequest')(`New ${RequestCode[requestCode]} Request with ${enr.nodeId} -- ConnectionId: ${connectionId}`)
+    this.logger.extend('utpRequest')(`Open Requests: ${this.openRequests()}`)
     return newRequest
   }
 
@@ -125,6 +131,7 @@ export class PortalNetworkUTP {
     } catch (err) {
       this.logger.extend('error')(`Error sending message to ${enr.nodeId}: ${err}`)
       this.closeAllPeerRequests(enr.nodeId)
+      this.logger.extend('utpRequest')(`Open Requests: ${this.openRequests()}`)
       throw err
     }
   }


### PR DESCRIPTION
Limits the total number of active uTP streams to `MAX_CONCURRENT_UTP_STREAMS`.  

Limit defaults to 50.  Chosen to match default set by other clients.

New OFFERs will be rejected while number of active requests is at this limit.