### PR TITLE
WIP: REPL Interface for Portal Network

### DIFF
--- a/packages/portalnetwork/examples/portalClient.ts
+++ b/packages/portalnetwork/examples/portalClient.ts
@@ -1,0 +1,120 @@
+import { SignableENR, ENR } from '@chainsafe/enr'
+import { keys } from '@libp2p/crypto'
+import { multiaddr } from '@multiformats/multiaddr'
+import { PortalNetwork, NetworkId, TransportLayer, HistoryNetwork, StateNetwork } from '../../portalnetwork/src'
+import repl from 'repl'
+
+class PortalNetworkRepl {
+  private node?: PortalNetwork
+  private historyNetwork?: any
+  private stateNetwork?: any
+
+  async init(port = 9090): Promise<void> {
+    const privateKey = await keys.generateKeyPair('secp256k1')
+    const enr = SignableENR.createFromPrivateKey(privateKey)
+    const nodeAddr = multiaddr(`/ip4/127.0.0.1/udp/${port}`)
+    enr.setLocationMultiaddr(nodeAddr)
+
+    this.node = await PortalNetwork.create({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [
+        { networkId: NetworkId.HistoryNetwork },
+        { networkId: NetworkId.StateNetwork },
+      ],
+      config: {
+        enr,
+        bindAddrs: { ip4: nodeAddr },
+        privateKey,
+      },
+    })
+
+    this.historyNetwork = new HistoryNetwork({
+          client: this.node,
+          networkId: NetworkId.HistoryNetwork
+        })
+        this.stateNetwork = new StateNetwork({
+          client: this.node,
+          networkId: NetworkId.StateNetwork
+        })
+    
+        this.node.networks[NetworkId.HistoryNetwork] = this.historyNetwork
+        this.node.networks[NetworkId.StateNetwork] = this.stateNetwork
+
+    await this.node.start()
+    this.node.enableLog('*Portal*,*uTP*,*discv5*')
+
+    // this.historyNetwork = this.node.networks[NetworkId.HistoryNetwork]
+    // this.stateNetwork = this.node.networks[NetworkId.StateNetwork]
+
+    this.startRepl()
+  }
+
+  private startRepl(): void {
+    const replServer = repl.start('portal> ')
+
+    const defineNetworkCommand = (commandName: string, methodName: string) => {
+      replServer.defineCommand(commandName, {
+        help: `Send ${methodName} to network (history/state)`,
+        async action(args: string) {
+          const context = this.context as any
+          const portalRepl: PortalNetworkRepl = context.portalRepl
+
+          const [network, ...params] = args.split(' ')
+          let enrObject;
+
+          try {
+            // Decode ENR if first param is an ENR string
+            if (params[0] && params[0].startsWith('enr:')) {
+              enrObject = ENR.decodeTxt(params[0])
+            }
+
+            const networkChoice = network.toLowerCase() === 'history' 
+              ? portalRepl.historyNetwork 
+              : portalRepl.stateNetwork
+
+            if (!networkChoice) {
+              console.log(`${network} Network not initialized`)
+              return this.displayPrompt()
+            }
+
+            const method = networkChoice[methodName]
+            if (!method) {
+              console.log(`Method ${methodName} not found`)
+              return this.displayPrompt()
+            }
+
+            const result = enrObject 
+              ? await method(enrObject, ...params.slice(1)) 
+              : await method(...params)
+
+            console.log(`${methodName} result:`, result)
+          } catch (error) {
+            console.error(`${methodName} failed:`, error)
+          }
+          this.displayPrompt()
+        }
+      })
+    }
+
+    // Define commands for various network methods
+    defineNetworkCommand('ping', 'sendPing')
+    defineNetworkCommand('findnodes', 'sendFindNodes')
+    defineNetworkCommand('findcontent', 'sendFindContent')
+    defineNetworkCommand('offer', 'sendOffer')
+
+    replServer.context.portalRepl = this
+
+    replServer.on('exit', async () => {
+      console.log('Shutting down Portal Network node...')
+      await this.node?.stop()
+      process.exit(0)
+    })
+  }
+}
+
+async function main() {
+  const repl = new PortalNetworkRepl()
+  await repl.init()
+}
+
+main().catch(console.error)

--- a/packages/portalnetwork/examples/portalClient.ts
+++ b/packages/portalnetwork/examples/portalClient.ts
@@ -1,111 +1,227 @@
 import { SignableENR, ENR } from '@chainsafe/enr'
 import { keys } from '@libp2p/crypto'
 import { multiaddr } from '@multiformats/multiaddr'
-import { PortalNetwork, NetworkId, TransportLayer, HistoryNetwork, StateNetwork } from '../../portalnetwork/src'
+import { 
+  PortalNetwork, 
+  NetworkId, 
+  TransportLayer, 
+  BaseNetwork, 
+  HistoryNetwork, 
+  StateNetwork,
+} from '../../portalnetwork/src'
 import repl from 'repl'
+import { hexToBytes } from '@ethereumjs/util'
+import debug, { Debugger } from 'debug'
 
 class PortalNetworkRepl {
   private node?: PortalNetwork
-  private historyNetwork?: any
-  private stateNetwork?: any
+  private historyNetwork?: BaseNetwork
+  private stateNetwork?: BaseNetwork
+  private enr?: SignableENR
+  private logger: Debugger
+
 
   async init(port = 9090): Promise<void> {
-    const privateKey = await keys.generateKeyPair('secp256k1')
-    const enr = SignableENR.createFromPrivateKey(privateKey)
-    const nodeAddr = multiaddr(`/ip4/127.0.0.1/udp/${port}`)
-    enr.setLocationMultiaddr(nodeAddr)
+    try {
+      const privateKey = await keys.generateKeyPair('secp256k1')
+      this.enr = SignableENR.createFromPrivateKey(privateKey)
 
-    this.node = await PortalNetwork.create({
-      transport: TransportLayer.NODE,
-      supportedNetworks: [
-        { networkId: NetworkId.HistoryNetwork },
-        { networkId: NetworkId.StateNetwork },
-      ],
-      config: {
-        enr,
-        bindAddrs: { ip4: nodeAddr },
-        privateKey,
-      },
-    })
+      this.logger = debug(this.enr.nodeId.slice(0, 5)).extend('Portal')
 
-    this.historyNetwork = new HistoryNetwork({
-          client: this.node,
-          networkId: NetworkId.HistoryNetwork
-        })
-        this.stateNetwork = new StateNetwork({
-          client: this.node,
-          networkId: NetworkId.StateNetwork
-        })
+      const nodeAddr = multiaddr(`/ip4/127.0.0.1/udp/${port}`)
+      this.enr.setLocationMultiaddr(nodeAddr)
+
+      this.node = await PortalNetwork.create({
+        transport: TransportLayer.NODE,
+        supportedNetworks: [
+          { networkId: NetworkId.HistoryNetwork },
+          { networkId: NetworkId.StateNetwork },
+        ],
+        config: {
+          enr: this.enr,
+          bindAddrs: { ip4: nodeAddr },
+          privateKey,
+        },
+      })
+
+      this.historyNetwork = new HistoryNetwork({
+        client: this.node,
+        networkId: NetworkId.HistoryNetwork
+      })
+      this.stateNetwork = new StateNetwork({
+        client: this.node,
+        networkId: NetworkId.StateNetwork
+      })
+
+      this.node.networks[NetworkId.HistoryNetwork] = this.historyNetwork
+      this.node.networks[NetworkId.StateNetwork] = this.stateNetwork
+
+      await this.node.start()
+
+      this.node.enableLog('*Portal*,*uTP*,*discv5*')
+
+      this.logger('Portal Network initialized successfully')
+      this.logger('History Network status:', !!this.historyNetwork)
+      this.logger('State Network status:', !!this.stateNetwork)
+
+      this.setupEventListeners()
+      this.startRepl()
+    } catch (error) {
+      console.error('Portal Network initialization failed', error)
+      process.exit(1)
+    }
+  }
+
+  private setupEventListeners(): void {
+    if (!this.node) return
+
+    this.node.on('SendTalkReq', (nodeId, requestId, payload) => 
+      this.logger('Sent talk request', { nodeId, requestId, payload }))
     
-        this.node.networks[NetworkId.HistoryNetwork] = this.historyNetwork
-        this.node.networks[NetworkId.StateNetwork] = this.stateNetwork
-
-    await this.node.start()
-    this.node.enableLog('*Portal*,*uTP*,*discv5*')
-
-    // this.historyNetwork = this.node.networks[NetworkId.HistoryNetwork]
-    // this.stateNetwork = this.node.networks[NetworkId.StateNetwork]
-
-    this.startRepl()
+    this.node.on('SendTalkResp', (nodeId, requestId, payload) => 
+      this.logger('Received talk response', { nodeId, requestId, payload }))
   }
 
   private startRepl(): void {
     const replServer = repl.start('portal> ')
 
-    const defineNetworkCommand = (commandName: string, methodName: string) => {
-      replServer.defineCommand(commandName, {
-        help: `Send ${methodName} to network (history/state)`,
-        async action(args: string) {
+    replServer.defineCommand('ping', {
+      help: 'Send ping to network (history/state)',
+      async action(network: string) {
+        const context = this.context as any
+        const portalRepl: PortalNetworkRepl = context.portalRepl
+
+        try {
+          const networkObj = network.toLowerCase() === 'history' 
+            ? portalRepl.historyNetwork 
+            : portalRepl.stateNetwork
+
+          if (!networkObj) {
+            portalRepl.logger(`${network} Network not initialized`)
+            return this.displayPrompt()
+          }
+
+          const enr = ENR.decodeTxt(networkObj.enr.encodeTxt())
+          const res = await networkObj.sendPing(enr)
+          portalRepl.logger(`Ping response for ${network} network:`, res)
+        } catch (error) {
+          portalRepl.logger(`Ping to ${network} network failed`, error)
+        }
+        this.displayPrompt()
+      }
+    })
+
+    replServer.defineCommand('findnodes', {
+      help: 'Find nodes in network (history/state) with ENR and distances',
+      async action(args: string) {
+        const context = this.context as any
+        const portalRepl: PortalNetworkRepl = context.portalRepl
+
+        const [network, enr, ...distancesStr] = args.split(' ')
+        const distances = distancesStr.map(d => parseInt(d, 10))
+
+        try {
+          switch (network.toLowerCase()) {
+            case 'history':
+              if (!portalRepl.historyNetwork) {
+                console.log('History Network not initialized')
+                break
+              }
+              const enrObject = ENR.decodeTxt(enr)
+              await portalRepl.historyNetwork.sendFindNodes(enrObject, distances)
+              break
+            case 'state':
+              if (!portalRepl.stateNetwork) {
+                console.log('State Network not initialized')
+                break
+              }
+              const enrObject2 = ENR.decodeTxt(enr)
+              await portalRepl.stateNetwork.sendFindNodes(enrObject2, distances)
+              break
+            default:
+              console.log('Invalid network. Choose "history" or "state"')
+          }
+        } catch (error) {
+          console.error('Find nodes failed:', error)
+        }
+        this.displayPrompt()
+      }
+    })
+
+    replServer.defineCommand('findcontent', {
+      help: 'Find content in network (history/state) with ENR and content key. Usage: findcontent <network> <enr> <contentKey>',
+      async action(args: string) {
+        try {
+
           const context = this.context as any
           const portalRepl: PortalNetworkRepl = context.portalRepl
 
-          const [network, ...params] = args.split(' ')
-          let enrObject;
-
-          try {
-            // Decode ENR if first param is an ENR string
-            if (params[0] && params[0].startsWith('enr:')) {
-              enrObject = ENR.decodeTxt(params[0])
-            }
-
-            const networkChoice = network.toLowerCase() === 'history' 
-              ? portalRepl.historyNetwork 
-              : portalRepl.stateNetwork
-
-            if (!networkChoice) {
-              console.log(`${network} Network not initialized`)
-              return this.displayPrompt()
-            }
-
-            const method = networkChoice[methodName]
-            if (!method) {
-              console.log(`Method ${methodName} not found`)
-              return this.displayPrompt()
-            }
-
-            const result = enrObject 
-              ? await method(enrObject, ...params.slice(1)) 
-              : await method(...params)
-
-            console.log(`${methodName} result:`, result)
-          } catch (error) {
-            console.error(`${methodName} failed:`, error)
+          const parts = args.trim().split(/\s+/)
+          if (parts.length !== 3) {
+            portalRepl.logger('Invalid arguments. Usage: findcontent <network> <enr> <contentKey>')
+            return this.displayPrompt()
           }
-          this.displayPrompt()
-        }
-      })
-    }
 
-    // Define commands for various network methods
-    defineNetworkCommand('ping', 'sendPing')
-    defineNetworkCommand('findnodes', 'sendFindNodes')
-    defineNetworkCommand('findcontent', 'sendFindContent')
-    defineNetworkCommand('offer', 'sendOffer')
+          const [network, enr, contentKey] = parts
+
+          const networkObj = network.toLowerCase() === 'history' 
+            ? portalRepl.historyNetwork 
+            : portalRepl.stateNetwork
+
+          if (!networkObj) {
+            portalRepl.logger(`${network} Network not initialized`)
+            return this.displayPrompt()
+          }
+
+          let parsedEnr
+          try {
+            parsedEnr = ENR.decodeTxt(enr)
+          } catch (enrError) {
+            portalRepl.logger('Invalid ENR format:', enrError)
+            return this.displayPrompt()
+          }
+
+          let contentBytes
+          try {
+            contentBytes = hexToBytes(contentKey)
+          } catch (hexError) {
+            portalRepl.logger('Invalid content key format. Must be a hex string:', hexError)
+            return this.displayPrompt()
+          }
+
+          if (!networkObj.sendFindContent) {
+            portalRepl.logger('sendFindContent method not available')
+            return this.displayPrompt()
+          }
+
+          const content = await networkObj.sendFindContent(parsedEnr, contentBytes)
+          portalRepl.logger('Content found:', content)
+        } catch (error) {
+          console.log('Find content operation failed', error)
+        }
+        this.displayPrompt()
+      }
+    })
+
+    replServer.defineCommand('status', {
+      help: 'Show current Portal Network status',
+      action() {
+        const context = this.context as any
+        const portalRepl: PortalNetworkRepl = context.portalRepl
+
+        portalRepl.logger('Portal Network Status:')
+        portalRepl.logger('History Network:', !!portalRepl.historyNetwork)
+        portalRepl.logger('State Network:', !!portalRepl.stateNetwork)
+        portalRepl.logger('Node initialized:', !!portalRepl.node)
+
+        this.displayPrompt()
+      }
+    })
 
     replServer.context.portalRepl = this
 
     replServer.on('exit', async () => {
-      console.log('Shutting down Portal Network node...')
+      this.logger('Shutting down Portal Network node...')
       await this.node?.stop()
       process.exit(0)
     })
@@ -113,8 +229,16 @@ class PortalNetworkRepl {
 }
 
 async function main() {
-  const repl = new PortalNetworkRepl()
-  await repl.init()
+  try {
+    const repl = new PortalNetworkRepl()
+    await repl.init()
+  } catch (error) {
+    console.log('Initialization failed', error)
+    process.exit(1)
+  }
 }
 
-main().catch(console.error)
+main().catch(err => {
+  console.log('Unhandled error in main', err)
+  process.exit(1)
+})


### PR DESCRIPTION
This PR introduces a REPL interface for interacting with the Portal Network, enabling developers to test and manage the network more effectively.

### Features:
**REPL Commands**:
   - `.ping <network>`: Send a ping request to the specified network (`history` or `state`).
   - `.findnodes <network> <enr> <distances>`: Locate nodes within a network using an ENR and distances.
   - `.findcontent <network> <enr> <contentKey>`: Search for content in a network using an ENR and content key.
   - `.offer <network> <enr> <contentKey> <contentValue>`: Offer content to a node in the specified network.
   - `.status`: Display the current status of the Portal Network and its components.

