### PR TITLE
Update Discv5 and Remove Buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -547,18 +547,20 @@
       }
     },
     "node_modules/@chainsafe/discv5": {
-      "version": "10.0.1",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.0.tgz",
+      "integrity": "sha512-g/x79Y5b7g6CrNuWazSzXTtnNguC0Sl8xkf9CPMlZ0BrsXmXPzwTp3zgtAiuJcG9x7zDUSDFOejrb4iFcJ0/FQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chainsafe/enr": "^4.0.1",
+        "@chainsafe/enr": "^5.0.0",
+        "@ethereumjs/rlp": "^5.0.2",
         "@libp2p/crypto": "^5.0.1",
         "@libp2p/interface": "^2.0.1",
         "@multiformats/multiaddr": "^12.1.10",
-        "bcrypto": "^5.4.0",
-        "bigint-buffer": "^1.1.5",
+        "@noble/hashes": "^1.7.0",
+        "@noble/secp256k1": "^2.2.2",
         "debug": "^4.3.1",
         "lru-cache": "^10.1.0",
-        "rlp": "^2.2.6",
         "strict-event-emitter-types": "^2.0.0"
       }
     },
@@ -574,31 +576,55 @@
         "uint8arraylist": "^2.4.8"
       }
     },
+    "node_modules/@chainsafe/discv5/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@chainsafe/enr": {
-      "version": "4.0.1",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/enr/-/enr-5.0.0.tgz",
+      "integrity": "sha512-xqWBsdFFHy/sLqddsyCT4BH/5PFheyK8Grho27tmiwg/a95nANYANsqXXUP8/HbgCx3F5VDl0/xFacV3Ik7kDA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
         "@libp2p/crypto": "^5.0.1",
         "@libp2p/interface": "^2.0.1",
         "@libp2p/peer-id": "^5.0.1",
         "@multiformats/multiaddr": "^12.1.10",
-        "bigint-buffer": "^1.1.5",
+        "@scure/base": "^1.2.1",
         "ethereum-cryptography": "^2.2.0",
-        "rlp": "^2.2.6",
-        "uint8-varint": "^2.0.2",
-        "uint8arrays": "^5.0.1"
+        "uint8-varint": "^2.0.2"
       }
     },
     "node_modules/@chainsafe/enr/node_modules/@libp2p/interface": {
-      "version": "2.1.0",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.4.0.tgz",
+      "integrity": "sha512-PfzxOaz7dU4sdnUNByGLoEk9iqhD0IS+LQMQB12CXh6VyYLA7J8oaoHk3yRBZze3Y4FPa5DHMm5Oi9O/IhreaQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr": "^12.3.3",
         "it-pushable": "^3.2.3",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.1.0",
-        "progress-events": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "multiformats": "^13.3.1",
+        "progress-events": "^1.0.1",
         "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@chainsafe/enr/node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@chainsafe/hashtree": {
@@ -1797,38 +1823,73 @@
         "uint8arraylist": "^2.4.8"
       }
     },
-    "node_modules/@libp2p/interface": {
-      "version": "1.7.0",
+    "node_modules/@libp2p/peer-id": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.0.10.tgz",
+      "integrity": "sha512-+rj61RN3VnmnVoO64LaIZAdLYW2VLsBeSuWIIjeYUXy1U2CpPAzrxmHBQw3YmM2Ozis3FbLgol4pM/9mXsbn2g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.2.3",
-        "it-pushable": "^3.2.3",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.1.0",
-        "progress-events": "^1.0.0",
-        "uint8arraylist": "^2.4.8"
+        "@libp2p/crypto": "^5.0.9",
+        "@libp2p/interface": "^2.4.0",
+        "multiformats": "^13.3.1",
+        "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/peer-id": {
-      "version": "5.0.2",
+    "node_modules/@libp2p/peer-id/node_modules/@libp2p/crypto": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.9.tgz",
+      "integrity": "sha512-KR+KK1d7BfwUIC/zKN1PhS4elY/6TNWMl//34O2xA/YzSJl6vW/62oXG/XD5ieqjq7qbJZWsgbSRry8w/vDHBg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.2",
-        "@libp2p/interface": "^2.1.0",
-        "multiformats": "^13.1.0",
+        "@libp2p/interface": "^2.4.0",
+        "@noble/curves": "^1.7.0",
+        "@noble/hashes": "^1.6.1",
+        "asn1js": "^3.0.5",
+        "multiformats": "^13.3.1",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-id/node_modules/@libp2p/interface": {
-      "version": "2.1.0",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.4.0.tgz",
+      "integrity": "sha512-PfzxOaz7dU4sdnUNByGLoEk9iqhD0IS+LQMQB12CXh6VyYLA7J8oaoHk3yRBZze3Y4FPa5DHMm5Oi9O/IhreaQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr": "^12.3.3",
         "it-pushable": "^3.2.3",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.1.0",
-        "progress-events": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "multiformats": "^13.3.1",
+        "progress-events": "^1.0.1",
         "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@lodestar/api": {
@@ -1908,12 +1969,13 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "12.2.3",
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.4.tgz",
+      "integrity": "sha512-R4pEEUyWGrRo16TSflz80Yr6XNbPirix1pfPqDLXsDZ4aaIrhZ7cez9jnyRQgci6DuuqSyZAdJKV6SdxpZ7Oiw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/interface": "^1.0.0",
         "@multiformats/dns": "^1.0.3",
         "multiformats": "^13.0.0",
         "uint8-varint": "^2.0.1",
@@ -1974,6 +2036,15 @@
       "engines": {
         "node": ">= 16"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.2.3.tgz",
+      "integrity": "sha512-l7r5oEQym9Us7EAigzg30/PQAvynhMt2uoYtT3t26eGDVm9Yii5mZ5jWSWmZ/oSIR2Et0xfc6DXrG0bZ787V3w==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -3291,18 +3362,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bcrypto": {
-      "version": "5.5.2",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bufio": "~1.0.7",
-        "loady": "~0.0.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "dev": true,
@@ -3354,6 +3413,7 @@
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -3422,13 +3482,6 @@
       },
       "engines": {
         "node": ">=6.14.2"
-      }
-    },
-    "node_modules/bufio": {
-      "version": "1.0.7",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/builtin-modules": {
@@ -5755,12 +5808,10 @@
       }
     },
     "node_modules/it-stream-types": {
-      "version": "2.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.2.tgz",
+      "integrity": "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/jackspeak": {
       "version": "3.1.2",
@@ -5976,13 +6027,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/loady": {
-      "version": "0.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -6346,7 +6390,9 @@
       "license": "MIT"
     },
     "node_modules/multiformats": {
-      "version": "13.1.0",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
+      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/nanoid": {
@@ -6977,12 +7023,10 @@
       }
     },
     "node_modules/progress-events": {
-      "version": "1.0.0",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/prom-client": {
       "version": "14.2.0",
@@ -7041,7 +7085,9 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "5.4.0",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
+      "integrity": "sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8-varint": "^2.0.2",
@@ -7228,16 +7274,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rlp": {
-      "version": "2.2.7",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      },
-      "bin": {
-        "rlp": "bin/rlp"
       }
     },
     "node_modules/rollup": {
@@ -8812,8 +8848,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@chainsafe/discv5": "^10.0.1",
-        "@chainsafe/enr": "^4.0.1",
+        "@chainsafe/discv5": "^11.0.0",
+        "@chainsafe/enr": "^5.0.0",
         "@chainsafe/persistent-merkle-tree": "^0.8.0",
         "@chainsafe/ssz": "^0.17.1",
         "@ethereumjs/block": "^5.2.0",
@@ -8947,8 +8983,8 @@
       "dependencies": {
         "@chainsafe/as-sha256": "^0.5.0",
         "@chainsafe/blst": "^2.0.3",
-        "@chainsafe/discv5": "^10.0.1",
-        "@chainsafe/enr": "^4.0.1",
+        "@chainsafe/discv5": "^11.0.0",
+        "@chainsafe/enr": "^5.0.0",
         "@chainsafe/persistent-merkle-tree": "^0.8.0",
         "@chainsafe/ssz": "^0.17.1",
         "@ethereumjs/block": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,8 @@
     "vitest": "^3.0.2"
   },
   "dependencies": {
-    "@chainsafe/discv5": "^10.0.1",
-    "@chainsafe/enr": "^4.0.1",
+    "@chainsafe/discv5": "^11.0.0",
+    "@chainsafe/enr": "^5.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/ssz": "^0.17.1",
     "@ethereumjs/block": "^5.2.0",

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.5.0",
     "@chainsafe/blst": "^2.0.3",
-    "@chainsafe/discv5": "^10.0.1",
-    "@chainsafe/enr": "^4.0.1",
+    "@chainsafe/discv5": "^11.0.0",
+    "@chainsafe/enr": "^5.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/ssz": "^0.17.1",
     "@ethereumjs/block": "^5.3.0",

--- a/packages/portalnetwork/src/transports/websockets.ts
+++ b/packages/portalnetwork/src/transports/websockets.ts
@@ -53,7 +53,7 @@ export class WebSocketTransportService
     this.multiaddr = multiaddr
     this.srcId = srcId
     this.socket = new WebSocketAsPromised(proxyAddress, {
-      packMessage: (data: Buffer) => data.buffer,
+      packMessage: (data: Uint8Array) => data.buffer,
       unpackMessage: (data) => data,
       //@ts-ignore node websocket types don't match browser websocket types - so tell Typescript not to worry about it
       createWebSocket: (url) => new WebSocket(url),

--- a/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
+++ b/packages/portalnetwork/src/wire/utp/Packets/PacketHeader.ts
@@ -1,5 +1,4 @@
 import { VERSION } from '../Utils/constants.js'
-
 import { SelectiveAckHeaderExtension } from './Extensions.js'
 
 import type { Uint16, Uint32, Uint8 } from '../index.js'
@@ -35,27 +34,32 @@ abstract class Header<T extends PacketType> {
     this.length = 20
   }
 
-  abstract encode(): Buffer
+  abstract encode(): Uint8Array
 }
 export class BasicPacketHeader<T extends PacketType> extends Header<T> {
   constructor(options: HeaderInput<T>) {
     super(options)
   }
-  encode(): Buffer {
-    const buffer = Buffer.alloc(this.length)
+  encode(): Uint8Array {
+    const array = new Uint8Array(this.length)
+    const view = new DataView(array.buffer)
+    
+    // Combine packet type and version into a single byte
     const p = Number(this.pType).toString(16)
     const v = this.version.toString(16)
     const pv = p + v
     const typeAndVer = parseInt(pv, 16)
-    buffer.writeUInt8(typeAndVer, 0)
-    buffer.writeUInt8(this.extension, 1)
-    buffer.writeUInt16BE(this.connectionId, 2)
-    buffer.writeUint32BE(this.timestampMicroseconds, 4)
-    buffer.writeUint32BE(this.timestampDifferenceMicroseconds, 8)
-    buffer.writeUInt32BE(this.wndSize, 12)
-    buffer.writeUInt16BE(this.seqNr, 16)
-    buffer.writeUInt16BE(this.ackNr, 18)
-    return buffer
+    
+    view.setUint8(0, typeAndVer)
+    view.setUint8(1, this.extension)
+    view.setUint16(2, this.connectionId, false) // false = big-endian
+    view.setUint32(4, this.timestampMicroseconds, false)
+    view.setUint32(8, this.timestampDifferenceMicroseconds, false)
+    view.setUint32(12, this.wndSize, false)
+    view.setUint16(16, this.seqNr, false)
+    view.setUint16(18, this.ackNr, false)
+    
+    return array
   }
 }
 
@@ -70,27 +74,33 @@ export class SelectiveAckHeader extends Header<PacketType.ST_STATE> {
     this.length = this.encode().length
   }
 
-  encode(): Buffer {
-    const buffer = Buffer.alloc(20 + this.bitmask.length + 2)
+  encode(): Uint8Array {
+    const array = new Uint8Array(20 + this.selectiveAckExtension.bitmask.length + 2)
+    const view = new DataView(array.buffer)
+    
+    // Combine packet type and version into a single byte
     const p = this.pType.toString(16)
     const v = this.version.toString(16)
     const pv = p + v
     const typeAndVer = parseInt(pv, 16)
-    buffer.writeUInt8(typeAndVer, 0)
-    buffer.writeUInt8(this.extension, 1)
-    buffer.writeUInt16BE(this.connectionId, 2)
-    buffer.writeUInt32BE(this.timestampMicroseconds, 4)
-    buffer.writeUInt32BE(this.timestampDifferenceMicroseconds, 8)
-    buffer.writeUInt32BE(this.wndSize, 12)
-    buffer.writeUInt16BE(this.seqNr, 16)
-    buffer.writeUInt16BE(this.ackNr, 18)
-    buffer.writeUInt8(this.selectiveAckExtension.type, 20)
-    buffer.writeUInt8(this.selectiveAckExtension.len, 21)
-    //eslint-disable-next-line
+    
+    view.setUint8(0, typeAndVer)
+    view.setUint8(1, this.extension)
+    view.setUint16(2, this.connectionId, false) // false = big-endian
+    view.setUint32(4, this.timestampMicroseconds, false)
+    view.setUint32(8, this.timestampDifferenceMicroseconds, false)
+    view.setUint32(12, this.wndSize, false)
+    view.setUint16(16, this.seqNr, false)
+    view.setUint16(18, this.ackNr, false)
+    view.setUint8(20, this.selectiveAckExtension.type)
+    view.setUint8(21, this.selectiveAckExtension.len)
+    
+    // Write bitmask values directly to the Uint8Array
     this.selectiveAckExtension.bitmask.forEach((value, idx) => {
-      buffer.writeUInt8(value, 22 + idx)
+      array[22 + idx] = value
     })
-    return buffer
+    
+    return array
   }
 }
 

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -120,7 +120,7 @@ export class PortalNetworkUTP {
     return newRequest
   }
 
-  async handleUtpPacket(packetBuffer: Buffer, srcId: INodeAddress): Promise<void> {
+  async handleUtpPacket(packetBuffer: Uint8Array, srcId: INodeAddress): Promise<void> {
     if (this.requestManagers[srcId.nodeId] === undefined) {
       throw new Error(`No request manager for ${srcId.nodeId}`)
     }
@@ -159,7 +159,7 @@ export class PortalNetworkUTP {
     }
   }
 
-  async send(enr: ENR | INodeAddress, msg: Buffer, networkId: NetworkId) {
+  async send(enr: ENR | INodeAddress, msg: Uint8Array, networkId: NetworkId) {
     try {
       await this.client.sendPortalNetworkMessage(enr, msg, networkId, true)
     } catch (err) {

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/requestManager.ts
@@ -78,7 +78,7 @@ export class RequestManager {
    * Handles an incoming uTP packet.
    * @param packetBuffer buffer containing the incoming packet
    */
-  async handlePacket(packetBuffer: Buffer) {
+  async handlePacket(packetBuffer: Uint8Array) {
     const packet = Packet.fromBuffer(packetBuffer)
     const request = this.lookupRequest(packet.header.connectionId)
     switch (request) {

--- a/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/UtpSocket.ts
@@ -81,7 +81,7 @@ export abstract class UtpSocket {
     clearTimeout(this.packetManager.congestionControl.timeoutCounter)
   }
 
-  async sendPacket<T extends PacketType>(packet: Packet<T>): Promise<Buffer> {
+  async sendPacket<T extends PacketType>(packet: Packet<T>): Promise<Uint8Array> {
     const msg = packet.encode()
     this.logger.extend('SEND').extend(PacketType[packet.header.pType])(
       `pid: ${packet.header.connectionId} sNr: ${packet.header.seqNr} aNr: ${packet.header.ackNr}`,

--- a/packages/portalnetwork/src/wire/utp/Utils/variantPrefix.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/variantPrefix.ts
@@ -1,3 +1,4 @@
+import { concatBytes } from '@ethereumjs/util'
 import * as leb from '@thi.ng/leb128'
 
 /**
@@ -7,7 +8,7 @@ import * as leb from '@thi.ng/leb128'
  */
 export function attatchPrefix(content: Uint8Array): Uint8Array {
   const prefix = leb.encodeULEB128(content.length)
-  return Uint8Array.from(Buffer.concat([prefix, content]))
+  return concatBytes(prefix, content)
 }
 
 /**
@@ -19,7 +20,7 @@ export function encodeWithVariantPrefix(contents: Uint8Array[]): Uint8Array {
   const packed: Uint8Array[] = contents.map((content) => {
     return attatchPrefix(content)
   })
-  return Uint8Array.from(Buffer.concat(packed))
+  return concatBytes(...packed)
 }
 
 type length = number

--- a/packages/portalnetwork/test/integration/postCapellaHeaderProof.spec.ts
+++ b/packages/portalnetwork/test/integration/postCapellaHeaderProof.spec.ts
@@ -32,7 +32,7 @@ describe('Block Bridge Data Test', () => {
         ]
         const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
         const enr1 = SignableENR.createFromPrivateKey(pk1)
-        const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5034`)
+        const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5033`)
 
         const client = await PortalNetwork.create({
             supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }, { networkId: NetworkId.BeaconChainNetwork }], config: { enr: enr1, bindAddrs: { ip4: initMa }, privateKey: pk1 }

--- a/packages/portalnetwork/test/wire/utp/packet.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/packet.spec.ts
@@ -164,7 +164,7 @@ export function encodingTest(
     const encodedPacket = testPacket.encode()
     assert.equal(bytesToHex(encodedPacket), expectedResult, 'Packet encoding test passed')
     const testHeader = testPacket.header
-    const decodedPacket = Packet.fromBuffer(Buffer.from(expectedResult.slice(2), 'hex'))
+    const decodedPacket = Packet.fromBuffer(hexToBytes(expectedResult))
     const decodedHeader = decodedPacket.header
     assert.equal(
       Object.entries(decodedHeader).toString(),
@@ -190,8 +190,8 @@ export function encodingTest(
     // }
     if (packetType === PacketType.ST_DATA) {
       assert.equal(
-        bytesToHex(Buffer.from(testData.payload!)),
-        bytesToHex(Buffer.from(Uint8Array.from(decodedPacket.payload!))),
+        bytesToHex(testData.payload!),
+        bytesToHex(Uint8Array.from(decodedPacket.payload!)),
         `Successfully encoded and decoded DATA Packet payload.`,
       )
     }

--- a/packages/portalnetwork/test/wire/utp/utp.spec.ts
+++ b/packages/portalnetwork/test/wire/utp/utp.spec.ts
@@ -22,6 +22,7 @@ import { WriteSocket } from '../../../src/wire/utp/Socket/WriteSocket.js'
 
 import { ENR } from '@chainsafe/enr'
 import { RequestManager } from '../../../src/wire/utp/PortalNetworkUtp/requestManager.js'
+import { utf8ToBytes } from '@ethereumjs/util'
 
 const sampleSize = 50000
 const enr = ENR.decodeTxt(
@@ -142,14 +143,14 @@ describe('PortalNetworkUTP test', async () => {
       connectionId,
       socketIds[RequestCode.FOUNDCONTENT_WRITE].sndId,
       socketIds[RequestCode.FOUNDCONTENT_WRITE].rcvId,
-      Buffer.from('test'),
+      utf8ToBytes('test'),
     )
     assert.ok(socket, 'UTPSocket created by PortalNetworkUTP')
     assert.equal(socket.sndConnectionId, connectionId + 1, 'UTPSocket has correct sndConnectionId')
     assert.equal(socket.rcvConnectionId, connectionId, 'UTPSocket has correct rcvConnectionId')
     assert.equal(socket.remoteAddress, enr, 'UTPSocket has correct peerId')
     assert.equal(socket.type, UtpSocketType.WRITE, 'UTPSocket has correct requestCode')
-    assert.deepEqual(socket.content, Buffer.from('test'), 'UTPSocket has correct content')
+    assert.deepEqual(socket.content, utf8ToBytes('test'), 'UTPSocket has correct content')
     assert.equal(
       socket.ackNr,
       startingNrs[RequestCode.FOUNDCONTENT_WRITE].ackNr,
@@ -185,7 +186,7 @@ describe('PortalNetworkUTP test', async () => {
       connectionId,
       socketIds[RequestCode.OFFER_WRITE].sndId,
       socketIds[RequestCode.OFFER_WRITE].rcvId,
-      Buffer.from('test'),
+      utf8ToBytes('test'),
     )
     assert.equal(socket.type, UtpSocketType.WRITE, 'UTPSocket has correct requestCode')
     assert.equal(socket.sndConnectionId, connectionId, 'UTPSocket has correct sndConnectionId')
@@ -238,7 +239,7 @@ describe('RequestManager', () => {
       requestManager: mgr,
       requestCode: RequestCode.FINDCONTENT_READ,
       contentKeys: [],
-      content: Buffer.from('test'),
+      content: utf8ToBytes('test'),
     })
     const packet1 = Packet.fromOpts({
       header: {


### PR DESCRIPTION
Updates `@chainsafe/discv5` to v.11.0.0
Updates `@chainsafe/enr` to v.5.0.0

Removes all remaining `Buffer` use.
Rewrites `Buffer` based code to use `Uint8Array`