### PR TITLE
Add new beacon endpoints

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,7 +24,7 @@ const main = async () => {
   let web3: jayson.Client | undefined
 
   const portalConfig = await cliConfig(args)
-
+  log(`portalConfig: ${JSON.stringify(args, null, 2)}`)
   portalConfig.operatingSystemAndCpuArchitecture = args.arch
   portalConfig.shortCommit = args.commit ?? execSync('git rev-parse HEAD').toString().slice(0, 7)
 
@@ -70,13 +70,11 @@ const main = async () => {
           })
         } else {
           log(
-            `Received ${method} with params: ${
-              params !== undefined &&
-              (params as any[]).map((p, idx) => {
-                return `${idx}: ${p.toString().slice(0, 64)}${
-                  p.toString().length > 64 ? '...' : ''
+            `Received ${method} with params: ${params !== undefined &&
+            (params as any[]).map((p, idx) => {
+              return `${idx}: ${p.toString().slice(0, 64)}${p.toString().length > 64 ? '...' : ''
                 }`
-              })
+            })
             }`,
           )
           return this.getMethod(method)

--- a/packages/cli/src/rpc/error-code.ts
+++ b/packages/cli/src/rpc/error-code.ts
@@ -6,3 +6,4 @@ export const METHOD_NOT_FOUND = -32601
 export const INVALID_PARAMS = -32602
 export const INTERNAL_ERROR = -32603
 export const CONTENT_NOT_FOUND = -39002
+export const BEACON_CLIENT_NOT_INITIALIZED = -39003


### PR DESCRIPTION
Fixes #728

Adds 2 new beacon RPC endpoints, `portal_beaconFinalizedStateRoot` and `portal_beaconOptimisticStateRoot`, that are needed for running the new hive tests for beacon sync.