### PR TITLE
fix type 0 ping error

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -315,7 +315,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
     const peerCapabilities = this.portal.enrCache.getPeerCapabilities(enr.nodeId)
 
-    if (peerCapabilities.has(extensionType) === false) {
+    if (extensionType !== 0 && peerCapabilities.has(extensionType) === false) {
       throw new Error(`Peer is not know to support extension type: ${extensionType}`)
     }
 


### PR DESCRIPTION
We should not check peer capabilities for sending type 0 ping.  

This is unnecessary and causes errors trying to ping new peers.