### PR TITLE
Return ephemeral headers in FOUNDCONTENT

### DIFF
--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -21,9 +21,10 @@ import debug from 'debug'
 import { getENR, shortId } from '../../util/util.js'
 import {
   FoundContent,
-  MAX_PACKET_SIZE,
+  MAX_UDP_PACKET_SIZE,
   RequestCode,
   encodeWithVariantPrefix,
+  getTalkReqOverhead,
   randUint16,
 } from '../../wire/index.js'
 import { ContentMessageType, MessageCodes, PortalWireMessageType } from '../../wire/types.js'
@@ -573,7 +574,10 @@ export class BeaconLightClientNetwork extends BaseNetwork {
     const value = await this.findContentLocally(decodedContentMessage.contentKey)
     if (!value) {
       await this.enrResponse(decodedContentMessage.contentKey, src, requestId)
-    } else if (value !== undefined && value.length < MAX_PACKET_SIZE) {
+    } else if (
+      value !== undefined &&
+      value.length < MAX_UDP_PACKET_SIZE - getTalkReqOverhead(hexToBytes(this.networkId).byteLength)
+    ) {
       this.logger(
         'Found value for requested content ' +
           bytesToHex(decodedContentMessage.contentKey) +

--- a/packages/portalnetwork/src/networks/beacon/types.ts
+++ b/packages/portalnetwork/src/networks/beacon/types.ts
@@ -76,8 +76,3 @@ export type HistoricalSummaries = Array<{
   blockSummaryRoot: Uint8Array
   stateSummaryRoot: Uint8Array
 }>
-
-export type EphemeralHeaderKeyValues = {
-  blockHash: Uint8Array
-  ancestorCount: number
-}

--- a/packages/portalnetwork/src/networks/beacon/types.ts
+++ b/packages/portalnetwork/src/networks/beacon/types.ts
@@ -54,7 +54,11 @@ export const HistoricalSummariesKey = new ContainerType({ epoch: new UintBigintT
 
 export const HistoricalSummariesStateProof = new VectorCompositeType(Bytes32Type, 5)
 
-export const HistoricalSummariesWithProof = new ContainerType(
+export const HistoricalSummariesWithProof = new ContainerType<{
+  epoch: UintBigintType
+  historicalSummaries: typeof ssz.capella.BeaconState.fields.historicalSummaries
+  proof: typeof HistoricalSummariesStateProof
+}>(
   {
     epoch: new UintBigintType(8),
     historicalSummaries: ssz.capella.BeaconState.fields.historicalSummaries,
@@ -72,3 +76,8 @@ export type HistoricalSummaries = Array<{
   blockSummaryRoot: Uint8Array
   stateSummaryRoot: Uint8Array
 }>
+
+export type EphemeralHeaderKeyValues = {
+  blockHash: Uint8Array
+  ancestorCount: number
+}

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -313,6 +313,8 @@ export class HistoryNetwork extends BaseNetwork {
         beacon.lightClient?.status === RunStatusCode.uninitialized ||
         beacon.lightClient?.status === RunStatusCode.stopped
       ) {
+        // TODO: Decide whether to keep this or not.  It's not technically correct according to the spec
+        // since you can track the HEAD of the chan however you want.
         const errorMessage = 'Cannot verify ephemeral headers when beacon network is not running'
         this.logger.extend('FINDCONTENT')(errorMessage)
         throw new Error(errorMessage)
@@ -450,6 +452,9 @@ export class HistoryNetwork extends BaseNetwork {
             }
           }
         }
+        this.logger.extend('FOUNDCONTENT')(
+          `found ${headersList.length} ancestor headers for ${bytesToHex(contentKey.keyOpt.blockHash)}`,
+        )
         value = EphemeralHeaderPayload.serialize(headersList)
       }
     } else {

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -566,6 +566,10 @@ export class HistoryNetwork extends BaseNetwork {
 
       case HistoryNetworkContentType.EphemeralHeader: {
         const payload = EphemeralHeaderPayload.deserialize(value)
+        if (payload.length === 0) {
+          this.logger.extend('STORE')('Received empty ephemeral header payload')
+          return
+        }
         try {
           // Verify first header matches requested header
           const firstHeader = BlockHeader.fromRLPSerializedHeader(payload[0], { setHardfork: true })

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -307,20 +307,6 @@ export class HistoryNetwork extends BaseNetwork {
    * @returns the value of the FOUNDCONTENT response or undefined
    */
   public sendFindContent = async (enr: ENR, key: Uint8Array) => {
-    if (key[0] === HistoryNetworkContentType.EphemeralHeader) {
-      const beacon = this.portal.network()['0x500c']
-      if (
-        beacon === undefined ||
-        beacon.lightClient?.status === RunStatusCode.uninitialized ||
-        beacon.lightClient?.status === RunStatusCode.stopped
-      ) {
-        // TODO: Decide whether to keep this or not.  It's not technically correct according to the spec
-        // since you can track the HEAD of the chan however you want.
-        const errorMessage = 'Cannot verify ephemeral headers when beacon network is not running'
-        this.logger.extend('FINDCONTENT')(errorMessage)
-        throw new Error(errorMessage)
-      }
-    }
     this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
     const payload = PortalWireMessageType.serialize({

--- a/packages/portalnetwork/src/networks/history/types.ts
+++ b/packages/portalnetwork/src/networks/history/types.ts
@@ -225,3 +225,8 @@ export const EphemeralHeaderPayload = new ListCompositeType(
   BlockHeader,
   MAX_EPHEMERAL_HEADERS_PAYLOAD,
 )
+
+export type EphemeralHeaderKeyValues = {
+  blockHash: Uint8Array
+  ancestorCount: number
+}

--- a/packages/portalnetwork/src/networks/history/util.ts
+++ b/packages/portalnetwork/src/networks/history/util.ts
@@ -41,6 +41,7 @@ import type { WithdrawalBytes } from '@ethereumjs/util'
 import type { ForkConfig } from '@lodestar/config'
 import type { HistoryNetwork } from './history.js'
 import type { BlockBodyContent, Witnesses } from './types.js'
+import type { EphemeralHeaderKeyValues } from '../beacon/types.js'
 
 export const BlockHeaderByNumberKey = (blockNumber: bigint) => {
   return Uint8Array.from([
@@ -120,12 +121,15 @@ export const decodeHistoryNetworkContentKey = (
         | HistoryNetworkContentType.BlockHeader
         | HistoryNetworkContentType.BlockBody
         | HistoryNetworkContentType.Receipt
-        | HistoryNetworkContentType.EphemeralHeader
       keyOpt: Uint8Array
     }
   | {
       contentType: HistoryNetworkContentType.BlockHeaderByNumber
       keyOpt: bigint
+    }
+  | {
+      contentType: HistoryNetworkContentType.EphemeralHeader
+      keyOpt: EphemeralHeaderKeyValues
     } => {
   const contentType: HistoryNetworkContentType = contentKey[0]
   switch (contentType) {
@@ -140,7 +144,7 @@ export const decodeHistoryNetworkContentKey = (
       const key = EphemeralHeaderKey.deserialize(contentKey.slice(1))
       return {
         contentType,
-        keyOpt: key.blockHash,
+        keyOpt: key,
       }
     }
     default: {

--- a/packages/portalnetwork/src/networks/history/util.ts
+++ b/packages/portalnetwork/src/networks/history/util.ts
@@ -58,7 +58,7 @@ export const BlockHeaderByNumberKey = (blockNumber: bigint) => {
  */
 export const getContentKey = (
   contentType: HistoryNetworkContentType,
-  key: Uint8Array | bigint | { blockHash: Uint8Array; ancestorCount: number },
+  key: Uint8Array | bigint | EphemeralHeaderKeyValues,
 ): Uint8Array => {
   let encodedKey
   switch (contentType) {

--- a/packages/portalnetwork/src/networks/history/util.ts
+++ b/packages/portalnetwork/src/networks/history/util.ts
@@ -41,7 +41,7 @@ import type { WithdrawalBytes } from '@ethereumjs/util'
 import type { ForkConfig } from '@lodestar/config'
 import type { HistoryNetwork } from './history.js'
 import type { BlockBodyContent, Witnesses } from './types.js'
-import type { EphemeralHeaderKeyValues } from '../beacon/types.js'
+import type { EphemeralHeaderKeyValues } from '../history/types.js'
 
 export const BlockHeaderByNumberKey = (blockNumber: bigint) => {
   return Uint8Array.from([

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -211,7 +211,6 @@ export abstract class BaseNetwork extends EventEmitter {
 
   public async handle(message: ITalkReqMessage, src: INodeAddress) {
     const id = message.id
-    const network = message.protocol
     const request = message.request
     const deserialized = PortalWireMessageType.deserialize(request)
     const decoded = deserialized.value
@@ -378,7 +377,9 @@ export abstract class BaseNetwork extends EventEmitter {
     if (this.capabilities.includes(pingMessage.payloadType)) {
       switch (pingMessage.payloadType) {
         case PingPongPayloadExtensions.CLIENT_INFO_RADIUS_AND_CAPABILITIES: {
-          const { DataRadius, Capabilities, ClientInfo } = ClientInfoAndCapabilities.deserialize(pingMessage.customPayload)
+          const { DataRadius, Capabilities, ClientInfo } = ClientInfoAndCapabilities.deserialize(
+            pingMessage.customPayload,
+          )
           this.routingTable.updateRadius(src.nodeId, DataRadius)
           this.portal.enrCache.updateNodeFromPing(src, this.networkId, {
             capabilities: Capabilities,

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -35,7 +35,7 @@ import {
   ContentMessageType,
   ErrorPayload,
   HistoryRadius,
-  MAX_PACKET_SIZE,
+  MAX_UDP_PACKET_SIZE,
   MessageCodes,
   NodeLookup,
   PingPongErrorCodes,
@@ -48,6 +48,7 @@ import {
   encodeClientInfo,
   encodeWithVariantPrefix,
   generateRandomNodeIdAtDistance,
+  getTalkReqOverhead,
   randUint16,
   shortId,
 } from '../index.js'
@@ -762,7 +763,10 @@ export abstract class BaseNetwork extends EventEmitter {
     const value = await this.findContentLocally(decodedContentMessage.contentKey)
     if (!value) {
       await this.enrResponse(decodedContentMessage.contentKey, src, requestId)
-    } else if (value instanceof Uint8Array && value.length < MAX_PACKET_SIZE) {
+    } else if (
+      value instanceof Uint8Array &&
+      value.length < MAX_UDP_PACKET_SIZE - getTalkReqOverhead(hexToBytes(this.networkId).byteLength)
+    ) {
       this.logger(
         'Found value for requested content ' +
           bytesToHex(decodedContentMessage.contentKey) +
@@ -818,7 +822,11 @@ export abstract class BaseNetwork extends EventEmitter {
     if (encodedEnrs.length > 0) {
       this.logger.extend('FINDCONTENT')(`Found ${encodedEnrs.length} closer to content`)
       // TODO: Add capability to send multiple TALKRESP messages if # ENRs exceeds packet size
-      while (encodedEnrs.length > 0 && arrayByteLength(encodedEnrs) > MAX_PACKET_SIZE) {
+      while (
+        encodedEnrs.length > 0 &&
+        arrayByteLength(encodedEnrs) >
+          MAX_UDP_PACKET_SIZE - getTalkReqOverhead(hexToBytes(this.networkId).byteLength)
+      ) {
         // Remove ENRs until total ENRs less than 1200 bytes
         encodedEnrs.pop()
       }

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -78,3 +78,76 @@ export const getENR = (routingTable: RoutingTable, enrOrId: string) => {
       : routingTable.getWithPending(enrOrId.slice(2))?.value
   return enr
 }
+
+/**
+ * Bidirectional map that maintains a one-to-one correspondence between keys and values.
+ * When a key-value pair is added, any existing pairs with the same key or value are removed.
+ * @template T The type of the keys
+ * @template U The type of the values
+ * @note Build by robots with oversight by acolytec3
+ */
+export class BiMap<T, U> {
+  #forward = new Map<T, U>()
+  #reverse = new Map<U, T>()
+
+  /**
+   * Sets a key-value pair in the map. If either the key or value already exists,
+   * the old mapping is removed before the new one is added.
+   * @param key The key to set
+   * @param value The value to set
+   */
+  set(key: T, value: U): void {
+    const oldValue = this.#forward.get(key)
+    if (oldValue !== undefined) {
+      this.#reverse.delete(oldValue)
+    }
+
+    const oldKey = this.#reverse.get(value)
+    if (oldKey !== undefined) {
+      this.#forward.delete(oldKey)
+    }
+
+    this.#forward.set(key, value)
+    this.#reverse.set(value, key)
+  }
+
+  /**
+   * Gets a value by its key
+   * @param key The key to look up
+   * @returns The associated value, or undefined if the key doesn't exist
+   */
+  getByKey(key: T): U | undefined {
+    return this.#forward.get(key)
+  }
+
+  /**
+   * Gets a key by its value
+   * @param value The value to look up
+   * @returns The associated key, or undefined if the value doesn't exist
+   */
+  getByValue(value: U): T | undefined {
+    return this.#reverse.get(value)
+  }
+
+  /**
+   * Removes a key-value pair from the map
+   * @param key The key to remove
+   * @returns true if a pair was removed, false if the key didn't exist
+   */
+  delete(key: T): boolean {
+    const value = this.#forward.get(key)
+    if (value === undefined) return false
+
+    this.#forward.delete(key)
+    this.#reverse.delete(value)
+    return true
+  }
+
+  /**
+   * Gets the size of the map
+   * @returns the size of the map
+   */
+  get size(): number {
+    return this.#forward.size
+  }
+}

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -85,6 +85,7 @@ export const getENR = (routingTable: RoutingTable, enrOrId: string) => {
  * @template T The type of the keys
  * @template U The type of the values
  * @note Built by robots with oversight by acolytec3
+ * @note Uint8Arrays can not be used as keys or values in this class since bytes are not directly comparable
  */
 export class BiMap<T, U> {
   #forward = new Map<T, U>()

--- a/packages/portalnetwork/src/util/util.ts
+++ b/packages/portalnetwork/src/util/util.ts
@@ -84,7 +84,7 @@ export const getENR = (routingTable: RoutingTable, enrOrId: string) => {
  * When a key-value pair is added, any existing pairs with the same key or value are removed.
  * @template T The type of the keys
  * @template U The type of the values
- * @note Build by robots with oversight by acolytec3
+ * @note Built by robots with oversight by acolytec3
  */
 export class BiMap<T, U> {
   #forward = new Map<T, U>()

--- a/packages/portalnetwork/src/wire/utp/Utils/constants.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/constants.ts
@@ -24,7 +24,7 @@ export const AUTO_ACK_SMALLER_THAN_ACK_NUMBER: boolean = true
 export const MINIMUM_DIFFERENCE_TIMESTAMP_MICROSEC: number = 120000000
 
 export const DEFAULT_PACKET_SIZE = 512
-export const MAX_PACKET_SIZE: number = 1225
+export const MAX_UDP_PACKET_SIZE: number = 1280
 export const MIN_PACKET_SIZE: number = 150
 export const MINIMUM_MTU: number = 576
 export const SEND_IN_BURST: boolean = true
@@ -34,7 +34,7 @@ export const MICROSECOND_WAIT_BETWEEN_BURSTS: number = 28000
 export const TIME_WAIT_AFTER_LAST_PACKET: number = 3000000
 export const ONLY_POSITIVE_GAIN: boolean = false
 export const DEBUG: boolean = false
-export const MAX_UTP_PACKET_LENGTH = MAX_PACKET_SIZE
+export const MAX_UTP_PACKET_LENGTH = MAX_UDP_PACKET_SIZE
 export const MAX_UDP_HEADER_LENGTH = 48
 export const DEF_HEADER_LENGTH = 20
 

--- a/packages/portalnetwork/src/wire/utp/Utils/constants.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/constants.ts
@@ -25,18 +25,6 @@ export const MINIMUM_DIFFERENCE_TIMESTAMP_MICROSEC: number = 120000000
 
 export const DEFAULT_PACKET_SIZE = 512
 export const MAX_UDP_PACKET_SIZE: number = 1280
-export const MIN_PACKET_SIZE: number = 150
-export const MINIMUM_MTU: number = 576
-export const SEND_IN_BURST: boolean = true
-export const MAX_BURST_SEND: number = 5
-export const MIN_SKIP_PACKET_BEFORE_RESEND: number = 3
-export const MICROSECOND_WAIT_BETWEEN_BURSTS: number = 28000
-export const TIME_WAIT_AFTER_LAST_PACKET: number = 3000000
-export const ONLY_POSITIVE_GAIN: boolean = false
-export const DEBUG: boolean = false
-export const MAX_UTP_PACKET_LENGTH = MAX_UDP_PACKET_SIZE
-export const MAX_UDP_HEADER_LENGTH = 48
-export const DEF_HEADER_LENGTH = 20
 
 export const startingNrs: Record<RequestCode, { seqNr: number; ackNr: number }> = {
   [RequestCode.FOUNDCONTENT_WRITE]: { seqNr: randUint16(), ackNr: 0 },

--- a/packages/portalnetwork/src/wire/utp/Utils/index.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/index.ts
@@ -1,3 +1,4 @@
 export * from './constants.js'
 export * from './math.js'
 export * from './variantPrefix.js'
+export * from './packet.js'

--- a/packages/portalnetwork/src/wire/utp/Utils/packet.ts
+++ b/packages/portalnetwork/src/wire/utp/Utils/packet.ts
@@ -1,0 +1,21 @@
+/**
+ * Compute the number of bytes required for a TALKREQ message header
+ * @param protocolIdLen is the length of the protocol ID
+ * @returns the number of bytes required for a TALKREQ message header
+ *
+ * @note Shamelessly copied from [Fluffy](https://github.com/status-im/nimbus-eth1/blob/45767278174a48521de46f029f6e66dc526880f6/fluffy/network/wire/messages.nim#L179)
+ */
+
+export const getTalkReqOverhead = (protocolIdLen: number): number => {
+  return (
+    16 + // IV size
+    55 + // header size
+    1 + // talkReq msg id
+    3 + // rlp encoding outer list, max length will be encoded in 2 bytes
+    9 + // request id (max = 8) + 1 byte from rlp encoding byte string
+    protocolIdLen + // bytes length of protocolid (e.g. 0x500b for History Network)
+    1 + // + 1 is necessary due to rlp encoding of byte string
+    3 + // rlp encoding response byte string, max length in 2 bytes
+    16 // HMAC
+  )
+}

--- a/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
+++ b/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
@@ -1,0 +1,90 @@
+import { SignableENR } from '@chainsafe/enr'
+import type { BlockHeader, JsonRpcBlock } from '@ethereumjs/block'
+import { Block } from '@ethereumjs/block'
+import { hexToBytes } from '@ethereumjs/util'
+import { keys } from '@libp2p/crypto'
+import { multiaddr } from '@multiformats/multiaddr'
+import { assert, beforeAll, describe, it } from 'vitest'
+import {
+  EphemeralHeaderPayload,
+  HistoryNetworkContentType,
+  NetworkId,
+  PortalNetwork,
+  getContentKey,
+} from '../../src/index.js'
+import latestBlocks from '../networks/history/testData/latest3Blocks.json'
+
+describe('should be able to retrieve ephemeral headers from a peer', () => {
+  let headers: BlockHeader[]
+  let headerPayload: Uint8Array
+  let contentKey: Uint8Array
+  beforeAll(() => {
+    headers = []
+    headers.push(Block.fromRPC(latestBlocks[0] as JsonRpcBlock, [], { setHardfork: true }).header)
+    headers.push(Block.fromRPC(latestBlocks[1] as JsonRpcBlock, [], { setHardfork: true }).header)
+    headers.push(Block.fromRPC(latestBlocks[2] as JsonRpcBlock, [], { setHardfork: true }).header)
+    headerPayload = EphemeralHeaderPayload.serialize(headers.map((h) => h.serialize()))
+    contentKey = getContentKey(HistoryNetworkContentType.EphemeralHeader, {
+      blockHash: headers[0].hash(),
+      ancestorCount: headers.length - 1,
+    })
+  })
+  it('should be able to retrieve ephemeral headers from a peer', async () => {
+    const privateKeys = [
+      '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
+      '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
+    ]
+
+    const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
+    const enr1 = SignableENR.createFromPrivateKey(pk1)
+    const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
+    const enr2 = SignableENR.createFromPrivateKey(pk2)
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/3198`)
+    enr1.setLocationMultiaddr(initMa)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/3199`)
+    enr2.setLocationMultiaddr(initMa2)
+    const node1 = await PortalNetwork.create({
+      supportedNetworks: [
+        { networkId: NetworkId.HistoryNetwork },
+        { networkId: NetworkId.BeaconChainNetwork },
+      ],
+      config: {
+        enr: enr1,
+        bindAddrs: {
+          ip4: initMa,
+        },
+        privateKey: pk1,
+      },
+    })
+
+    const node2 = await PortalNetwork.create({
+      supportedNetworks: [
+        { networkId: NetworkId.HistoryNetwork },
+        { networkId: NetworkId.BeaconChainNetwork },
+      ],
+      config: {
+        enr: enr2,
+        bindAddrs: {
+          ip4: initMa2,
+        },
+        privateKey: pk2,
+      },
+    })
+    await node1.start()
+    await node2.start()
+    const network1 = node1.network()['0x500b']
+    await network1!.store(contentKey, headerPayload)
+    const network2 = node2.network()['0x500b']
+    const res = await network2!.sendFindContent(node1.discv5.enr.toENR(), contentKey)
+    assert.exists(res)
+    if ('content' in res!) {
+      const payload = EphemeralHeaderPayload.deserialize(res.content)
+      assert.equal(payload.length, headers.length)
+      assert.deepEqual(payload[0], headers[0].serialize())
+      assert.deepEqual(payload[1], headers[1].serialize())
+      assert.deepEqual(payload[2], headers[2].serialize())
+    } else {
+      assert.fail('Expected content in response')
+    }
+  })
+})

--- a/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
+++ b/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
@@ -87,6 +87,7 @@ describe('should be able to retrieve ephemeral headers from a peer', () => {
       assert.fail('Expected content in response')
     }
 
+    // Verify that we get a single ancestor for a content key with an ancestor count of 1
     const contentKeyForOneAncestor = getContentKey(HistoryNetworkContentType.EphemeralHeader, {
       blockHash: headers[0].hash(),
       ancestorCount: 1,
@@ -116,5 +117,5 @@ describe('should be able to retrieve ephemeral headers from a peer', () => {
     } else {
       assert.fail('Expected content in response')
     }
-  }, 10000)
+  })
 })

--- a/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
+++ b/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
@@ -97,7 +97,7 @@ describe('should be able to retrieve ephemeral headers from a peer', () => {
     assert.exists(res2)
     if ('content' in res2!) {
       const payload = EphemeralHeaderPayload.deserialize(res2.content)
-      assert.equal(payload.length, 1, 'should only get a single ancestor')
+      assert.equal(payload.length, 2, 'should only get a single ancestor')
     } else {
       assert.fail('Expected content in response')
     }

--- a/packages/portalnetwork/test/networks/history/ephemeralHeader.spec.ts
+++ b/packages/portalnetwork/test/networks/history/ephemeralHeader.spec.ts
@@ -35,7 +35,7 @@ describe('ephemeral header handling', () => {
     const storedHeaderPayload = await network?.get(getEphemeralHeaderDbKey(headers[0].hash()))
     assert.deepEqual(hexToBytes(storedHeaderPayload!), headers[0].serialize())
     assert.equal(
-      network?.ephemeralHeaderIndex.get(headers[1].number),
+      network?.ephemeralHeaderIndex.getByKey(headers[1].number),
       bytesToHex(headers[1].hash()),
     )
   })

--- a/packages/portalnetwork/test/networks/history/ephemeralHeader.spec.ts
+++ b/packages/portalnetwork/test/networks/history/ephemeralHeader.spec.ts
@@ -1,7 +1,7 @@
-import { assert, beforeAll, describe, it } from 'vitest'
-import { Block } from '@ethereumjs/block'
 import type { BlockHeader, JsonRpcBlock } from '@ethereumjs/block'
-import latestBlocks from './testData/latest3Blocks.json'
+import { Block } from '@ethereumjs/block'
+import { hexToBytes } from '@ethereumjs/util'
+import { assert, beforeAll, describe, it } from 'vitest'
 import {
   EphemeralHeaderPayload,
   HistoryNetworkContentType,
@@ -11,7 +11,8 @@ import {
   getContentKey,
   getEphemeralHeaderDbKey,
 } from '../../../src/index.js'
-import { bytesToHex, hexToBytes } from '@ethereumjs/util'
+import latestBlocks from './testData/latest3Blocks.json'
+
 describe('ephemeral header handling', () => {
   let headers: BlockHeader[]
   let headerPayload: Uint8Array
@@ -24,20 +25,17 @@ describe('ephemeral header handling', () => {
     headerPayload = EphemeralHeaderPayload.serialize(headers.map((h) => h.serialize()))
     contentKey = getContentKey(HistoryNetworkContentType.EphemeralHeader, {
       blockHash: headers[0].hash(),
-      ancestorCount: headers.length,
+      ancestorCount: headers.length - 1,
     })
   })
   it('should be able to store a valid ephemeral header payload', async () => {
     const node = await PortalNetwork.create({})
     const network = node.network()['0x500b']
 
-    await network?.store(contentKey, headerPayload)
+    await network!.store(contentKey, headerPayload)
     const storedHeaderPayload = await network?.get(getEphemeralHeaderDbKey(headers[0].hash()))
     assert.deepEqual(hexToBytes(storedHeaderPayload!), headers[0].serialize())
-    assert.equal(
-      network?.ephemeralHeaderIndex.getByKey(headers[1].number),
-      bytesToHex(headers[1].hash()),
-    )
+    assert.deepEqual(network!.ephemeralHeaderIndex.getByKey(headers[1].number), headers[1].hash())
   })
   it('should produce the correct HISTORY_RADIUS ping payload', async () => {
     const node = await PortalNetwork.create({})

--- a/packages/portalnetwork/test/networks/history/ephemeralHeader.spec.ts
+++ b/packages/portalnetwork/test/networks/history/ephemeralHeader.spec.ts
@@ -1,6 +1,6 @@
 import type { BlockHeader, JsonRpcBlock } from '@ethereumjs/block'
 import { Block } from '@ethereumjs/block'
-import { hexToBytes } from '@ethereumjs/util'
+import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { assert, beforeAll, describe, it } from 'vitest'
 import {
   EphemeralHeaderPayload,
@@ -35,7 +35,10 @@ describe('ephemeral header handling', () => {
     await network!.store(contentKey, headerPayload)
     const storedHeaderPayload = await network?.get(getEphemeralHeaderDbKey(headers[0].hash()))
     assert.deepEqual(hexToBytes(storedHeaderPayload!), headers[0].serialize())
-    assert.deepEqual(network!.ephemeralHeaderIndex.getByKey(headers[1].number), headers[1].hash())
+    assert.deepEqual(
+      network!.ephemeralHeaderIndex.getByKey(headers[1].number),
+      bytesToHex(headers[1].hash()),
+    )
   })
   it('should produce the correct HISTORY_RADIUS ping payload', async () => {
     const node = await PortalNetwork.create({})

--- a/packages/portalnetwork/test/util/bimap.spec.ts
+++ b/packages/portalnetwork/test/util/bimap.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { BiMap } from '../../src/index.js'
+
+describe('BiMap', () => {
+  it('should be able to set, get, and delete values', () => {
+    const bimap = new BiMap()
+    bimap.set(1, 'a')
+    bimap.set(2, 'b')
+    bimap.set(3, 'c')
+    expect(bimap.getByKey(1)).toBe('a')
+    expect(bimap.getByKey(2)).toBe('b')
+    expect(bimap.getByKey(3)).toBe('c')
+    expect(bimap.getByValue('a')).toBe(1)
+    expect(bimap.getByValue('b')).toBe(2)
+    expect(bimap.getByValue('c')).toBe(3)
+    bimap.delete(2)
+    expect(bimap.getByKey(2)).toBeUndefined()
+    expect(bimap.getByValue('b')).toBeUndefined()
+    bimap.delete(1)
+    expect(bimap.getByKey(1)).toBeUndefined()
+    expect(bimap.getByValue('a')).toBeUndefined()
+    expect(bimap.size).toBe(1)
+  })
+})


### PR DESCRIPTION
This continues work on #741

- Returns ephemeral headers in FOUNDCONTENT messages
- Adds a new `BiMap` class for the ephemeral headers index
- Cleans up some typing related to Ephemeral Headers
- Adds new integration tests covering transmission of Ephemeral Headers with FINDCONTENT/CONTENT messages