### PR TITLE
uTP: compare AckNr's for ST_STATE packets

### DIFF
--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
@@ -6,9 +6,9 @@ import { Heap } from "heap-js";
 import { MAX_IN_FLIGHT_PACKETS, type RequestId } from "./types.js";
 
 const packetComparator: Comparator<Packet<PacketType>> = (a: Packet<PacketType>, b: Packet<PacketType>) => {
-    // If packets belong to the same connection, sort by sequence number
+    // If packets belong to the same connection, sort by sequence number (or ackNr for ST_STATE packets)
     if (a.header.connectionId === b.header.connectionId) {
-        return a.header.seqNr - b.header.seqNr;
+        return a.header.pType === PacketType.ST_STATE ? a.header.ackNr - b.header.ackNr : a.header.seqNr - b.header.seqNr;
     }
     // Otherwise, sort by timestamp
     return a.header.timestampMicroseconds - b.header.timestampMicroseconds;

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
@@ -90,7 +90,7 @@ export class RequestManager {
         } else {
             this.packetHeap.push(packet)
         }
-        this.logger.extend('HANDLE_PACKET')(`Adding ${PacketType[packet.header.pType]} [${packet.header.seqNr}] for Req:${packet.header.connectionId} to queue (size: ${this.packetHeap.size()} packets)`)
+        this.logger.extend('HANDLE_PACKET')(`Adding ${PacketType[packet.header.pType]} [${packet.header.pType === PacketType.ST_STATE ? packet.header.ackNr : packet.header.seqNr}] for Req:${packet.header.connectionId} to queue (size: ${this.packetHeap.size()} packets)`)
         if (this.currentPacket === undefined) {
             this.currentPacket = this.packetHeap.pop()
             await this.processCurrentPacket()
@@ -108,7 +108,7 @@ export class RequestManager {
             await this.processCurrentPacket()
             return
         }
-        this.logger.extend('PROCESS_CURRENT_PACKET')(`Processing ${PacketType[this.currentPacket.header.pType]} [${this.currentPacket.header.seqNr}] for Req:${this.currentPacket.header.connectionId}`)
+        this.logger.extend('PROCESS_CURRENT_PACKET')(`Processing ${PacketType[this.currentPacket.header.pType]} [${this.currentPacket.header.pType === PacketType.ST_STATE ? this.currentPacket.header.ackNr : this.currentPacket.header.seqNr}] for Req:${this.currentPacket.header.connectionId}`)
         const request = this.lookupRequest(this.currentPacket.header.connectionId)
         if (request === undefined) {
             this.logger.extend('PROCESS_CURRENT_PACKET')(`Request not found for current packet - connectionId: ${this.currentPacket.header.connectionId}`)

--- a/packages/portalnetwork/src/wire/utp/Socket/WriteSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/WriteSocket.ts
@@ -71,7 +71,7 @@ export class WriteSocket extends UtpSocket {
     this._clearTimeout()
   }
   logProgress() {
-    const needed = this.writer!.dataChunks.filter((n) => !this.ackNrs.includes(n[0]))
+    const needed = this.writer!.dataChunks.filter((n) => !this.ackNrs.includes(n[0])).map((n) => n[0])
     this.logger(
       `AckNr's received (${this.ackNrs.length}/${
         this.writer!.sentChunks.length


### PR DESCRIPTION
This is a fix for PR: #702 

When sorting incoming packets, the uTP packet heap sorts packets from the same request by `seqNr`.

This fails during outgoing uTP streams, since the `seqNr` of ST_STATE (ack) packets does not increment.  Instead, we should sort these packets by `ackNr`.

Also adjusted the logging for these packets to display ackNr.

Also fixed a bug in the logging of expected ackNr's (needed).  