### PR TITLE
Beacon: fix PutContent

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -804,15 +804,15 @@ export class portal {
   }
   async statePutContent(params: [string, string]) {
     const [contentKey, content] = params.map((param) => hexToBytes(param))
-    const contentId = this._history.contentKeyToId(contentKey)
+    const contentId = this._state.contentKeyToId(contentKey)
     const d = distance(contentId, this._client.discv5.enr.nodeId)
     let storedLocally = false
     try {
-      if (d <= this._history.nodeRadius) {
-        await this._history.store(contentKey, content)
+      if (d <= this._state.nodeRadius) {
+        await this._state.store(contentKey, content)
         storedLocally = true
       }
-      const peerCount = await this._history.gossipContent(contentKey, content)
+      const peerCount = await this._state.gossipContent(contentKey, content)
       return {
         peerCount,
         storedLocally,
@@ -826,13 +826,18 @@ export class portal {
   }
   async beaconPutContent(params: [string, string]) {
     const [contentKey, content] = params.map((param) => hexToBytes(param))
-    const contentId = this._history.contentKeyToId(contentKey)
+    const contentId = this._beacon.contentKeyToId(contentKey)
     const d = distance(contentId, this._client.discv5.enr.nodeId)
     let storedLocally = false
     try {
-      if (d <= this._history.nodeRadius) {
-        await this._history.store(contentKey, content)
+      if (d <= this._beacon.nodeRadius) {
+        await this._beacon.store(contentKey, content)
         storedLocally = true
+      }
+      const peerCount = await this._beacon.gossipContent(contentKey, content)
+      return {
+        peerCount,
+        storedLocally,
       }
     } catch {
       return {

--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -974,7 +974,6 @@ export class portal {
     this.logger.extend('stateGetContent')(`request received for ${contentKey}`)
     const lookup = new ContentLookup(this._state, hexToBytes(contentKey))
     const res = await lookup.startLookup()
-    this.logger.extend('stateGetContent')(`request returned ${JSON.stringify(res)}`)
     if (!res) {
       this.logger.extend('stateGetContent')(`request returned { enrs: [] }`)
       throw new Error('No content found')

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -391,10 +391,10 @@ export class BeaconLightClientNetwork extends BaseNetwork {
           )
           if (value !== undefined) {
             const decoded = hexToBytes(value)
-            // const forkhash = decoded.slice(0, 4) as Uint8Array
-            // const forkname = this.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
+            const forkHash = decoded.slice(0, 4) as Uint8Array
+            const forkName = this.beaconConfig.forkDigest2ForkName(forkHash) as LightClientForkName
             if (
-              ssz[ForkName.capella].LightClientFinalityUpdate.deserialize(decoded.slice(4))
+              ssz[ForkName[forkName]].LightClientFinalityUpdate.deserialize(decoded.slice(4))
                 .finalizedHeader.beacon.slot < Number(key.finalitySlot)
             ) {
               // If what we have stored locally is older than the finality update requested, don't send it
@@ -732,9 +732,9 @@ export class BeaconLightClientNetwork extends BaseNetwork {
     if (typeof input === 'number') {
       period = input
     } else {
-      // const forkhash = input.slice(0, 4) as Uint8Array
-      // const forkname = this.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
-      const deserializedUpdate = ssz[ForkName.capella].LightClientUpdate.deserialize(
+      const forkhash = input.slice(0, 4) as Uint8Array
+      const forkName = this.beaconConfig.forkDigest2ForkName(forkhash) as LightClientForkName
+      const deserializedUpdate = ssz[ForkName[forkName]].LightClientUpdate.deserialize(
         input.slice(4),
       ) as LightClientUpdate
       period = computeSyncPeriodAtSlot(deserializedUpdate.attestedHeader.beacon.slot)


### PR DESCRIPTION
Fixes issues with `portal_beaconPutContent` and `portal_statePutContent`

Also fixes ssz bug in `beacon.store` by reactivating the `forkName` parsing.  This had been commented out because tests were failing.  With the tests fixed, this code is necessary.

Also deletes a duplicate log from `state_getContent`