### PR TITLE
Get block by hash loop

### DIFF
--- a/packages/portalnetwork/src/client/eth.ts
+++ b/packages/portalnetwork/src/client/eth.ts
@@ -75,12 +75,6 @@ export class ETH {
       lookupResponse = await lookup.startLookup()
       this.logger.extend('getBlockByHash')(lookupResponse)
       if (!lookupResponse || !('content' in lookupResponse)) {
-        // Header not found by hash, try to find by number if known
-        const blockNumber = this.history!.blockHashToNumber(blockHash)
-        if (blockNumber !== undefined) {
-          const block = await this.getBlockByNumber(blockNumber, includeTransactions)
-          return block
-        }
         return undefined
       } else {
         header = lookupResponse.content
@@ -177,13 +171,9 @@ export class ETH {
         // Body not found by hash.  Reassemble block without body
         return reassembleBlock(header)
       }
-    } else {
-      // Header not found by number.  If block hash is known, search for header by hash
-      const blockHash = this.history!.blockNumberToHash(BigInt(blockNumber))
-      if (blockHash !== undefined) {
-        return this.getBlockByHash(blockHash, includeTransactions)
-      }
     }
+    // Block not found by number
+    return undefined
   }
 
   /**

--- a/packages/portalnetwork/test/client/eth/ethGetBlockByHash.spec.ts
+++ b/packages/portalnetwork/test/client/eth/ethGetBlockByHash.spec.ts
@@ -1,15 +1,18 @@
 import { assert, describe, it } from 'vitest'
-import { randomBytes } from '@ethereumjs/util'
+import { hexToBytes } from '@ethereumjs/util'
 import { PortalNetwork } from '../../../src/client/client.js'
 import { NetworkId } from '../../../src/networks/types.js'
 
 import type { HistoryNetwork } from '../../../src/networks/history/history.js'
-describe('ETH class base level API checks', async () => {
+describe('getBlockByHash', async () => {
     const ultralight = await PortalNetwork.create({
         bindAddress: '127.0.0.1',
     })
-    it('should get stuck in an infinite loop', async () => {
-        const block = await ultralight.ETH.getBlockByHash(randomBytes(32), false)
-        console.log('Block', block)
-    })
+    it('should not find a block by hash', async () => {
+        const blockHash = '0x1e98ea9bdf6e44eaed730041682e7db748812d5baef84a38435c8ad5f6c5d1e2'
+        const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+        await history.indexBlockHash(21591997n, blockHash)
+        const block = await ultralight.ETH.getBlockByHash(hexToBytes(blockHash), false)
+        assert.equal(block, undefined)
+    }, 3000)
 })

--- a/packages/portalnetwork/test/client/eth/ethGetBlockByHash.spec.ts
+++ b/packages/portalnetwork/test/client/eth/ethGetBlockByHash.spec.ts
@@ -1,0 +1,15 @@
+import { assert, describe, it } from 'vitest'
+import { randomBytes } from '@ethereumjs/util'
+import { PortalNetwork } from '../../../src/client/client.js'
+import { NetworkId } from '../../../src/networks/types.js'
+
+import type { HistoryNetwork } from '../../../src/networks/history/history.js'
+describe('ETH class base level API checks', async () => {
+    const ultralight = await PortalNetwork.create({
+        bindAddress: '127.0.0.1',
+    })
+    it('should get stuck in an infinite loop', async () => {
+        const block = await ultralight.ETH.getBlockByHash(randomBytes(32), false)
+        console.log('Block', block)
+    })
+})

--- a/packages/portalnetwork/test/client/eth/getBlockBy.spec.ts
+++ b/packages/portalnetwork/test/client/eth/getBlockBy.spec.ts
@@ -14,5 +14,13 @@ describe('getBlockByHash', async () => {
         await history.indexBlockHash(21591997n, blockHash)
         const block = await ultralight.ETH.getBlockByHash(hexToBytes(blockHash), false)
         assert.equal(block, undefined)
-    }, 3000)
+    })
+    it('should not find a block by number', async () => {
+        const blockNumber = 21591997n
+        const blockHash = '0x1e98ea9bdf6e44eaed730041682e7db748812d5baef84a38435c8ad5f6c5d1e2'
+        const history = ultralight.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+        await history.indexBlockHash(blockNumber, blockHash)
+        const block = await ultralight.ETH.getBlockByNumber(blockNumber, false)
+        assert.equal(block, undefined)
+    })
 })


### PR DESCRIPTION
Removes fallback pattern where `getBlockByHash` and `getBlockByNumber` would try to retrieve via number or hash respectively if the direct retrieval failed as this caused infinite looping searches for a block.

Fixes #716