### PR TITLE
RPC: Ping extension support

### DIFF
--- a/packages/cli/src/rpc/modules/ultralight.ts
+++ b/packages/cli/src/rpc/modules/ultralight.ts
@@ -1,5 +1,5 @@
 import { hexToBytes } from '@ethereumjs/util'
-import { HistoryNetworkContentType, NetworkId, addRLPSerializedBlock } from 'portalnetwork'
+import { HistoryNetworkContentType, NetworkId } from 'portalnetwork'
 
 import { INTERNAL_ERROR } from '../error-code.js'
 import { middleware, validators } from '../validators.js'
@@ -22,6 +22,7 @@ const methods = [
   'ultralight_getNetworkDBSize',
   'ultralight_pruneNetworkDB',
   'ultralight_setNetworkStorage',
+  'ultralight_getPingPayload'
 ]
 
 export class ultralight {
@@ -63,6 +64,10 @@ export class ultralight {
     this.setNetworkStorage = middleware(this.setNetworkStorage.bind(this), 2, [
       [validators.networkId],
       [validators.megabytes],
+    ])
+    this.getPingPayload = middleware(this.getPingPayload.bind(this), 1, [
+      [validators.networkId],
+      [validators.extension]
     ])
   }
   async methods() {
@@ -196,4 +201,17 @@ export class ultralight {
       radius: '0x' + network.nodeRadius.toString(16),
     }
   }
+  async getPingPayload(params: [NetworkId, number]) {
+    const [networkId, extension] = params
+    const network = this._client.networks.get(networkId)
+    if (!network) {
+      throw {
+        code: INTERNAL_ERROR, 
+        message: `Invalid network id ${networkId}`,
+      }
+    }
+    const payload = network.pingPongPayload(extension)
+    return payload
+  }
+  
 }

--- a/packages/cli/src/rpc/validators.ts
+++ b/packages/cli/src/rpc/validators.ts
@@ -1,5 +1,5 @@
 import { bytesToHex } from '@ethereumjs/util'
-import { HistoryNetworkContentType, NetworkId } from 'portalnetwork'
+import { HistoryNetworkContentType, NetworkId, PingPongCustomPayload } from 'portalnetwork'
 
 import { isValidEnr } from '../util.js'
 
@@ -506,4 +506,22 @@ export const validators = {
       }
     }
   },
+
+  get extension() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'number') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a number`,
+        }
+      }
+      if (!(params[index] in PingPongCustomPayload)) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a supported PingPong payload type`,
+        }
+      }
+    }
+  },
 }
+


### PR DESCRIPTION
Implements changes in https://github.com/ethereum/portal-network-specs/pull/369/files

- Adds helper method `ultralight_getPingPayload`
  - Params: `NetworkId`, `Extension Type`
  - Returns: Ping extension payload

TODO: 
- Updates `portal_*Ping` with ping extension support