### PR TITLE
uTP: fix openRequests

### DIFF
--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -46,7 +46,10 @@ export class PortalNetworkUTP {
 
   openRequests(): number {
     return Object.keys(this.requestManagers).reduce((acc, nodeId) => {
-      return acc + Object.keys(this.requestManagers[nodeId].requestMap).length
+      return (
+        acc +
+        Object.values(this.requestManagers[nodeId].requestMap).filter((v) => v !== 'closed').length
+      )
     }, 0)
   }
 


### PR DESCRIPTION
Fix `openRequests()` method by filtering out `closed` requests.

This method was not updated when `requestMap` was modified to track `closed` requests.  `requestMap` used to only contain open requests, but since it was updated to track `closed` requests as well, the `openRequests` method needed to be updated to filter out `closed`.

