### PR TITLE
Remove NodeJS configs from portalnetwork

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ const main = async () => {
 
   const portalConfig = await cliConfig({
     ...args,
+    bindAddress: args.bindAddress ?? `${ip}:9000`,
     bootnodeList: args.bootnodeList ? readFileSync(args.bootnodeList, 'utf-8').split('\n') : undefined,
   })
   log(`portalConfig: ${JSON.stringify(args, null, 2)}`)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { PortalNetwork, cliConfig } from 'portalnetwork'
 import * as PromClient from 'prom-client'
 import { args } from './cliArgs.js'
 import { RPCManager } from './rpc/rpc.js'
+import { readFileSync } from 'fs'
 
 const register = new PromClient.Registry()
 
@@ -23,7 +24,10 @@ const main = async () => {
   const log = debug('ultralight')
   let web3: jayson.Client | undefined
 
-  const portalConfig = await cliConfig(args)
+  const portalConfig = await cliConfig({
+    ...args,
+    bootnodeList: args.bootnodeList ? readFileSync(args.bootnodeList, 'utf-8').split('\n') : undefined,
+  })
   log(`portalConfig: ${JSON.stringify(args, null, 2)}`)
   portalConfig.operatingSystemAndCpuArchitecture = args.arch
   portalConfig.shortCommit = args.commit ?? execSync('git rev-parse HEAD').toString().slice(0, 7)

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -16,7 +16,7 @@ import {
   SyncStrategy,
 } from '../networks/index.js'
 import { CapacitorUDPTransportService, WebSocketTransportService } from '../transports/index.js'
-import { MEGABYTE, dirSize } from '../util/index.js'
+import { MEGABYTE } from '../util/index.js'
 import { PortalNetworkUTP } from '../wire/utp/PortalNetworkUtp/index.js'
 
 import { DBManager } from './dbManager.js'
@@ -121,9 +121,6 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
         break
       case TransportLayer.NODE:
       default:
-        dbSize = async function () {
-          return dirSize(opts.dataDir ?? './')
-        }
     }
 
     // Configure transport layer

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import { distance } from '@chainsafe/discv5'
 import { ContainerType, UintBigintType } from '@chainsafe/ssz'
 import { bytesToHex, hexToBytes, padToEven } from '@ethereumjs/util'
@@ -129,30 +128,16 @@ export class NetworkDB {
    * @returns the size of the data directory in bytes
    */
   async size(): Promise<number> {
-    if (this.dataDir === undefined) {
-      const _db = this.db as MemoryLevel<string, string>
-      let size = 0
-      for await (const [key, value] of _db.iterator()) {
-        try {
-          size += hexToBytes('0x' + padToEven(key.slice(2))).length
-          size += hexToBytes(value).length
-        } catch {
-          // ignore
-        }
+    let size = 0
+    for await (const [key, value] of this.db.iterator()) {
+      try {
+        size += hexToBytes('0x' + padToEven(key.slice(2))).length
+        size += hexToBytes(value).length
+      } catch {
+        // ignore
       }
-      return size
     }
-    try {
-      const files = fs.readdirSync(this.dataDir)
-      let size = 0
-      for (const file of files) {
-        const stats = fs.lstatSync(this.dataDir + '/' + file)
-        size += stats.size
-      }
-      return size
-    } catch (err: any) {
-      throw new Error(`Error reading data directory: ${err.toString()}`)
-    }
+    return size
   }
 
   /**

--- a/packages/portalnetwork/src/util/config.ts
+++ b/packages/portalnetwork/src/util/config.ts
@@ -1,5 +1,3 @@
-import { execSync } from 'child_process'
-import { readFileSync } from 'fs'
 import { SignableENR } from '@chainsafe/enr'
 import { hexToBytes } from '@ethereumjs/util'
 import { keys } from '@libp2p/crypto'
@@ -23,7 +21,7 @@ export interface PortalClientOpts {
   pk?: string
   bootnode?: string
   bindAddress?: string
-  bootnodeList?: string
+  bootnodeList?: string[]
   dataDir?: string
   networks: string
   storage: string
@@ -38,11 +36,10 @@ export const NetworkStrings: Record<string, NetworkId> = {
 }
 
 export const cliConfig = async (args: PortalClientOpts) => {
-  const cmd = 'hostname -I'
   const ip =
     args.bindAddress !== undefined
       ? args.bindAddress.split(':')[0]
-      : execSync(cmd).toString().split(' ')[0].trim()
+      : '0.0.0.0'
   const bindPort = args.bindAddress !== undefined ? args.bindAddress.split(':')[1] : 9000 // Default discv5 port
   let privateKey: AsyncReturnType<typeof keys.generateKeyPair>
   try {
@@ -100,9 +97,7 @@ export const cliConfig = async (args: PortalClientOpts) => {
     bootnodes.push(args.bootnode)
   }
   if (args.bootnodeList !== undefined) {
-    const bootnodeData = readFileSync(args.bootnodeList, 'utf-8')
-    const bootnodeList = bootnodeData.split('\n')
-    for (const bootnode of bootnodeList) {
+    for (const bootnode of args.bootnodeList) {
       bootnodes.push(bootnode)
     }
   }

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -1,5 +1,3 @@
-import { promises as fs } from 'fs'
-import * as path from 'path'
 import { digest } from '@chainsafe/as-sha256'
 import { ENR } from '@chainsafe/enr'
 import {
@@ -59,16 +57,6 @@ export const generateRandomNodeIdAtDistance = (nodeId: NodeId, targetDistance: n
  */
 export const serializedContentKeyToContentId = (contentKey: Uint8Array) => {
   return bytesToUnprefixedHex(digest(contentKey))
-}
-
-export const dirSize = async (directory: string) => {
-  const files = await fs?.readdir(directory)
-  const stats = files.map((file) => fs?.stat(path.join(directory, file)))
-  const bytesSize = (await Promise.all(stats)).reduce(
-    (accumulator, { size }) => accumulator + size,
-    0,
-  )
-  return bytesSize / MEGABYTE
 }
 
 export function arrayByteLength(byteArray: any[]): number {

--- a/packages/portalnetwork/test/util/util.spec.ts
+++ b/packages/portalnetwork/test/util/util.spec.ts
@@ -4,7 +4,6 @@ import { assert, describe, it } from 'vitest'
 
 import {
   arrayByteLength,
-  dirSize,
   generateRandomNodeIdAtDistance,
   shortId,
 } from '../../src/util/index.js'
@@ -37,6 +36,5 @@ describe('utility method tests', async () => {
       5,
       'computed correct length of nested Uint8Arrays',
     )
-    assert.equal(await dirSize('./test/util/testDir'), 0.00002765655517578125)
   })
 })


### PR DESCRIPTION
Removes use of `fs` and `child_process` from `portalnetwork/src/util/config.ts`

Moves functionality to CLI startup script.  `fs` was used to import a bootnodes file, and `child_process` was used to determine `ip` if not set manually.