### PR TITLE
Debug bucket refresh

### DIFF
--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -968,7 +968,7 @@ export abstract class BaseNetwork extends EventEmitter {
       .reverse()
       .slice(0, 16)
       .filter((pair) => pair.bucket.size() < MAX_NODES_PER_BUCKET)
-      .slice(0, 4)
+      .slice(0, 3)
     this.logger.extend('bucketRefresh')(
       `Refreshing buckets: ${bucketsToRefresh.map((b) => b.distance).join(', ')}`,
     )

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -959,6 +959,7 @@ export abstract class BaseNetwork extends EventEmitter {
       this.refreshing = false
       return
     }
+    await this.livenessCheck()
     this.logger.extend('bucketRefresh')(`Starting bucket refresh with ${size} peers`)
     const bucketsToRefresh = this.routingTable.buckets
       .map((bucket, idx) => {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -939,7 +939,6 @@ export abstract class BaseNetwork extends EventEmitter {
       return
     }
     this.lastRefreshTime = now
-    await this.livenessCheck()
     const size = this.routingTable.size
     if (size === 0) {
       this.logger.extend('bucketRefresh')(`No peers in routing table.  Skipping bucket refresh and liveness check`)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -505,21 +505,8 @@ export abstract class BaseNetwork extends EventEmitter {
       this.portal.metrics?.nodesMessagesReceived.inc()
       const decoded = PortalWireMessageType.deserialize(res).value as NodesMessage
       const enrs = decoded.enrs ?? []
-      try {
-        if (enrs.length > 0) {
-          const notIgnored = enrs.filter((e) => !this.routingTable.isIgnored(ENR.decode(e).nodeId))
-          // Ping node if not currently ignored by subnetwork routing table
-          await Promise.allSettled(
-            notIgnored.map((e) => {
-              const decodedEnr = ENR.decode(e)
-              return this.sendPing(decodedEnr)
-            }),
-          )
-
-          this.logger.extend(`NODES`)(`Received ${enrs.length} ENRs from ${shortId(enr.nodeId)}`)
-        }
-      } catch (err: any) {
-        this.logger(`Error processing NODES message: ${err.toString()}`)
+      if (enrs.length > 0) {
+        this.logger.extend(`NODES`)(`Received ${enrs.length} ENRs from ${shortId(enr.nodeId)}`)
       }
 
       return decoded

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -88,7 +88,9 @@ export class NodeLookup {
 
         for (const enr of response.enrs) {
           const decodedEnr = ENR.decode(enr)
-          this.foundNodes.push(decodedEnr)
+          !this.network.routingTable.getWithPending(decodedEnr.nodeId) &&
+            !this.foundNodes.contains(decodedEnr.encodeTxt()) &&
+            this.foundNodes.push(decodedEnr.encodeTxt())
           const nodeId = decodedEnr.nodeId
           try {
             // Skip if we've already queried this node

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -60,13 +60,15 @@ export class NodeLookup {
   }
 
   private selectClosestPending(): ENR[] {
-    return Array.from(this.pendingNodes.values())
-      // Skip nodes with active uTP requests
-      .filter((peer) => this.network.portal.uTP.hasRequests(peer.nodeId) === false)
-      .sort((a, b) =>
-        Number(distance(a.nodeId, this.nodeSought) - distance(b.nodeId, this.nodeSought)),
-      )
-      .slice(0, NodeLookup.CONCURRENT_LOOKUPS)
+    return (
+      Array.from(this.pendingNodes.values())
+        // Skip nodes with active uTP requests
+        .filter((peer) => this.network.portal.uTP.hasRequests(peer.nodeId) === false)
+        .sort((a, b) =>
+          Number(distance(a.nodeId, this.nodeSought) - distance(b.nodeId, this.nodeSought)),
+        )
+        .slice(0, NodeLookup.CONCURRENT_LOOKUPS)
+    )
   }
 
   private async queryPeer(peer: ENR): Promise<void> {

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -78,7 +78,13 @@ export class NodeLookup {
 
       const queryPromise = async () => {
         const response = await this.network.sendFindNodes(peer, [distanceToTarget])
-        if (!response?.enrs) return
+        if (!response) {
+          this.network.routingTable.evictNode(peer.nodeId)
+          return
+        }
+        if (response.enrs.length === 0) {
+          return
+        }
 
         for (const enr of response.enrs) {
           const decodedEnr = ENR.decode(enr)

--- a/packages/portalnetwork/src/networks/nodeLookup.ts
+++ b/packages/portalnetwork/src/networks/nodeLookup.ts
@@ -139,7 +139,7 @@ export class NodeLookup {
       // Select closest α nodes we haven't queried yet
       const currentBatch = this.selectClosestPending()
       if (currentBatch.length === 0) break
-
+      this.log(`Querying ${currentBatch.length} peers`)
       // Query selected nodes in parallel with timeout
       const lookupPromises = currentBatch.map((peer) => this.queryPeer(peer))
 


### PR DESCRIPTION
This PR improves and debugs the bucket refresh and NodeLookup process.

- Reduces concurrent bucket refresh from 4 to 3
- Adds **Lock** to bucket refresh to avoid overlap
  - `network.refreshing` set to true during `bucketRefresh`
  - subsequent calls to `bucketRefresh` will be cancelled
- Changes to NodeLookup
  - `foundNodes` heap type changed from ENR to string
    - `heap.contains()` does not work with ENR values
    - using strings avoids duplication
  - All PING calls moved to end of NodeLookup process
    - Only send PINGs after NODES lookups
    - Stop sending PINGs when bucket is full (or out of new nodes)
  - Evict nodes that fail to responsd to FINDNODES
    - Avoids duplicate requests
- Changes to FINDNODES
  - No longer automatically PING all nodes during FINDNODES