### PR TITLE
Run typescript code directly when specified

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,8 +55,8 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "devnet": "tsx scripts/devnet.ts ",
-    "dev": "tsx watch src/index.ts --bindAddress=127.0.0.1:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data'",
-    "dev-testnet": "tsx watch src/index.ts --bindAddress=0.0.0.0:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data' --bootnodeList=./bootnodes.txt",
+    "dev": "tsx --conditions=typescript src/index.ts --bindAddress=127.0.0.1:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data'",
+    "dev-testnet": "tsx --conditions=typescript src/index.ts --bindAddress=0.0.0.0:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data' --bootnodeList=./bootnodes.txt",
     "build": "tsc && cp bootnodes.txt ./dist",
     "test": "npx vitest run test/* -c=./vitest.config.unit.ts",
     "lint": "../../config/cli/lint.sh",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     }
   },
   "scripts": {
-    "start": "tsx src/index.ts",
+    "start": "tsx --conditions=typescript src/index.ts",
     "devnet": "tsx scripts/devnet.ts ",
     "dev": "tsx --conditions=typescript src/index.ts --bindAddress=127.0.0.1:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data'",
     "dev-testnet": "tsx --conditions=typescript src/index.ts --bindAddress=0.0.0.0:9000 --pk=0x0a27002508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb634122508021221031947fd30ff7c87d8c7ff2c0ad1515624d247970f946efda872e884a432abb6341a2408021220456aad29a26c39bf438813d30bb3f0730b8b776ebc4cb0721a3d9a5b3955380e --dataDir='./dist/data' --bootnodeList=./bootnodes.txt",

--- a/packages/cli/src/rpc/types.ts
+++ b/packages/cli/src/rpc/types.ts
@@ -4,7 +4,7 @@ import type { Block } from '@ethereumjs/block'
 import type { JSONTx, TypedTransaction } from '@ethereumjs/tx'
 import type { Address } from '@ethereumjs/util'
 import type { PostByzantiumTxReceipt, PreByzantiumTxReceipt, TxReceipt } from '@ethereumjs/vm'
-import type { Log } from 'portalnetwork/src/networks/index.js'
+import type { Log } from 'portalnetwork'
 
 export type GetLogsParams = {
   fromBlock?: string // QUANTITY, block number or "earliest" or "latest" (default: "latest")

--- a/packages/cli/vitest.config.unit.ts
+++ b/packages/cli/vitest.config.unit.ts
@@ -5,4 +5,11 @@ export default defineConfig({
     silent: true,
     testTimeout: 180000,
   },
+  environments: {
+    ssr: {
+      resolve: {
+        conditions: ['typescript'],
+      },
+    },
+  },
 })

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "type": "module",
   "exports": {
-    "default": "./dist/index.js",
-    "typescript": "./src/index.ts"
+    "typescript": "./src/index.ts",
+    "default": "./dist/index.js"
   },
   "engines": {
     "node": "^20"

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "type": "module",
   "exports": {
-    "typescript": "./src/index.ts",
-    "default": "./dist/index.js"
+    "default": "./dist/index.js",
+    "typescript": "./src/index.ts"
   },
   "engines": {
     "node": "^20"

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -4,6 +4,10 @@
   "description": "",
   "main": "dist/index.js",
   "type": "module",
+  "exports": {
+    "typescript": "./src/index.ts",
+    "default": "./dist/index.js"
+  },
   "engines": {
     "node": "^20"
   },


### PR DESCRIPTION
Same idea as [#3944](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3944).  Basically, this allows us to use `tsx` to run the typescript code from the `src` directory directly rather than having to rebuild `portalnetwork` every time we make a change.