### PR TITLE
CLI: use node:fs based size function

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,9 +33,7 @@ const main = async () => {
   log(`portalConfig: ${JSON.stringify(args, null, 2)}`)
   portalConfig.operatingSystemAndCpuArchitecture = args.arch
   portalConfig.shortCommit = args.commit ?? execSync('git rev-parse HEAD').toString().slice(0, 7)
-  portalConfig.dbSize = async () => {
-    return dirSize(args.dataDir ?? './')
-  }
+  portalConfig.dbSize = dirSize
   const portal = await PortalNetwork.create(portalConfig)
 
   log(`discv5Config: ${JSON.stringify(portal.discv5['config'], null, 2)}`)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import * as PromClient from 'prom-client'
 import { args } from './cliArgs.js'
 import { RPCManager } from './rpc/rpc.js'
 import { readFileSync } from 'fs'
+import { dirSize } from './util.js'
 
 const register = new PromClient.Registry()
 
@@ -27,12 +28,14 @@ const main = async () => {
   const portalConfig = await cliConfig({
     ...args,
     bindAddress: args.bindAddress ?? `${ip}:9000`,
-    bootnodeList: args.bootnodeList ? readFileSync(args.bootnodeList, 'utf-8').split('\n') : undefined,
+    bootnodeList: args.bootnodeList !== undefined ? readFileSync(args.bootnodeList, 'utf-8').split('\n') : undefined,
   })
   log(`portalConfig: ${JSON.stringify(args, null, 2)}`)
   portalConfig.operatingSystemAndCpuArchitecture = args.arch
   portalConfig.shortCommit = args.commit ?? execSync('git rev-parse HEAD').toString().slice(0, 7)
-
+  portalConfig.dbSize = async () => {
+    return dirSize(args.dataDir ?? './')
+  }
   const portal = await PortalNetwork.create(portalConfig)
 
   log(`discv5Config: ${JSON.stringify(portal.discv5['config'], null, 2)}`)
@@ -113,3 +116,5 @@ main().catch((err) => {
   console.error('Encountered an error', err)
   console.error('Shutting down...')
 })
+
+export * from './util.js'

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -54,7 +54,7 @@ export const addBootNode = async (networkId: NetworkId, baseNetwork: BaseNetwork
   }
 }
 
-const MEGABYTE = 1024 * 1024
+const MEGABYTE = 1000 * 1000
 
 export const dirSize = async (directory: string) => {
   const files = fs.readdirSync(directory)

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -1,7 +1,8 @@
 
 import type { BaseNetwork, NetworkId } from 'portalnetwork'
 import type { Enr } from './rpc/schema/types.js'
-
+import path from 'path'
+import fs from 'fs'
 export const hasValidEnrPrefix = (enr: Enr) => {
   return enr.startsWith('enr:')
 }
@@ -51,4 +52,16 @@ export const addBootNode = async (networkId: NetworkId, baseNetwork: BaseNetwork
     throw new Error(`Error adding bootnode ${enr} to network \
       ${networkId}: ${error.message ?? error}`)
   }
+}
+
+const MEGABYTE = 1024 * 1024
+
+export const dirSize = async (directory: string) => {
+  const files = fs.readdirSync(directory)
+  const stats = files.map((file) => fs.statSync(path.join(directory, file)))
+  const bytesSize = stats.reduce(
+    (accumulator, { size }) => accumulator + size,
+    0,
+  )
+  return bytesSize / MEGABYTE
 }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -117,6 +117,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
         break
       case TransportLayer.NODE:
       default:
+        dbSize = opts.dbSize
     }
 
     // Configure transport layer

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -198,7 +198,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
     this.bootnodes = opts.bootnodes ?? []
     this.uTP = new PortalNetworkUTP(this)
     this.utpTimout = opts.utpTimeout ?? 180000 // set default utpTimeout to 3 minutes
-    this.db = new DBManager(this.discv5.enr.nodeId, this.logger, opts.dbSize, opts.db) as DBManager
+    this.db = new DBManager(this.discv5.enr.nodeId, this.logger, async () => opts.dbSize(opts.dataDir ?? './'), opts.db) as DBManager
     opts.supportedNetworks = opts.supportedNetworks ?? []
     for (const network of opts.supportedNetworks) {
       switch (network.networkId) {

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -211,6 +211,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
               maxStorage: network.maxStorage,
               db: network.db,
               gossipCount: opts.gossipCount,
+              dbSize: async () => opts.dbSize((opts.dataDir ?? '.') + '/history'),
             }),
           )
           break
@@ -223,6 +224,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
               maxStorage: network.maxStorage,
               db: network.db,
               gossipCount: opts.gossipCount,
+              dbSize: async () => opts.dbSize((opts.dataDir ?? '.') + '/state'),
             }),
           )
           break
@@ -242,6 +244,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
                 sync: syncStrategy,
                 db: network.db,
                 gossipCount: opts.gossipCount,
+                dbSize: async () => opts.dbSize((opts.dataDir ?? '.') + '/beacon'),
               }),
             )
           }

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -51,7 +51,7 @@ export interface PortalNetworkOpts {
   rebuildFromMemory?: boolean
   config: Partial<IDiscv5CreateOptions>
   dataDir?: string
-  dbSize(): Promise<number>
+  dbSize(dir: string): Promise<number>
   trustedBlockRoot?: string
   eventLog?: boolean
   utpTimeout?: number

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -92,6 +92,7 @@ export abstract class BaseNetwork extends EventEmitter {
     maxStorage,
     bridge,
     gossipCount,
+    dbSize,
   }: BaseNetworkConfig) {
     super()
     this.bridge = bridge ?? false
@@ -109,6 +110,7 @@ export abstract class BaseNetwork extends EventEmitter {
       contentId: this.contentKeyToId,
       db,
       logger: this.logger,
+      dbSize,
     })
     if (this.portal.metrics) {
       this.portal.metrics.knownHistoryNodes.collect = () => {

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -16,6 +16,7 @@ interface NetworkDBConfig {
   logger?: Debugger
   contentId?: (contentKey: Uint8Array) => string
   maxStorage?: number
+  dbSize?: () => Promise<number>
 }
 
 export class NetworkDB {
@@ -27,7 +28,8 @@ export class NetworkDB {
   contentId: (contentKey: Uint8Array) => string
   logger: Debugger
   dataDir?: string
-  constructor({ networkId, nodeId, db, logger, contentId, maxStorage }: NetworkDBConfig) {
+  dbSize?: () => Promise<number>
+  constructor({ networkId, nodeId, db, logger, contentId, maxStorage, dbSize }: NetworkDBConfig) {
     this.networkId = networkId
     this.nodeId = nodeId ?? '0'.repeat(64)
     this.db = db?.db ?? (new MemoryLevel() as any)
@@ -40,6 +42,7 @@ export class NetworkDB {
         return bytesToHex(contentKey)
       }
     this.maxStorage = maxStorage ?? 1024
+    this.dbSize = dbSize
   }
 
   /**

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -131,6 +131,9 @@ export class NetworkDB {
    * @returns the size of the data directory in bytes
    */
   async size(): Promise<number> {
+    if (this.dbSize) {
+      return this.dbSize()
+    }
     let size = 0
     for await (const [key, value] of this.db.iterator()) {
       try {

--- a/packages/portalnetwork/src/networks/types.ts
+++ b/packages/portalnetwork/src/networks/types.ts
@@ -18,6 +18,7 @@ export interface BaseNetworkConfig {
   maxStorage?: number
   bridge?: boolean
   gossipCount?: number
+  dbSize?: () => Promise<number>
 }
 
 const BYTE_SIZE = 256


### PR DESCRIPTION
This reintroduces the `fs` based DB size function for use in the Node environment.  This function is more efficient and more accurate than the default iterative size function .

CLI client can set `portalConfig.dbSize` to custom `dirSize` function.

DBManager (client) can measure size of whole Portal Client DB (including network DB's)

Network DBManagers can measure size of subnetwork DB directory.

Network DBManagers will use more accurate dbSize method if available