### PR TITLE
uTP: roll back blacklisting

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -439,13 +439,6 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
    * @param packetBuffer uTP packet encoded to Buffer
    */
   private handleUTP = async (src: INodeAddress, msg: ITalkReqMessage, packetBuffer: Uint8Array) => {
-    if (this.uTP.requestManagers[src.nodeId] === undefined) {
-      this.logger.extend('handleUTP').extend('error')(
-        `Received uTP packet from peer with no uTP stream history: ${src.nodeId}.  Blacklisting peer.`,
-      )
-      this.addToBlackList(src.socketAddr)
-      return
-    }
     await this.sendPortalNetworkResponse(src, msg.id, new Uint8Array())
     try {
       await this.uTP.handleUtpPacket(packetBuffer, src)

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -132,6 +132,8 @@ export class PortalNetworkUTP {
     try {
       await this.requestManagers[srcId.nodeId].handlePacket(packetBuffer)
     } catch (err: any) {
+      this.logger(`Error handling uTP packet: ${err}`)
+      this.logger(`Sending reset packet to ${srcId.nodeId}`)
       const packet = Packet.fromBuffer(packetBuffer)
       const resetPacket = new Packet({
         header: {

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -132,35 +132,21 @@ export class PortalNetworkUTP {
     try {
       await this.requestManagers[srcId.nodeId].handlePacket(packetBuffer)
     } catch (err: any) {
-      switch (err.message) {
-        case `REQUEST_CLOSED`: {
-          // Packet arrived after request was closed.  Send RESET packet to peer.
-          const packet = Packet.fromBuffer(packetBuffer)
-          const resetPacket = new Packet({
-            header: {
-              connectionId: packet.header.connectionId,
-              pType: PacketType.ST_RESET,
-              ackNr: 0,
-              extension: 0,
-              version: 1,
-              timestampMicroseconds: 0,
-              timestampDifferenceMicroseconds: 0,
-              seqNr: 0,
-              wndSize: 0,
-            },
-          })
-          await this.send(srcId, resetPacket.encode(), NetworkId.UTPNetwork)
-          break
-        }
-        case `REQUEST_NOT_FOUND`: {
-          // Packet arrived for non-existent request.  Treat as spam and blacklist peer.
-          this.client.addToBlackList(srcId.socketAddr)
-          break
-        }
-        default: {
-          throw err
-        }
-      }
+      const packet = Packet.fromBuffer(packetBuffer)
+      const resetPacket = new Packet({
+        header: {
+          connectionId: packet.header.connectionId,
+          pType: PacketType.ST_RESET,
+          ackNr: 0,
+          extension: 0,
+          version: 1,
+          timestampMicroseconds: 0,
+          timestampDifferenceMicroseconds: 0,
+          seqNr: 0,
+          wndSize: 0,
+        },
+      })
+      await this.send(srcId, resetPacket.encode(), NetworkId.UTPNetwork)
     }
   }
 


### PR DESCRIPTION
Rolls back "blacklisting" of peers when uTP streams go wrong.  

This created more issues than it solved.  To be replaced in future PR by more active peer scoring behavior.