### PR TITLE
Protocol Versioning

### DIFF
--- a/packages/cli/src/cliArgs.ts
+++ b/packages/cli/src/cliArgs.ts
@@ -91,4 +91,9 @@ export const args: ClientOpts = yargs(hideBin(process.argv))
     string: true,
     optional: true,
   })
+  .option('supportedVersions', {
+    describe: 'supported versions',
+    string: true,
+    optional: true,
+  })
   .strict().argv as ClientOpts

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -409,11 +409,9 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
 
   public updateENRCache = (enrs: ENR[]) => {
     for (const enr of enrs) {
-      this.highestCommonVersion(enr)
-        .catch(() => [this.addToBlackList(enr.getLocationMultiaddr('udp')!)])
-        .finally(() => {
-          this.enrCache.updateENR(enr)
-        })
+      this.highestCommonVersion(enr).finally(() => {
+        this.enrCache.updateENR(enr)
+      })
     }
   }
 
@@ -456,7 +454,8 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
       .filter((v) => mySupportedVersions.includes(v))
       .sort((a, b) => b - a)[0]
     if (highestCommonVersion === undefined) {
-      throw new Error('No common version found')
+      this.addToBlackList(peer.getLocationMultiaddr('udp')!)
+      return -1
     }
     return highestCommonVersion
   }

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -13,6 +13,7 @@ import { PortalNetworkUTP } from '../wire/utp/PortalNetworkUtp/index.js'
 
 import { DBManager } from './dbManager.js'
 import { ETH } from './eth.js'
+import { SupportedVersions } from './types.js'
 
 import type { IDiscv5CreateOptions } from '@chainsafe/discv5'
 import type { ITalkReqMessage, ITalkRespMessage } from '@chainsafe/discv5/message'
@@ -26,7 +27,7 @@ import type {
 } from './types.js'
 import { MessageCodes, PortalWireMessageType } from '../wire/types.js'
 import { type IClientInfo } from '../wire/payloadExtensions.js'
-import { RateLimiter } from '../transports/rateLimiter.js'
+import type { RateLimiter } from '../transports/rateLimiter.js'
 import { ENRCache } from './enrCache.js'
 
 export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
@@ -62,6 +63,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
     this.discv5 = Discv5.create(opts.config as IDiscv5CreateOptions)
     // cache signature to ensure ENR can be encoded on startup
     this.discv5.enr.encode()
+    this.discv5.enr.set('pv', SupportedVersions.serialize(opts.supportedVersions ?? [0]))
     this.enrCache = new ENRCache({})
     this.logger = debug(this.discv5.enr.nodeId.slice(0, 5)).extend('Portal')
     this.networks = new Map()

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -439,4 +439,17 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
       // No action
     }
   }
+  public async highestCommonVersion(peer: ENR): Promise<number> {
+    const mySupportedVersions: number[] = SupportedVersions.deserialize(this.discv5.enr.kvs.get('pv')!)
+    const pv = peer.kvs.get('pv')
+    if (pv === undefined) {
+      return 0
+    }
+    const peerSupportedVersions: number[] = SupportedVersions.deserialize(pv)
+    const highestCommonVersion = peerSupportedVersions.filter((v) => mySupportedVersions.includes(v)).sort((a, b) => b - a)[0]
+    if (highestCommonVersion === undefined) {
+      throw new Error('No common version found')
+    }
+    return highestCommonVersion
+  }
 }

--- a/packages/portalnetwork/src/client/constructor.ts
+++ b/packages/portalnetwork/src/client/constructor.ts
@@ -127,6 +127,7 @@ export async function createPortalNetwork(opts: Partial<PortalNetworkOpts>): Pro
     shouldRefresh: opts.shouldRefresh,
     operatingSystemAndCpuArchitecture: opts.operatingSystemAndCpuArchitecture,
     shortCommit: opts.shortCommit,
+    supportedVersions: opts.supportedVersions,
   })
   for (const network of portal.networks.values()) {
     try {

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -58,6 +58,7 @@ export interface PortalNetworkOpts {
   utpTimeout?: number
   shouldRefresh?: boolean
   gossipCount?: number
+  supportedVersions?: number[]
 }
 
 export type RoutingTable = PortalNetworkRoutingTable

--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -5,6 +5,7 @@ import type { AbstractLevel } from 'abstract-level'
 import type { NetworkId } from '../index.js'
 import type { PortalNetworkRoutingTable } from './routingTable.js'
 import type { Multiaddr } from '@multiformats/multiaddr'
+import { ListBasicType, UintNumberType } from '@chainsafe/ssz'
 
 /** A representation of an unsigned contactable node. */
 export interface INodeAddress {
@@ -106,3 +107,6 @@ export interface RpcTx {
   maxFeePerGas?: string
   type?: string
 }
+
+export const ProtocolVersion = new UintNumberType(1)
+export const SupportedVersions = new ListBasicType(ProtocolVersion, 8)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -42,6 +42,7 @@ import {
   PingPongErrorCodes,
   PortalWireMessageType,
   RequestCode,
+  SupportedVersions,
   arrayByteLength,
   decodeClientInfo,
   encodeClientInfo,
@@ -1097,5 +1098,18 @@ export abstract class BaseNetwork extends EventEmitter {
       return 10000 // Unhealthy table = shorter interval
     }
     return 30000
+  }
+  public async highestCommonVersion(peer: ENR | INodeAddress): Promise<number> {
+    const mySupportedVersions: number[] = SupportedVersions.deserialize(this.enr.kvs.get('pv')!)
+    const peerENR = peer instanceof ENR ? peer : this.findEnr(peer.nodeId)
+    if (peerENR === undefined) {
+      return 0
+    }
+    const pv = peerENR.kvs.get('pv')
+    if (pv === undefined) {
+      return 0
+    }
+    const peerSupportedVersions: number[] = SupportedVersions.deserialize(pv)
+    return peerSupportedVersions.filter((v) => mySupportedVersions.includes(v)).sort((a, b) => b - a)[0] || 0
   }
 }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -42,7 +42,6 @@ import {
   PingPongErrorCodes,
   PortalWireMessageType,
   RequestCode,
-  SupportedVersions,
   arrayByteLength,
   decodeClientInfo,
   encodeClientInfo,

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -1099,17 +1099,4 @@ export abstract class BaseNetwork extends EventEmitter {
     }
     return 30000
   }
-  public async highestCommonVersion(peer: ENR | INodeAddress): Promise<number> {
-    const mySupportedVersions: number[] = SupportedVersions.deserialize(this.enr.kvs.get('pv')!)
-    const peerENR = peer instanceof ENR ? peer : this.findEnr(peer.nodeId)
-    if (peerENR === undefined) {
-      return 0
-    }
-    const pv = peerENR.kvs.get('pv')
-    if (pv === undefined) {
-      return 0
-    }
-    const peerSupportedVersions: number[] = SupportedVersions.deserialize(pv)
-    return peerSupportedVersions.filter((v) => mySupportedVersions.includes(v)).sort((a, b) => b - a)[0] || 0
-  }
 }

--- a/packages/portalnetwork/src/util/config.ts
+++ b/packages/portalnetwork/src/util/config.ts
@@ -8,7 +8,7 @@ import { NetworkId } from '../networks/types.js'
 
 import { setupMetrics } from './metrics.js'
 
-import type { NetworkConfig, PortalNetworkOpts } from '../client'
+import { type NetworkConfig, type PortalNetworkOpts, SupportedVersions } from '../client/index.js'
 import { DEFAULT_BOOTNODES } from './bootnodes.js'
 
 export type AsyncReturnType<T extends (...args: any) => Promise<any>> = T extends (
@@ -27,6 +27,7 @@ export interface PortalClientOpts {
   storage: string
   trustedBlockRoot?: string
   gossipCount?: number
+  supportedVersions?: number[]
 }
 
 export const NetworkStrings: Record<string, NetworkId> = {
@@ -54,7 +55,7 @@ export const cliConfig = async (args: PortalClientOpts) => {
   const enr = SignableENR.createFromPrivateKey(privateKey)
   const initMa = multiaddr(`/ip4/${ip}/udp/${bindPort}`)
   enr.setLocationMultiaddr(initMa)
-
+  enr.set('pv', SupportedVersions.serialize(args.supportedVersions ?? [0]))
   let db
   if (args.dataDir !== undefined) {
     db = new Level<string, string>(args.dataDir)
@@ -113,6 +114,7 @@ export const cliConfig = async (args: PortalClientOpts) => {
     trustedBlockRoot: args.trustedBlockRoot,
     bootnodes,
     gossipCount: args.gossipCount,
+    supportedVersions: args.supportedVersions,
   }
   return clientConfig
 }

--- a/packages/portalnetwork/test/client/client.spec.ts
+++ b/packages/portalnetwork/test/client/client.spec.ts
@@ -1,17 +1,22 @@
 import { assert, describe, it } from 'vitest'
 
-import { NetworkId, createPortalNetwork, TransportLayer } from '../../src/index.js'
+import { NetworkId, SupportedVersions, TransportLayer, createPortalNetwork } from '../../src/index.js'
 describe('Client unit tests', () => {
   it('node initialization/startup', async () => {
     const node = await createPortalNetwork({
       bindAddress: '192.168.0.1',
       transport: TransportLayer.WEB,
       supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      supportedVersions: [0, 1],
     })
     assert.equal(
       node.discv5.enr.getLocationMultiaddr('udp')!.toOptions().host,
       '192.168.0.1',
       'created portal network node with correct ip address',
     )
+    const pv = node.discv5.enr.kvs.get('pv')
+    assert.isDefined(pv)
+    const versions = SupportedVersions.deserialize(pv)
+    assert.deepEqual(versions, [0, 1])
   })
 })

--- a/packages/portalnetwork/test/client/provider.spec.ts
+++ b/packages/portalnetwork/test/client/provider.spec.ts
@@ -5,7 +5,7 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { assert, describe, expect, it } from 'vitest'
 
 import { createUltralightProvider } from '../../src/client/provider.js'
-import { TransportLayer } from '../../src/index.js'
+import { TransportLayer } from '../../src/client/types.js'
 import { NetworkId } from '../../src/networks/types.js'
 import { bytesToUnprefixedHex, hexToBytes } from '@ethereumjs/util'
 

--- a/packages/portalnetwork/test/integration/blacklist.spec.ts
+++ b/packages/portalnetwork/test/integration/blacklist.spec.ts
@@ -126,4 +126,8 @@ describe('version conflict', async () => {
   it('should blacklist peer with version conflict', async () => {
     assert.isTrue(blacklisted)
   })
+  const compare = await node1.highestCommonVersion(node2.discv5.enr.toENR())
+  it('should compare versions', async () => {
+    assert.equal(compare, -1)
+  })
 })

--- a/packages/portalnetwork/test/integration/blacklist.spec.ts
+++ b/packages/portalnetwork/test/integration/blacklist.spec.ts
@@ -78,7 +78,7 @@ describe('version conflict', async () => {
   enr1.setLocationMultiaddr(initMa)
   const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/5033`)
   enr2.setLocationMultiaddr(initMa2)
-  const node1 = await PortalNetwork.create({
+  const node1 = await createPortalNetwork({
     transport: TransportLayer.NODE,
     supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {
@@ -90,7 +90,7 @@ describe('version conflict', async () => {
     },
     supportedVersions: [2],
   })
-  const node2 = await PortalNetwork.create({
+  const node2 = await createPortalNetwork({
     transport: TransportLayer.NODE,
     supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
     config: {

--- a/packages/portalnetwork/test/integration/blacklist.spec.ts
+++ b/packages/portalnetwork/test/integration/blacklist.spec.ts
@@ -1,14 +1,19 @@
-import { SignableENR } from "@chainsafe/enr"
-import { keys } from "@libp2p/crypto"
-import { multiaddr } from "@multiformats/multiaddr"
-import { hexToBytes } from "ethereum-cryptography/utils"
-import { assert, describe, it } from "vitest"
-import type { HistoryNetwork } from "../../src";
-import { NetworkId, TransportLayer, createPortalNetwork } from "../../src/index.js"
+import { SignableENR } from '@chainsafe/enr'
+import { keys } from '@libp2p/crypto'
+import { multiaddr } from '@multiformats/multiaddr'
+import { hexToBytes } from 'ethereum-cryptography/utils'
+import { assert, describe, it } from 'vitest'
+import type { HistoryNetwork } from '../../src'
+import {
+  NetworkId,
+ 
+  SupportedVersions,
+  TransportLayer, createPortalNetwork,
+} from '../../src/index.js'
 const privateKeys = [
-    '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
-    '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
-  ]
+  '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
+  '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
+]
 const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
 const enr1 = SignableENR.createFromPrivateKey(pk1)
 const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
@@ -51,17 +56,74 @@ describe('black list test', async () => {
     assert.isDefined(pong)
   })
   node1.addToBlackList(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  const blacklisted = node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!)
   it('should blacklist peer', () => {
-    assert.isTrue(node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!))
+    assert.isTrue(blacklisted)
   })
   const pong2 = await network2?.sendPing(network1?.enr!.toENR())
   it('blacklisted peer should not be able to ping', () => {
     assert.isUndefined(pong2)
   })
+  node1.removeFromBlackList(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  const stillBlacklisted = node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  const pong3 = await network2?.sendPing(network1?.enr!.toENR())
   it('should remove peer from blacklist', async () => {
-    node1.removeFromBlackList(node2.discv5.enr.getLocationMultiaddr('udp')!)
-    assert.isFalse(node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!))
-    const pong3 = await network2?.sendPing(network1?.enr!.toENR())
+    assert.isFalse(stillBlacklisted)
     assert.isDefined(pong3)
+  })
+})
+
+describe('version conflict', async () => {
+  const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/5032`)
+  enr1.setLocationMultiaddr(initMa)
+  const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/5033`)
+  enr2.setLocationMultiaddr(initMa2)
+  const node1 = await PortalNetwork.create({
+    transport: TransportLayer.NODE,
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+    config: {
+      enr: enr1,
+      bindAddrs: {
+        ip4: initMa,
+      },
+      privateKey: pk1,
+    },
+    supportedVersions: [2],
+  })
+  const node2 = await PortalNetwork.create({
+    transport: TransportLayer.NODE,
+    supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+    config: {
+      enr: enr2,
+      bindAddrs: {
+        ip4: initMa2,
+      },
+      privateKey: pk2,
+    },
+    supportedVersions: [0, 1],
+  })
+
+  await node1.start()
+  await node2.start()
+  const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+  const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+
+  it('should encode versions in enrs', () => {
+    const versions = node1.discv5.enr.kvs.get('pv')
+    assert.isDefined(versions)
+    assert.deepEqual(SupportedVersions.deserialize(versions), [2])
+  })
+  const control = node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  it('should begin with no blacklist', async () => {
+    assert.isFalse(control)
+  })
+
+  const pong = await network1?.sendPing(network2?.enr!.toENR())
+  it('should fail to ping peer with version conflict', async () => {
+    assert.isUndefined(pong)
+  })
+  const blacklisted = node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  it('should blacklist peer with version conflict', async () => {
+    assert.isTrue(blacklisted)
   })
 })

--- a/packages/portalnetwork/test/integration/pingpong.spec.ts
+++ b/packages/portalnetwork/test/integration/pingpong.spec.ts
@@ -57,6 +57,10 @@ describe('PING/PONG', async () => {
   await node2.start()
   const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
   const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+  it('should share common version of 0', async () => {
+    const commonVersion = await node1.highestCommonVersion(node2.discv5.enr.toENR())
+    assert.equal(commonVersion, 0)
+  })
   it('should exchange type 0 PING/PONG', async () => {
     const pingpong = await network1.sendPing(network2?.enr!.toENR(), 0)
     assert.exists(pingpong, 'should have received a pong')

--- a/packages/portalnetwork/test/integration/pingpong.spec.ts
+++ b/packages/portalnetwork/test/integration/pingpong.spec.ts
@@ -39,6 +39,7 @@ describe('PING/PONG', async () => {
       },
       privateKey: pk1,
     },
+    supportedVersions: [0, 1],
   })
 
   const node2 = await createPortalNetwork({


### PR DESCRIPTION
Implements changes in https://github.com/ethereum/portal-network-specs/pull/379

Implements `Protocol Versioning` as deployment vehicle for future updates.


SSZ types:
- version_number
  - uint8
- supported_versions
  - List[version_number, limit=8]

CLI args:
- supportedVersions
  - list of supported version numbers

PortalNetwork constructor opts:
- supportedVersions
  - array of supported version numbers

Supported protocol versions will be encoded into ENR using the key `pv` during PortalNetwork class constructor

`this.discv5.enr.set('pv', SupportedVersions.serialize(opts.supportedVersions ?? [0]))`

-- 

Current protocol version (at time of writing) is 0 with candidates for version 1 in development