### PR TITLE
Network Census

### DIFF
--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -3,16 +3,22 @@ import { KademliaRoutingTable } from '@chainsafe/discv5'
 import type { ENR, NodeId } from '@chainsafe/enr'
 import type { Debugger } from 'debug'
 import { shortId } from '../index.js'
+import { ScoredPeer } from '../networks/peers.js'
 export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   public logger?: Debugger
   private radiusMap: Map<NodeId, bigint>
   private gossipMap: Map<NodeId, Set<Uint8Array>>
   private ignored: [number, NodeId][]
+  /**
+   * Map of all known peers in the network
+   */
+  private networkCensus: Map<string, ScoredPeer>
   constructor(nodeId: NodeId) {
     super(nodeId)
     this.radiusMap = new Map()
     this.gossipMap = new Map()
     this.ignored = []
+    this.networkCensus = new Map()
   }
 
   public setLogger(logger: Debugger) {

--- a/packages/portalnetwork/src/client/routingTable.ts
+++ b/packages/portalnetwork/src/client/routingTable.ts
@@ -13,7 +13,7 @@ export class PortalNetworkRoutingTable extends KademliaRoutingTable {
   /**
    * Map of all known peers in the network
    */
-  private networkCensus: Map<string, ScoredPeer>
+  public networkCensus: Map<string, ScoredPeer>
   constructor(nodeId: NodeId) {
     super(nodeId)
     this.radiusMap = new Map()

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -296,8 +296,9 @@ export abstract class BaseNetwork extends EventEmitter {
       this.logger(`Invalid ENR provided. PING aborted`)
       return
     }
-    if (!this.routingTable.getWithPending(enr.nodeId)?.value && extensionType !== 0) {
-      throw new Error(`First PING message must be type 0: CLIENT_INFO_RADIUS_AND_CAPABILITIES.`)
+    const peerCapabilities = this.routingTable.networkCensus.get(enr.nodeId)?.capabilities ?? [0]
+    if (!peerCapabilities.includes(extensionType)) {
+      throw new Error(`Peer is not know to support extension type: ${extensionType}`)
     }
     const timeout = setTimeout(() => {
       return undefined

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -327,17 +327,21 @@ export abstract class BaseNetwork extends EventEmitter {
             this.logger.extend('PONG')(
               `Client ${shortId(enr.nodeId)} is ${decodeClientInfo(ClientInfo).clientName} node with capabilities: ${Capabilities}`,
             )
-            this.routingTable.updateRadius(enr.nodeId, DataRadius)
+            this.routingTable.updateNodeFromPong(enr, {
+              capabilities: Capabilities,
+              clientInfo: decodeClientInfo(ClientInfo),
+              radius: DataRadius,
+            })
             break
           }
           case PingPongPayloadExtensions.BASIC_RADIUS_PAYLOAD: {
             const { dataRadius } = BasicRadius.deserialize(pongMessage.customPayload)
-            this.routingTable.updateRadius(enr.nodeId, dataRadius)
+            this.routingTable.updateNodeFromPong(enr, { radius: dataRadius })
             break
           }
           case PingPongPayloadExtensions.HISTORY_RADIUS_PAYLOAD: {
             const { dataRadius } = HistoryRadius.deserialize(pongMessage.customPayload)
-            this.routingTable.updateRadius(enr.nodeId, dataRadius)
+            this.routingTable.updateNodeFromPong(enr, { radius: dataRadius })
             break
           }
           case PingPongPayloadExtensions.ERROR_RESPONSE: {
@@ -377,20 +381,26 @@ export abstract class BaseNetwork extends EventEmitter {
     if (this.capabilities.includes(pingMessage.payloadType)) {
       switch (pingMessage.payloadType) {
         case PingPongPayloadExtensions.CLIENT_INFO_RADIUS_AND_CAPABILITIES: {
-          const { DataRadius } = ClientInfoAndCapabilities.deserialize(pingMessage.customPayload)
-          this.routingTable.updateRadius(src.nodeId, DataRadius)
+          const { DataRadius, Capabilities, ClientInfo } = ClientInfoAndCapabilities.deserialize(
+            pingMessage.customPayload,
+          )
+          this.routingTable.updateNodeFromPing(src, {
+            capabilities: Capabilities,
+            clientInfo: decodeClientInfo(ClientInfo),
+            radius: DataRadius,
+          })
           pongPayload = this.pingPongPayload(pingMessage.payloadType)
           break
         }
         case PingPongPayloadExtensions.BASIC_RADIUS_PAYLOAD: {
           const { dataRadius } = BasicRadius.deserialize(pingMessage.customPayload)
-          this.routingTable.updateRadius(src.nodeId, dataRadius)
+          this.routingTable.updateNodeFromPing(src, { radius: dataRadius })
           pongPayload = this.pingPongPayload(pingMessage.payloadType)
           break
         }
         case PingPongPayloadExtensions.HISTORY_RADIUS_PAYLOAD: {
           const { dataRadius } = HistoryRadius.deserialize(pingMessage.customPayload)
-          this.routingTable.updateRadius(src.nodeId, dataRadius)
+          this.routingTable.updateNodeFromPing(src, { radius: dataRadius })
           pongPayload = this.pingPongPayload(pingMessage.payloadType)
           break
         }

--- a/packages/portalnetwork/src/networks/peers.ts
+++ b/packages/portalnetwork/src/networks/peers.ts
@@ -1,0 +1,49 @@
+import type { ENR } from '@chainsafe/enr'
+import type { INodeAddress } from '../client/types.js'
+import type { IClientInfo } from '../index.js'
+
+export type PeerScore = {
+  errors: number
+}
+
+export class ScoredPeer {
+  nodeAddress: INodeAddress
+  enr?: ENR
+  score: PeerScore = {
+    errors: 0,
+  }
+  capabilities: Array<number> = []
+  clientInfo?: IClientInfo
+  radius?: bigint
+  ignored: boolean = false
+  banned: boolean = false
+  constructor({
+    nodeAddress,
+    enr,
+    score,
+    capabilities,
+    clientInfo,
+    radius,
+    ignored,
+    banned,
+  }: {
+    nodeAddress: INodeAddress
+    enr?: ENR
+    score?: PeerScore
+    capabilities?: Array<number>
+    clientInfo?: IClientInfo
+    radius?: bigint
+    ignored?: boolean
+    banned?: boolean
+  }) {
+    this.nodeAddress = nodeAddress
+    this.enr = enr
+    this.score = score ?? this.score
+    this.capabilities = capabilities ?? this.capabilities
+    this.clientInfo = clientInfo
+    this.radius = radius
+    this.ignored = ignored ?? this.ignored
+    this.banned = banned ?? this.banned
+  }
+}
+


### PR DESCRIPTION
This introdueces a new mapping in the `RoutingTable` class which track the client info from Ping/Pong payloads.  

The network census tracks all known nodes in the network, not just nodes in the kademlia routing table, which has bucket size limits.

A new class called ScoredPeer was created for this mapping.  The currently implementation of ScoredPeer stores minimal information, but the class could be used in future updates to track different metrics or history.