### PR TITLE
Remove invalid ping extension error

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -367,19 +367,6 @@ export abstract class BaseNetwork extends EventEmitter {
 
   handlePing = async (src: INodeAddress, id: bigint, pingMessage: PingMessage) => {
     if (!this.routingTable.getWithPending(src.nodeId)?.value) {
-      if (
-        pingMessage.payloadType !== PingPongPayloadExtensions.CLIENT_INFO_RADIUS_AND_CAPABILITIES
-      ) {
-        const customPayload = ErrorPayload.serialize({
-          errorCode: PingPongErrorCodes.EXTENSION_NOT_SUPPORTED,
-          message: hexToBytes(
-            fromAscii(
-              `First PING message must be type 0: CLIENT_INFO_RADIUS_AND_CAPABILITIES.  Received type ${pingMessage.payloadType}`,
-            ),
-          ),
-        })
-        return this.sendPong(src, id, customPayload, PingPongPayloadExtensions.ERROR_RESPONSE)
-      }
       // Check to see if node is already in corresponding network routing table and add if not
       const enr = this.findEnr(src.nodeId)
       if (enr !== undefined) {

--- a/packages/portalnetwork/test/integration/pingpong.spec.ts
+++ b/packages/portalnetwork/test/integration/pingpong.spec.ts
@@ -68,24 +68,6 @@ describe('PING/PONG', async () => {
       )
     }
   })
-  it('should respond with ERROR_RESPONSE to type !== 0 PING from unknown node', async () => {
-    const pingPayload = network1.pingPongPayload(PingPongPayloadExtensions.HISTORY_RADIUS_PAYLOAD)
-    const pingMsg = {
-      enrSeq: 1n,
-      payloadType: PingPongPayloadExtensions.HISTORY_RADIUS_PAYLOAD,
-      customPayload: pingPayload,
-    }
-    const network1NodeAddress: INodeAddress = {
-      nodeId: node1.discv5.enr.nodeId,
-      socketAddr: initMa,
-    }
-    const pong = await network2.handlePing(network1NodeAddress, 1234n, pingMsg)
-    const pongMsg = PortalWireMessageType.deserialize(pong)
-    // const pongPayload = HistoryRadius.deserialize(
-    //   (<any>pongMsg.value).customPayload,
-    // )
-    assert.equal((<any>pongMsg.value).payloadType, PingPongPayloadExtensions.ERROR_RESPONSE)
-  })
   it('should exchange type 0 PING/PONG', async () => {
     const pingpong = await network1.sendPing(network2?.enr!.toENR(), 0)
     assert.exists(pingpong, 'should have received a pong')


### PR DESCRIPTION
Just because the other node isn't in your routing table, doesn't Ultralight isn't in their routing table. You shouldn't block a ping extension based on if it is in your routing table or not, as Ultralight's routing table is more then likely full, but is still apart of the other nodes routing table.

Anyways I am getting this error, when Trin is trying to upgrade to type 2 after sending an initial type 0

@ScottyPoi @acolytec3 ping for review