### PR TITLE
Blacklist via RateLimiter

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -32,6 +32,7 @@ import type {
   PortalNetworkOpts,
 } from './types.js'
 import { MessageCodes, PortalWireMessageType } from '../wire/types.js'
+import { RateLimiter } from '../transports/rateLimiter.js'
 
 export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
   eventLog: boolean
@@ -132,6 +133,11 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
         config.transport = new CapacitorUDPTransportService(ma, config.enr.nodeId)
         break
       case TransportLayer.NODE:
+        config.transport = new UDPTransportService({
+          bindAddrs: config.bindAddrs,
+          nodeId: config.enr.nodeId,
+          rateLimiter: new RateLimiter(),
+        })
         break
     }
 

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from 'eventemitter3'
-import { Discv5 } from '@chainsafe/discv5'
+import { Discv5, UDPTransportService } from '@chainsafe/discv5'
 import { ENR, SignableENR } from '@chainsafe/enr'
 import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { keys } from '@libp2p/crypto'
+import type { Multiaddr } from '@multiformats/multiaddr'
 import { fromNodeAddress, multiaddr } from '@multiformats/multiaddr'
 import debug from 'debug'
 
@@ -473,5 +474,23 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
     } catch (err: any) {
       this.logger.extend('error')(`Error sending TALKRESP message: ${err}.  SrcId: ${src.nodeId} MultiAddr: ${src.socketAddr.toString()}`)
     }
+  }
+
+  public addToBlackList = (ma: Multiaddr) => {
+    (<RateLimiter>(
+      (<UDPTransportService>this.discv5.sessionService.transport)['rateLimiter']
+    )).addToBlackList(ma.nodeAddress().address)
+  }
+
+  public isBlackListed = (ma: Multiaddr) => {
+    return (<RateLimiter>(
+      (<UDPTransportService>this.discv5.sessionService.transport)['rateLimiter']
+    )).isBlackListed(ma.nodeAddress().address)
+  }
+
+  public removeFromBlackList = (ma: Multiaddr) => {
+    (<RateLimiter>(
+      (<UDPTransportService>this.discv5.sessionService.transport)['rateLimiter']
+    )).removeFromBlackList(ma.nodeAddress().address)
   }
 }

--- a/packages/portalnetwork/src/transports/rateLimiter.ts
+++ b/packages/portalnetwork/src/transports/rateLimiter.ts
@@ -1,0 +1,51 @@
+type IPAddress = string
+
+export interface IRateLimiter {
+  allowEncodedPacket(ip: IPAddress): boolean
+  addExpectedResponse(ip: IPAddress): void
+  removeExpectedResponse(ip: IPAddress): void
+}
+
+const DEFAULT_BLACKLIST_DURATION = 1000 * 60 * 60 * 24 // 24 hours
+
+export class RateLimiter implements IRateLimiter {
+  private blackListed: Set<IPAddress> = new Set<IPAddress>()
+  private blackListTimeouts: Map<IPAddress, ReturnType<typeof setTimeout>> = new Map<
+    IPAddress,
+    ReturnType<typeof setTimeout>
+  >()
+  constructor() {}
+
+  public allowEncodedPacket(ip: IPAddress): boolean {
+    return !this.blackListed.has(ip)
+  }
+
+  public addExpectedResponse(_ip: IPAddress): void {
+    return
+  }
+
+  public removeExpectedResponse(_ip: IPAddress): void {
+    return
+  }
+
+  public addToBlackList(ip: IPAddress): void {
+    this.blackListed.add(ip)
+    this.blackListTimeouts.set(
+      ip,
+      setTimeout(() => {
+        this.blackListed.delete(ip)
+        this.blackListTimeouts.delete(ip)
+      }, DEFAULT_BLACKLIST_DURATION),
+    )
+  }
+
+  public removeFromBlackList(ip: IPAddress): void {
+    clearTimeout(this.blackListTimeouts.get(ip))
+    this.blackListTimeouts.delete(ip)
+    this.blackListed.delete(ip)
+  }
+
+  public isBlackListed(ip: IPAddress): boolean {
+    return this.blackListed.has(ip)
+  }
+}

--- a/packages/portalnetwork/test/integration/blacklist.spec.ts
+++ b/packages/portalnetwork/test/integration/blacklist.spec.ts
@@ -1,0 +1,67 @@
+import { SignableENR } from "@chainsafe/enr"
+import { keys } from "@libp2p/crypto"
+import { multiaddr } from "@multiformats/multiaddr"
+import { hexToBytes } from "ethereum-cryptography/utils"
+import { assert, describe, it } from "vitest"
+import type { HistoryNetwork } from "../../src";
+import { NetworkId, PortalNetwork, TransportLayer } from "../../src/index.js"
+const privateKeys = [
+    '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
+    '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
+  ]
+const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
+const enr1 = SignableENR.createFromPrivateKey(pk1)
+const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
+const enr2 = SignableENR.createFromPrivateKey(pk2)
+
+describe('black list test', async () => {
+  const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5030`)
+  enr1.setLocationMultiaddr(initMa)
+  const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/5031`)
+  enr2.setLocationMultiaddr(initMa2)
+  const node1 = await PortalNetwork.create({
+    transport: TransportLayer.NODE,
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+    config: {
+      enr: enr1,
+      bindAddrs: {
+        ip4: initMa,
+      },
+      privateKey: pk1,
+    },
+  })
+  const node2 = await PortalNetwork.create({
+    transport: TransportLayer.NODE,
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+    config: {
+      enr: enr2,
+      bindAddrs: {
+        ip4: initMa2,
+      },
+      privateKey: pk2,
+    },
+  })
+
+  await node1.start()
+  await node2.start()
+  const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+  const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+  const pong = await network1?.sendPing(network2?.enr!.toENR())
+  it('should ping peer', () => {
+    assert.isDefined(pong)
+  })
+  node1.addToBlackList(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  it('should blacklist peer', () => {
+    assert.isTrue(node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!))
+  })
+  const pong2 = await network2?.sendPing(network1?.enr!.toENR())
+  it('blacklisted peer should not be able to ping', () => {
+    assert.isUndefined(pong2)
+  })
+  it('should remove peer from blacklist', async () => {
+    node1.removeFromBlackList(node2.discv5.enr.getLocationMultiaddr('udp')!)
+    assert.isFalse(node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!))
+    const pong3 = await network2?.sendPing(network1?.enr!.toENR())
+    assert.isDefined(pong3)
+  })
+})


### PR DESCRIPTION
Implements a solution for blacklisting nodes at the UDP level.

The `UDPTransportService` class is the default `transport` layer used by discv5 to interact with UDP sockets.

This class can be constructed with an object called `RateLimiter`.  If `transport.rateLimiter` exists, `transport.handleIncomingPacket` will check `rateLimiter.allowEncodedPacket` before processing incoming packets.

This PR introduces a custom `RateLimiter` which will maintain a set of blacklisted IP addresses.  When `tranport.handleIncomingPacket` calls `rateLimiter.allowEncodedPacket`, the `RateLimiter` will check this set of blacklisted IP addresses before allowing the packet to be processed.

This now allows us to blacklist peers on the UDP level.

Previously, Ultralight could add a peer to `routingTable.ignored`, which prevents us from sending new requests to peers that have been unresponsive.  `RateLimiter` allows us to block **incoming** messages from banned peers.

Currently the timeout for blacklisting is set at 24 hours.