### PR TITLE
client: catch handle TalkReq error

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -424,8 +424,14 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
 
       return
     }
-
-    await network.handle(message, nodeAddress)
+    try {
+      await network.handle(message, nodeAddress)
+    } catch (err: any) {
+      this.logger.extend('error')(
+        `Error handling TALKREQ message from ${nodeAddress.nodeId}: ${err}.  `,
+      )
+      await this.sendPortalNetworkResponse(nodeAddress, message.id, new Uint8Array())
+    }
   }
 
   private onTalkResp = (_: INodeAddress, src: ENR | null, message: ITalkRespMessage) => {


### PR DESCRIPTION
Clients will ERROR and freeze if an incoming TalkReq message contains a payload that cannot be deserialized.

This PR adds a try/catch around `network.handle` so that this sort of error does not kill the client.