### PR TITLE
Prune from approximate size

### DIFF
--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -649,6 +649,8 @@ export class HistoryNetwork extends BaseNetwork {
     const bodyContentKey = getContentKey(HistoryNetworkContentType.BlockBody, hashKey)
     if (block instanceof Block) {
       await this.put(bodyContentKey, bytesToHex(bodyBytes))
+      this.emit('ContentAdded', bodyContentKey, bodyBytes)
+
       // TODO: Decide when and if to build and store receipts.
       //       Doing this here caused a bottleneck when same receipt is gossiped via uTP at the same time.
       // if (block.transactions.length > 0) {
@@ -658,6 +660,7 @@ export class HistoryNetwork extends BaseNetwork {
       this.logger(`Could not verify block content`)
       this.logger(`Adding anyway for testing...`)
       await this.put(bodyContentKey, bytesToHex(bodyBytes))
+      this.emit('ContentAdded', bodyContentKey, bodyBytes)
       // TODO: Decide what to do here.  We shouldn't be storing block bodies without a corresponding header
       // as it's against spec
       return

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -36,6 +36,7 @@ import {
   ErrorPayload,
   HistoryRadius,
   MAX_UDP_PACKET_SIZE,
+  MEGABYTE,
   MessageCodes,
   NodeLookup,
   PingPongErrorCodes,
@@ -118,7 +119,8 @@ export abstract class BaseNetwork extends EventEmitter {
     }
     this.gossipManager = new GossipManager(this, gossipCount)
     this.on('ContentAdded', () => {
-      if (this.db.approximateSize > this.maxStorage) {
+      if ((this.db.approximateSize / MEGABYTE) > this.maxStorage) {
+        this.logger(`Pruning due to size limit ${this.db.approximateSize / MEGABYTE} > ${this.maxStorage}`)
         void this.prune()
       }
     })

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -74,7 +74,7 @@ export class NetworkDB {
       val = bytesToHex(val)
     }
     if (!key.startsWith('0x')) throw new Error('Key must be 0x prefixed hex string')
-    if (!val.startsWith('0x')) throw new Error('Key must be 0x prefixed hex string')
+    if (!val.startsWith('0x')) throw new Error('Value must be 0x prefixed hex string')
     try {
       await this.db.put(key, val)
     } catch (err: any) {

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -138,18 +138,20 @@ export class NetworkDB {
    * @returns the size of the data directory in bytes
    */
   async size(): Promise<number> {
-    if (this.dbSize) {
-      return this.dbSize()
-    }
     let size = 0
+    if (this.dbSize) {
+      size = await this.dbSize()
+    } else {
     for await (const [key, value] of this.db.iterator()) {
       try {
         size += hexToBytes('0x' + padToEven(key.slice(2))).length
         size += hexToBytes(value).length
-      } catch {
-        // ignore
+        } catch {
+          // ignore
+        }
       }
     }
+    this.approximateSize = size
     return size
   }
 

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -29,6 +29,7 @@ export class NetworkDB {
   logger: Debugger
   dataDir?: string
   dbSize?: () => Promise<number>
+  approximateSize: number
   constructor({ networkId, nodeId, db, logger, contentId, maxStorage, dbSize }: NetworkDBConfig) {
     this.networkId = networkId
     this.nodeId = nodeId ?? '0'.repeat(64)
@@ -43,6 +44,7 @@ export class NetworkDB {
       }
     this.maxStorage = maxStorage ?? 1024
     this.dbSize = dbSize
+    this.approximateSize = 0
   }
 
   /**

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -82,6 +82,8 @@ export class NetworkDB {
     }
     this.streaming.delete(key)
     this.logger(`Put ${key} in DB.  Size=${hexToBytes(padToEven(val)).length} bytes`)
+    this.approximateSize += 2 * (val.length - 2)
+    this.approximateSize += 2 * (key.length - 2)
   }
   /**
    * Get a value from the database by key.
@@ -119,7 +121,10 @@ export class NetworkDB {
     if (key instanceof Uint8Array) {
       key = bytesToHex(key)
     }
+    const val = await this.db.get(key)
     await this.db.del(key)
+    this.approximateSize -= 2 * (key.length - 2)
+    this.approximateSize -= 2 * (val.length - 2)
   }
   /**
    * Perform multiple put and/or del operations in bulk.

--- a/packages/portalnetwork/src/networks/networkDB.ts
+++ b/packages/portalnetwork/src/networks/networkDB.ts
@@ -176,6 +176,10 @@ export class NetworkDB {
   ): Promise<[string, string][]> {
     const toDelete: [string, string][] = []
     for await (const [key, value] of this.db.iterator()) {
+      if (!key.startsWith('0x')) {
+        this.logger.extend('prune')(`Skipping non-hex key: ${key}`)
+        continue
+      }
       // Calculate distance between node and content
       const d = distance(this.nodeId, this.contentId(hexToBytes(key)))
       // If content is out of radius -- delete content

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -242,6 +242,7 @@ export class StateNetwork extends BaseNetwork {
     }
     for (const { contentKey, dbContent } of interested) {
       await this.db.put(contentKey, dbContent)
+      this.emit('ContentAdded', contentKey, dbContent)
     }
     return { interested, notInterested }
   }
@@ -265,6 +266,7 @@ export class StateNetwork extends BaseNetwork {
       node: curRlp,
     })
     await this.db.put(contentKey, dbContent)
+    this.emit('ContentAdded', contentKey, dbContent)
   }
 
   async storeStorageTrieNode(contentKey: Uint8Array, content: Uint8Array) {
@@ -274,6 +276,7 @@ export class StateNetwork extends BaseNetwork {
       node: curRlp,
     })
     await this.db.put(contentKey, dbContent)
+    this.emit('ContentAdded', contentKey, dbContent)
   }
 
   async receiveStorageTrieNodeOffer(
@@ -344,6 +347,7 @@ export class StateNetwork extends BaseNetwork {
     }
     for (const { contentKey, dbContent } of interested) {
       await this.db.put(contentKey, dbContent)
+      this.emit('ContentAdded', contentKey, dbContent)
     }
     return { interested, notInterested }
   }
@@ -375,6 +379,7 @@ export class StateNetwork extends BaseNetwork {
     const codeContent = ContractRetrieval.serialize({ code })
     this.manager.trie.db.local.set(bytesToUnprefixedHex(codeHash), bytesToHex(contentKey))
     await this.db.put(contentKey, codeContent)
+    this.emit('ContentAdded', contentKey, codeContent)
     await this.receiveAccountTrieNodeOffer(
       ...extractAccountProof(addressHash, accountProof, blockHash),
     )

--- a/packages/portalnetwork/test/networks/history/networkDB.spec.ts
+++ b/packages/portalnetwork/test/networks/history/networkDB.spec.ts
@@ -1,0 +1,44 @@
+import { assert, describe, expect, it } from 'vitest'
+import content from '../../testData/headersWithProofs.json'
+import { HistoryNetwork, NetworkId, PortalNetwork } from '../../../src/index.js'
+import { keys } from '@libp2p/crypto'
+import { SignableENR } from '@chainsafe/enr'
+import { hexToBytes } from '@ethereumjs/util'
+
+const privateKey =
+  '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130'
+
+const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKey).slice(-36))
+const enr = SignableENR.createFromPrivateKey(pk1)
+
+describe('NetworkDB', async () => {
+  const client = await PortalNetwork.create({
+    config: {
+      privateKey: pk1,
+      enr,
+    },
+  })
+  const history = new HistoryNetwork({
+    client,
+    networkId: NetworkId.HistoryNetwork,
+  })
+  for (const [k, v] of content) {
+    await history.store(hexToBytes(k), hexToBytes(v))
+  }
+  const size = await history.db.size()
+  it('should have the correct size', () => {
+    assert.equal(size, 10572)
+  })
+  const newMaxStorage = 0.01
+  it('should change prune and shrink radius', async () => {
+    expect(size).toBeGreaterThan(newMaxStorage * 1000000)
+    assert.isFalse(history.pruning)
+    assert.equal(history.nodeRadius, 2n ** 256n - 1n)
+    await history.prune(newMaxStorage)
+    assert.equal(history.maxStorage, newMaxStorage)
+    expect(history.nodeRadius).toBeLessThan(2n ** 256n - 1n)
+    const size2 = await history.db.size()
+    expect(size2).toBeLessThan(size)
+    expect(size2).toBeLessThan(history.maxStorage * 1000000)
+  })
+})


### PR DESCRIPTION
This PR aims to improve and optimize the process of pruning a network DB.  

Instead of measuring / pruning after **random** `OFFER`s, we keep an approximate db measurment updated and prune when the approximate size reaches `maxStorage`

1. Adds `Lock` to prune method
  - boolean `network.pruning` set to `true` during async `prune` method
  -  prune method "locked" while `network.pruning` set to `true`
2. Track `networkDB.approximateSize`
  - `approximateSize` updated during `networkDB.put` and `networkDB.del`
  -  `approximateSize` set to "accurate size" during `networkDB.size()`
3. `network.prune()` triggered when `networkDB.approximateSize > network.maxStorage`
  - compare on `ContentAdded` event
  - no longer prune on random OFFER

----

Also fixed bugs in `prune` method.
- Handle case of non-hex key (like `radius`)
- Handle case of deleting header where block not indexed
