### PR TITLE
uTP:  Handle cases of unexpected packets

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -391,11 +391,6 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
   ) => {
     this.metrics?.totalBytesReceived.inc(message.request.length)
     if (bytesToHex(message.protocol) === NetworkId.UTPNetwork) {
-      if (!this.discv5.findEnr(nodeAddress.nodeId)) {
-        this.logger.extend('TalkReq').extend('error')(`Received uTP packet from unknown node: ${nodeAddress.nodeId}. Adding to blacklist.`)
-        this.addToBlackList(nodeAddress.socketAddr)
-        return
-      }
       await this.handleUTP(nodeAddress, message, message.request)
       return
     }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -391,6 +391,11 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
   ) => {
     this.metrics?.totalBytesReceived.inc(message.request.length)
     if (bytesToHex(message.protocol) === NetworkId.UTPNetwork) {
+      if (!this.discv5.findEnr(nodeAddress.nodeId)) {
+        this.logger.extend('TalkReq').extend('error')(`Received uTP packet from unknown node: ${nodeAddress.nodeId}. Adding to blacklist.`)
+        this.addToBlackList(nodeAddress.socketAddr)
+        return
+      }
       await this.handleUTP(nodeAddress, message, message.request)
       return
     }
@@ -416,13 +421,18 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
    * @param packetBuffer uTP packet encoded to Buffer
    */
   private handleUTP = async (src: INodeAddress, msg: ITalkReqMessage, packetBuffer: Buffer) => {
+    if (this.uTP.requestManagers[src.nodeId] === undefined) {
+      this.logger.extend('handleUTP').extend('error')(`Received uTP packet from peer with no uTP stream history: ${src.nodeId}.  Blacklisting peer.`)
+      this.addToBlackList(src.socketAddr)
+      return
+    }
     await this.sendPortalNetworkResponse(src, msg.id, new Uint8Array())
     try {
-      await this.uTP.handleUtpPacket(packetBuffer, src.nodeId)
+      await this.uTP.handleUtpPacket(packetBuffer, src)
     } catch (err: any) {
       this.logger.extend('error')(
-
-        `handleUTP error: ${err.message}.  SrcId: ${src.nodeId
+        `handleUTP error: ${err.message}.  SrcId: ${
+          src.nodeId
         } MultiAddr: ${src.socketAddr.toString()}`,
       )
     }
@@ -442,7 +452,10 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
     utpMessage?: boolean,
   ): Promise<Uint8Array> => {
     const messageNetwork = utpMessage !== undefined ? NetworkId.UTPNetwork : networkId
-    const remote = enr instanceof ENR ? enr : this.discv5.findEnr(enr.nodeId) ?? fromNodeAddress(enr.socketAddr.nodeAddress(), 'udp')
+    const remote =
+      enr instanceof ENR
+        ? enr
+        : (this.discv5.findEnr(enr.nodeId) ?? fromNodeAddress(enr.socketAddr.nodeAddress(), 'udp'))
     try {
       this.metrics?.totalBytesSent.inc(payload.length)
       const res = await this.discv5.sendTalkReq(
@@ -454,10 +467,14 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
       return res
     } catch (err: any) {
       if (networkId === NetworkId.UTPNetwork || utpMessage === true) {
-        throw new Error(`Error sending uTP TALKREQ message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err.message}`)
+        throw new Error(
+          `Error sending uTP TALKREQ message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err.message}`,
+        )
       } else {
         const messageType = PortalWireMessageType.deserialize(payload).selector
-        throw new Error(`Error sending TALKREQ ${MessageCodes[messageType]} message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err}.  NetworkId: ${networkId} NodeId: ${enr.nodeId} MultiAddr: ${enr instanceof ENR ? enr.getLocationMultiaddr('udp')?.toString() : enr.socketAddr.toString()}`)
+        throw new Error(
+          `Error sending TALKREQ ${MessageCodes[messageType]} message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err}.  NetworkId: ${networkId} NodeId: ${enr.nodeId} MultiAddr: ${enr instanceof ENR ? enr.getLocationMultiaddr('udp')?.toString() : enr.socketAddr.toString()}`,
+        )
       }
     }
   }
@@ -472,7 +489,9 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
     try {
       await this.discv5.sendTalkResp(src, requestId, payload)
     } catch (err: any) {
-      this.logger.extend('error')(`Error sending TALKRESP message: ${err}.  SrcId: ${src.nodeId} MultiAddr: ${src.socketAddr.toString()}`)
+      this.logger.extend('error')(
+        `Error sending TALKRESP message: ${err}.  SrcId: ${src.nodeId} MultiAddr: ${src.socketAddr.toString()}`,
+      )
     }
   }
 

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
@@ -105,8 +105,9 @@ export class RequestManager {
           packet.header.pType === PacketType.ST_SYN ||
           packet.header.pType === PacketType.ST_RESET
         ) {
+            const packetType = packet.header.pType === PacketType.ST_SYN ? 'SYN' : 'RESET'
           this.logger.extend('HANDLE_PACKET')(
-            `Processing SYN packet for Req:${packet.header.connectionId}`,
+            `Processing ${packetType} packet for Req:${packet.header.connectionId}`,
           )
           await request.handleUtpPacket(packet)
           return

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
@@ -155,7 +155,7 @@ export class RequestManager {
         }
         this.logger.extend('CLOSE_REQUEST')(`Closing request ${connectionId}`)
         this.removeRequestPackets(connectionId)
-        delete this.requestMap[connectionId]
+        this.requestMap[connectionId] = 'closed'
     }
 
     closeAllRequests() {


### PR DESCRIPTION
This PR implements solutions for cases where Ultralight receives a `uTP` packet for a closed or non-existent connection.

Previously Ultralight would ignore these packets on the `uTP` level.  The packet arrives via `talkReq`, UL responds with `talkResp`, and sends the packet to the `uTP` packet queue to process.  During `handleCurrentPacket`, `uTP` would find no open request for the packet, and simply throw it away and move on to the next packet in the queue.  

There are generally 3 scenarios where this may occur:

1. We completed a `uTP` stream, sending a FIN-ACK packet to close the stream, but our peer failed to receive this packet.  Since the peer still believes the connection to be open, they resend the FIN packet one or more times, attempting to complete the transfer.  
2. We aborted a `uTP` stream, sending a RESET packet to close the stream, but our peer failed to receive the RESET.  Unaware that we have closed our end, they continue to send packets, awaiting a reply that will never come.
3. A malicious peer sends bogus `uTP` packets as a DoS attack.

In the first 2 scenarios, we are dealing with a well-meaning peer who is behaving as expected, unaware that packet-loss has corrupted the connection.  The proper response in these cases should be to send this peer a RESET packet, so that they know to close the connection on their side.

In the attack scenario, we waste resources by processing the malicious packets and responding with our own RESET packets.  For each malicious packet, we would be responding with 2 of our own packets (talkResp, and RESET).  With no safeguards, a bad actor could send infinite malicious packets as a DoS attack.

PR: #712  enabled Ultralight to **BLACKLIST** peers on the UDP level.  UDP packets from a blacklisted peer will never be processed by the client.

This PR modifies `uTP` to respond with BLACKLIST when an unexpected packet can't be traced to a closed connection, and to respond with RESET when a packet arrives for a previously closed stream.   An exception to this is when receiving a RESET packet for an already closed connection.  In that case we do not send a RESET, as this could result in an infinite RESET loop between peers.


This should improve network health by closing connections that linger open, and improve client health by safeguarding against this DoS attack vector.