### PR TITLE
RPC: fix portal_*PutContent

### DIFF
--- a/packages/cli/src/rpc/modules/portal.ts
+++ b/packages/cli/src/rpc/modules/portal.ts
@@ -823,11 +823,11 @@ export class portal {
     const d = distance(contentId, this._client.discv5.enr.nodeId)
     let storedLocally = false
     try {
+      const peerCount = await this._history.gossipContent(contentKey, content)
       if (d <= this._history.nodeRadius) {
         await this._history.store(contentKey, content)
         storedLocally = true
       }
-      const peerCount = await this._history.gossipContent(contentKey, content)
       return {
         peerCount,
         storedLocally,
@@ -845,11 +845,11 @@ export class portal {
     const d = distance(contentId, this._client.discv5.enr.nodeId)
     let storedLocally = false
     try {
+      const peerCount = await this._state.gossipContent(contentKey, content)
       if (d <= this._state.nodeRadius) {
         await this._state.store(contentKey, content)
         storedLocally = true
       }
-      const peerCount = await this._state.gossipContent(contentKey, content)
       return {
         peerCount,
         storedLocally,
@@ -867,11 +867,11 @@ export class portal {
     const d = distance(contentId, this._client.discv5.enr.nodeId)
     let storedLocally = false
     try {
+      const peerCount = await this._beacon.gossipContent(contentKey, content)
       if (d <= this._beacon.nodeRadius) {
         await this._beacon.store(contentKey, content)
         storedLocally = true
       }
-      const peerCount = await this._beacon.gossipContent(contentKey, content)
       return {
         peerCount,
         storedLocally,


### PR DESCRIPTION
Hive test for `portal_*PutContent` can fail, even though the content was successfully gossiped.

This happens because we call `.store` before `.gossipContent`

The return value for `portal_*PutContent` includes both a `PeerCount` for how many peers accepted the gossip, and a `storedLocally` boolean, indicating whether we also stored the content locally.  

Since gossip is also triggered by the `store` method, calling this method before `gossipContent` resulted in the content being gossiped during  `.store`.  Then when `gossipContent` is called, it returns a `PeerCount` of 0 because the same content was already gossiped.

By switching the order in which these methods are called, we get an accurate `PeerCount` value.

This fix can be verified in `hive`