### PR TITLE
Version 1: Accept-codes / Varint prefix

### DIFF
--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -25,6 +25,7 @@ import type {
   PortalNetworkMetrics,
   PortalNetworkOpts,
 } from './types.js'
+import type { Version } from '../wire/types.js'
 import { MessageCodes, PortalWireMessageType } from '../wire/types.js'
 import { type IClientInfo } from '../wire/payloadExtensions.js'
 import type { RateLimiter } from '../transports/rateLimiter.js'
@@ -346,6 +347,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
     payload: Uint8Array,
     networkId: NetworkId,
     utpMessage?: boolean,
+    version: Version = 0,
   ): Promise<Uint8Array> => {
     const messageNetwork = utpMessage !== undefined ? NetworkId.UTPNetwork : networkId
     const remote =
@@ -363,7 +365,7 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
           `Error sending uTP TALKREQ message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err.message}`,
         )
       } else {
-        const messageType = PortalWireMessageType.deserialize(payload).selector
+        const messageType = PortalWireMessageType[version].deserialize(payload).selector
         throw new Error(
           `Error sending TALKREQ ${MessageCodes[messageType]} message using ${enr instanceof ENR ? 'ENR' : 'MultiAddr'}: ${err}.  NetworkId: ${networkId} NodeId: ${enr.nodeId} MultiAddr: ${enr instanceof ENR ? enr.getLocationMultiaddr('udp')?.toString() : enr.socketAddr.toString()}`,
         )

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -27,7 +27,12 @@ import {
   getTalkReqOverhead,
   randUint16,
 } from '../../wire/index.js'
-import { ContentMessageType, MessageCodes, PortalWireMessageType } from '../../wire/types.js'
+import {
+  AcceptCode,
+  ContentMessageType,
+  MessageCodes,
+  PortalWireMessageType,
+} from '../../wire/types.js'
 import { BaseNetwork } from '../network.js'
 import { NetworkId } from '../types.js'
 
@@ -49,7 +54,7 @@ import { getBeaconContentKey } from './util.js'
 import type { BeaconConfig } from '@lodestar/config'
 import type { LightClientUpdate } from '@lodestar/types'
 import type { Debugger } from 'debug'
-import type { AcceptMessage, FindContentMessage, OfferMessage } from '../../wire/types.js'
+import type { AcceptMessage, FindContentMessage, OfferMessage, Version } from '../../wire/types.js'
 import type { ContentLookupResponse } from '../types.js'
 import type { BeaconChainNetworkConfig, HistoricalSummaries, LightClientForkName } from './types.js'
 import type { INodeAddress } from '../../index.js'
@@ -433,9 +438,16 @@ export class BeaconNetwork extends BaseNetwork {
     enr: ENR,
     key: Uint8Array,
   ): Promise<ContentLookupResponse | undefined> => {
+    let version: Version
+    try {
+      version = await this.portal.highestCommonVersion(enr)
+    } catch (e: any) {
+      this.logger.extend('error')(e.message)
+      return
+    }
     this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
-    const payload = PortalWireMessageType.serialize({
+    const payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })
@@ -785,6 +797,13 @@ export class BeaconNetwork extends BaseNetwork {
     contentKeys: Uint8Array[],
     contents?: Uint8Array[],
   ) => {
+    let version: Version
+    try {
+      version = await this.portal.highestCommonVersion(enr)
+    } catch (e: any) {
+      this.logger.extend('error')(e.message)
+      return
+    }
     if (contents && contents.length !== contentKeys.length) {
       throw new Error('Provided Content and content key arrays must be the same length')
     }
@@ -793,7 +812,7 @@ export class BeaconNetwork extends BaseNetwork {
       const offerMsg: OfferMessage = {
         contentKeys,
       }
-      const payload = PortalWireMessageType.serialize({
+      const payload = PortalWireMessageType[version].serialize({
         selector: MessageCodes.OFFER,
         value: offerMsg,
       })
@@ -803,15 +822,20 @@ export class BeaconNetwork extends BaseNetwork {
       const res = await this.sendMessage(enr, payload, this.networkId)
       if (res.length > 0) {
         try {
-          const decoded = PortalWireMessageType.deserialize(res)
+          const decoded = PortalWireMessageType[version].deserialize(res)
           if (decoded.selector === MessageCodes.ACCEPT) {
             this.portal.metrics?.acceptMessagesReceived.inc()
-            const msg = decoded.value as AcceptMessage
+            const msg = decoded.value as AcceptMessage<Version>
             const id = new DataView(msg.connectionId.buffer).getUint16(0, false)
             // Initiate uTP streams with serving of requested content
-            const requestedKeys: Uint8Array[] = contentKeys.filter(
-              (n, idx) => msg.contentKeys.get(idx) === true,
-            )
+            const requestedKeys: Uint8Array[] =
+              version === 0
+                ? contentKeys.filter(
+                    (n, idx) => (<AcceptMessage<0>>msg).contentKeys.get(idx) === true,
+                  )
+                : contentKeys.filter(
+                    (n, idx) => (<AcceptMessage<1>>msg).contentKeys[idx] === AcceptCode.ACCEPT,
+                  )
             if (requestedKeys.length === 0) {
               // Don't start uTP stream if no content ACCEPTed
               this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr.nodeId)}`)
@@ -822,7 +846,11 @@ export class BeaconNetwork extends BaseNetwork {
             const requestedData: Uint8Array[] = []
             if (contents) {
               for (const [idx, _] of requestedKeys.entries()) {
-                if (msg.contentKeys.get(idx) === true) {
+                if (
+                  version === 0
+                    ? (<AcceptMessage<0>>msg).contentKeys.get(idx) === true
+                    : (<AcceptMessage<1>>msg).contentKeys[idx] === AcceptCode.ACCEPT
+                ) {
                   requestedData.push(contents[idx])
                 }
               }

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -857,7 +857,7 @@ export class BeaconNetwork extends BaseNetwork {
             if (requestedKeys.length === 0) {
               // Don't start uTP stream if no content ACCEPTed
               this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr.nodeId)}`)
-              return []
+              return msg.contentKeys
             }
             this.logger.extend(`ACCEPT`)(`ACCEPT message received with uTP id: ${id}`)
 

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -307,7 +307,14 @@ export class HistoryNetwork extends BaseNetwork {
   public sendFindContent = async (enr: ENR, key: Uint8Array) => {
     this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
-    const payload = PortalWireMessageType.serialize({
+    let version
+    try {
+      version = await this.portal.highestCommonVersion(enr)
+    } catch (e: any) {
+      this.logger.extend('error')(e.message)
+      return
+    }
+    const payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -25,6 +25,7 @@ import {
   decodeHistoryNetworkContentKey,
   decodeReceipts,
   encodeClientInfo,
+  encodeWithVariantPrefix,
   getTalkReqOverhead,
   randUint16,
   reassembleBlock,
@@ -348,6 +349,7 @@ export class HistoryNetwork extends BaseNetwork {
                 enr,
                 connectionId: id,
                 requestCode: RequestCode.FINDCONTENT_READ,
+                version
               })
             })
             break
@@ -511,6 +513,7 @@ export class HistoryNetwork extends BaseNetwork {
         connectionId: _id,
         requestCode: RequestCode.FOUNDCONTENT_WRITE,
         contents,
+        version
       })
 
       const id = new Uint8Array(2)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -65,7 +65,7 @@ export abstract class BaseNetwork extends EventEmitter {
     PingPongPayloadExtensions.CLIENT_INFO_RADIUS_AND_CAPABILITIES,
     PingPongPayloadExtensions.BASIC_RADIUS_PAYLOAD,
   ]
-  static MAX_CONCURRENT_UTP_STREAMS = 50
+  public MAX_CONCURRENT_UTP_STREAMS = 50
   public routingTable: PortalNetworkRoutingTable
   public nodeRadius: bigint
   public db: NetworkDB
@@ -765,7 +765,7 @@ export abstract class BaseNetwork extends EventEmitter {
       case 0:
       default: {
         const contentIds: boolean[] = Array(msg.contentKeys.length).fill(false)
-        if (this.portal.uTP.openRequests() > BaseNetwork.MAX_CONCURRENT_UTP_STREAMS) {
+        if (this.portal.uTP.openRequests() > this.MAX_CONCURRENT_UTP_STREAMS) {
           this.logger.extend('OFFER')(`Too many open UTP streams - rejecting offer`)
           return this.sendAccept<0>(src, requestId, contentIds, [])
         }

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -648,7 +648,7 @@ export abstract class BaseNetwork extends EventEmitter {
             if (requestedKeys.length === 0) {
               // Don't start uTP stream if no content ACCEPTed
               this.logger.extend('ACCEPT')(`No content ACCEPTed by ${shortId(enr.nodeId)}`)
-              return []
+              return msg.contentKeys
             }
             this.logger.extend(`OFFER`)(`ACCEPT message received with uTP id: ${id}`)
 

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -750,11 +750,11 @@ export abstract class BaseNetwork extends EventEmitter {
             for (const k of desiredKeys) {
               this.streamingKey(k)
             }
-            await this.sendAccept<1>(src, requestId, contentIds, desiredKeys)
+            await this.sendAccept<1>(src, requestId, contentIds, desiredKeys, 1)
           } catch (err: any) {
             this.logger(`Something went wrong handling offer message: ${err.toString()}`)
             // Send empty response if something goes wrong parsing content keys
-            await this.sendAccept<1>(src, requestId, contentIds, [])
+            await this.sendAccept<1>(src, requestId, contentIds, [], 1)
           }
         } catch {
           this.logger(`Error Processing OFFER msg`)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -709,13 +709,14 @@ export abstract class BaseNetwork extends EventEmitter {
     )
     switch (version) {
       case 1: {
-        if (this.portal.uTP.openRequests() > BaseNetwork.MAX_CONCURRENT_UTP_STREAMS) {
+        if (this.portal.uTP.openRequests() > this.MAX_CONCURRENT_UTP_STREAMS) {
           this.logger.extend('OFFER')(`Too many open UTP streams - rejecting offer`)
           return this.sendAccept<1>(
             src,
             requestId,
             Array(msg.contentKeys.length).fill(AcceptCode.RATE_LIMITED),
             [],
+            1
           )
         }
         const contentIds: number[] = Array(msg.contentKeys.length).fill(AcceptCode.GENERIC_DECLINE)

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -728,6 +728,7 @@ export abstract class BaseNetwork extends EventEmitter {
                 this.logger.extend('OFFER')(
                   `Content key: ${bytesToHex(msg.contentKeys[x])} is outside radius.\ndistance=${d}\nradius=${this.nodeRadius}`,
                 )
+                contentIds[x] = AcceptCode.CONTENT_OUT_OF_RADIUS
                 continue
               }
               try {

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -242,13 +242,7 @@ export abstract class BaseNetwork extends EventEmitter {
     const id = message.id
     const request = message.request
     const enr = this.findEnr(src.nodeId)!
-    let version: Version
-    try {
-      version = await this.portal.highestCommonVersion(enr)
-    } catch (e: any) {
-      this.logger.extend('error')(e.message)
-      return
-    }
+    const version = await this.portal.highestCommonVersion(enr)
     const deserialized = PortalWireMessageType[version].deserialize(request)
     const decoded = deserialized.value
     const messageType = deserialized.selector

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -46,7 +46,7 @@ import {
 } from './util.js'
 import type { ENR } from '@chainsafe/enr'
 import type { Debugger } from 'debug'
-import type { FindContentMessage } from '../../wire/types.js'
+import type { FindContentMessage, Version } from '../../wire/types.js'
 import type { BaseNetworkConfig, ContentLookupResponse } from '../index.js'
 import type { TNibbles } from './types.js'
 
@@ -76,9 +76,16 @@ export class StateNetwork extends BaseNetwork {
    * @returns the value of the FOUNDCONTENT response or undefined
    */
   public sendFindContent = async (enr: ENR, key: Uint8Array) => {
+    let version: Version
+    try {
+      version = await this.portal.highestCommonVersion(enr)
+    } catch (e: any) {
+      this.logger.extend('error')(e.message)
+      return
+    }
     this.portal.metrics?.findContentMessagesSent.inc()
     const findContentMsg: FindContentMessage = { contentKey: key }
-    const payload = PortalWireMessageType.serialize({
+    const payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.FINDCONTENT,
       value: findContentMsg,
     })

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -120,6 +120,7 @@ export class StateNetwork extends BaseNetwork {
                 enr,
                 connectionId: id,
                 requestCode: RequestCode.FINDCONTENT_READ,
+                version
               })
             })
             break

--- a/packages/portalnetwork/src/wire/types.ts
+++ b/packages/portalnetwork/src/wire/types.ts
@@ -116,10 +116,8 @@ export const OfferMessageType = new ContainerType({
   contentKeys: new ListCompositeType(ByteList, 64),
 })
 
-export type AcceptMessage = {
-  connectionId: Uint8Array
-  contentKeys: BitArray
-}
+export type Version = 0 | 1
+
 
 export const AcceptMessageType = new ContainerType({
   connectionId: Bytes2,

--- a/packages/portalnetwork/src/wire/types.ts
+++ b/packages/portalnetwork/src/wire/types.ts
@@ -176,3 +176,11 @@ export const PortalWireMessageType: Record<Version, UnionType<any>> = {
   ]),
 }
 
+export enum AcceptCode {
+  ACCEPT = 0,
+  GENERIC_DECLINE = 1,
+  CONTENT_ALREADY_STORED = 2,
+  CONTENT_OUT_OF_RADIUS = 3,
+  RATE_LIMITED = 4,
+  CONTENT_ID_LIMITED = 5,
+}

--- a/packages/portalnetwork/src/wire/types.ts
+++ b/packages/portalnetwork/src/wire/types.ts
@@ -151,15 +151,28 @@ export type MessageTypeUnion = [
   | FindContentMessage
   | ContentMessage
   | OfferMessage
-  | AcceptMessage,
+  | AcceptMessage<Version>,
 ]
-export const PortalWireMessageType = new UnionType([
-  PingMessageType,
-  PongMessageType,
-  FindNodesMessageType,
-  NodesMessageType,
-  FindContentMessageType,
-  ContentMessageType,
-  OfferMessageType,
-  AcceptMessageType,
-])
+export const PortalWireMessageType: Record<Version, UnionType<any>> = {
+  0: new UnionType([
+    PingMessageType,
+    PongMessageType,
+    FindNodesMessageType,
+    NodesMessageType,
+    FindContentMessageType,
+    ContentMessageType,
+    OfferMessageType,
+    AcceptMessageType[0],
+  ]),
+  1: new UnionType([
+    PingMessageType,
+    PongMessageType,
+    FindNodesMessageType,
+    NodesMessageType,
+    FindContentMessageType,
+    ContentMessageType,
+    OfferMessageType,
+    AcceptMessageType[1],
+  ]),
+}
+

--- a/packages/portalnetwork/src/wire/types.ts
+++ b/packages/portalnetwork/src/wire/types.ts
@@ -118,6 +118,17 @@ export const OfferMessageType = new ContainerType({
 
 export type Version = 0 | 1
 
+export type AcceptMessage<V extends Version> = V extends 0
+  ? {
+      connectionId: Uint8Array
+      contentKeys: BitArray
+    }
+  : V extends 1
+    ? {
+        connectionId: Uint8Array
+        contentKeys: Uint8Array
+      }
+    : never
 
 export const AcceptMessageType = new ContainerType({
   connectionId: Bytes2,

--- a/packages/portalnetwork/src/wire/types.ts
+++ b/packages/portalnetwork/src/wire/types.ts
@@ -130,10 +130,18 @@ export type AcceptMessage<V extends Version> = V extends 0
       }
     : never
 
-export const AcceptMessageType = new ContainerType({
-  connectionId: Bytes2,
-  contentKeys: new BitListType(64),
-})
+export const AcceptCodesType = new ByteListType(64)
+
+export const AcceptMessageType: Record<Version, ContainerType<any>> = {
+  0: new ContainerType({
+    connectionId: Bytes2,
+    contentKeys: new BitListType(64),
+  }),
+  1: new ContainerType({
+    connectionId: Bytes2,
+    contentKeys: AcceptCodesType,
+  }),
+}
 
 export type MessageTypeUnion = [
   | PingMessage

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -5,6 +5,7 @@ import debug from 'debug'
 import {
   Bytes32TimeStamp,
   ConnectionState,
+  ContentReader,
   PacketType,
   StateNetwork,
   bitmap,
@@ -119,7 +120,9 @@ export abstract class ContentRequest {
     }
   }
   async returnContent(contents: Uint8Array[], keys: Uint8Array[]) {
-    this.logger.extend('returnContent')(`Decompressing stream into ${keys.length} pieces of content`)
+    this.logger.extend('returnContent')(
+      `Decompressing stream into ${keys.length} pieces of content`,
+    )
     for (const [idx, k] of keys.entries()) {
       const _content = contents[idx]
       this.logger.extend(`FINISHED`)(
@@ -195,13 +198,23 @@ export class FindContentReadRequest extends ContentReadRequest {
     if (this.socket.state === ConnectionState.SynSent) {
       this.socket.setAckNr(packet.header.seqNr)
       this.socket.setReader(packet.header.seqNr)
-      this.socket.reader!.bytesExpected = Infinity
+      if (this.version === 0) {
+        // Content is not prefixed with a varint length
+        this.socket.reader!.bytesExpected = Infinity
+      }
       return
     } else {
       throw new Error('READ socket should not get ACKs after SYN-ACK')
     }
   }
   async _handleDataPacket(packet: DataPacket) {
+    if (!this.socket.reader) {
+      this.socket.reader = new ContentReader(packet.header.seqNr)
+      if (this.version === 0) {
+        // Content is not prefixed with a varint length
+        this.socket.reader!.bytesExpected = Infinity
+      }
+    }
     await this.socket.handleDataPacket(packet)
     if (this.socket.state === ConnectionState.GotFin) {
       // FIN packet number marks the end of data stream
@@ -216,14 +229,41 @@ export class FindContentReadRequest extends ContentReadRequest {
         }
       }
       // If all packets have been received, return content
-      await this.returnContent([Uint8Array.from(this.socket.reader!.bytes)], [this.contentKey])
+      switch (this.version) {
+        case 0:
+          await this.returnContent([Uint8Array.from(this.socket.reader!.bytes)], [this.contentKey])
+          break
+        case 1: {
+          if (this.socket.reader!.contents.length > 0) {
+            const key = this.contentKey
+            const value = this.socket.reader!.contents.shift()!
+            this.logger(`Storing: ${bytesToHex(key)}.  length: ${value.length} `)
+            await this.returnContent([value], [key])
+          }
+        }
+      }
     }
     return
   }
   async _handleFinPacket(packet: Packet<PacketType.ST_FIN>): Promise<void> {
-    const content = await this.socket.handleFinPacket(packet, true)
-    if (!content) return
-    await this.returnContent([content], [this.contentKey])
+    switch (this.version) {
+      case 0: {
+        const content = await this.socket.handleFinPacket(packet, true)
+        if (!content) return
+        await this.returnContent([content], [this.contentKey])
+        break
+      }
+      case 1: {
+        while (this.socket.reader!.contents.length > 0) {
+          const key = this.contentKey
+          const value = this.socket.reader!.contents.shift()!
+          this.logger(`Storing: ${bytesToHex(key)}.  length: ${value.length} `)
+          await this.returnContent([value], [key])
+        }
+        await this.socket.handleFinPacket(packet, false)
+        break
+      }
+    }
   }
 }
 
@@ -309,7 +349,7 @@ export class OfferWriteRequest extends ContentWriteRequest {
     }
     await this.socket.handleStatePacket(packet.header.ackNr, packet.header.timestampMicroseconds)
     if (this.socket.state === ConnectionState.Closed) {
-       this.requestManager.closeRequest(packet.header.connectionId)
+      this.requestManager.closeRequest(packet.header.connectionId)
     }
   }
 }

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/ContentRequest.ts
@@ -20,8 +20,9 @@ import type {
   SelectiveAckHeader,
   SocketType,
   StatePacket,
-
-  SynPacket} from '../../../index.js'
+  SynPacket,
+  Version,
+} from '../../../index.js'
 import type { ReadSocket } from '../Socket/ReadSocket.js'
 import type { WriteSocket } from '../Socket/WriteSocket.js'
 import type { RequestManager } from './requestManager.js'
@@ -42,6 +43,7 @@ export interface ContentRequestOptions {
   connectionId: number
   contentKeys: Uint8Array[]
   content: Uint8Array
+  version?: Version
   logger?: Debugger
 }
 
@@ -52,6 +54,7 @@ export abstract class ContentRequest {
   socket: SocketType
   connectionId: number
   logger: Debugger
+  version: Version
   constructor(options: ContentRequestOptions) {
     this.requestManager = options.requestManager
     this.network = options.network
@@ -59,6 +62,7 @@ export abstract class ContentRequest {
     this.connectionId = options.connectionId
     this.socket = options.socket
     this.logger = options.logger ? options.logger.extend('ContentRequest') : debug('ContentRequest')
+    this.version = options.version ?? 0
   }
 
   abstract init(): Promise<void>

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/index.ts
@@ -94,7 +94,7 @@ export class PortalNetworkUTP {
   }
 
   async handleNewRequest(params: INewRequest): Promise<ContentRequestType> {
-    const { contentKeys, enr, connectionId, requestCode } = params
+    const { contentKeys, enr, connectionId, requestCode, version } = params
     if (this.requestManagers[enr.nodeId] === undefined) {
       this.requestManagers[enr.nodeId] = new RequestManager(enr.nodeId, this.logger)
     }
@@ -119,6 +119,7 @@ export class PortalNetworkUTP {
       connectionId,
       content,
       contentKeys,
+      version,
     })
     await this.requestManagers[enr.nodeId].handleNewRequest(connectionId, newRequest)
     this.logger.extend('utpRequest')(

--- a/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
+++ b/packages/portalnetwork/src/wire/utp/PortalNetworkUtp/types.ts
@@ -2,6 +2,7 @@ import type { ENR } from '@chainsafe/enr'
 
 import type { NetworkId } from '../../../networks/types.js'
 import type { INodeAddress } from '@chainsafe/discv5/lib/session/nodeInfo.js'
+import { Version } from '../../../index.js'
 
 export type UtpSocketKey = string
 
@@ -22,6 +23,7 @@ export interface INewRequest {
   connectionId: number
   requestCode: RequestCode
   contents?: Uint8Array
+  version?: Version
 }
 
 

--- a/packages/portalnetwork/src/wire/utp/Socket/ReadSocket.ts
+++ b/packages/portalnetwork/src/wire/utp/Socket/ReadSocket.ts
@@ -42,10 +42,7 @@ export class ReadSocket extends UtpSocket {
       expected = this.ackNr + 1 === packet.header.seqNr
     }
     this.setSeqNr(this.getSeqNr() + 1)
-    if (!this.reader) {
-      this.reader = new ContentReader(packet.header.seqNr)
-      this.reader.bytesExpected = Infinity
-    }
+
     // Add the packet.seqNr to this.ackNrs at the relative index, regardless of order received.
     if (this.ackNrs[0] === undefined) {
       this.logger(`Setting AckNr[0] to ${packet.header.seqNr}`)
@@ -56,10 +53,10 @@ export class ReadSocket extends UtpSocket {
       )
       this.ackNrs[packet.header.seqNr - this.ackNrs[0]] = packet.header.seqNr
     }
-    this.reader.addPacket(packet)
+    this.reader!.addPacket(packet)
     this.logger(
       `Packet bytes: ${packet.payload!.length} bytes.  Total bytes: ${
-        this.reader.bytesReceived
+        this.reader!.bytesReceived
       } bytes.`,
     )
     if (expected) {

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -25,6 +25,7 @@ import {
 } from '../../src/index.js'
 
 import type { BeaconNetwork } from '../../src/index.js'
+import { BitArray } from '@chainsafe/ssz'
 
 const require = createRequire(import.meta.url)
 
@@ -453,7 +454,7 @@ describe('OFFER/ACCEPT tests', () => {
     const acceptedOffers = await network1.sendOffer(network2.enr.toENR(), [
       staleOptimisticUpdateContentKey,
     ])
-    assert.deepEqual(acceptedOffers, [], 'no content was accepted by node 2')
+    assert.deepEqual(acceptedOffers, BitArray.fromBoolArray([false]), 'no content was accepted by node 2')
     const content = await network2.retrieve(
       hexToBytes(intToHex(BeaconNetworkContentType.LightClientOptimisticUpdate)),
     )

--- a/packages/portalnetwork/test/integration/blacklist.spec.ts
+++ b/packages/portalnetwork/test/integration/blacklist.spec.ts
@@ -5,10 +5,12 @@ import { hexToBytes } from 'ethereum-cryptography/utils'
 import { assert, describe, it } from 'vitest'
 import type { HistoryNetwork } from '../../src'
 import {
+  MessageCodes,
   NetworkId,
- 
+  PortalWireMessageType,
   SupportedVersions,
-  TransportLayer, createPortalNetwork,
+  TransportLayer,
+  createPortalNetwork,
 } from '../../src/index.js'
 const privateKeys = [
   '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
@@ -118,15 +120,30 @@ describe('version conflict', async () => {
     assert.isFalse(control)
   })
 
-  const pong = await network1?.sendPing(network2?.enr!.toENR())
-  it('should fail to ping peer with version conflict', async () => {
-    assert.isUndefined(pong)
+  // const pong = await network1?.sendPing(network2?.enr!.toENR())
+  // Send a PING (bypass version conflict)
+  const pingMsg = PortalWireMessageType[0].serialize({
+    selector: MessageCodes.PING,
+    value: {
+      enrSeq: node1.discv5.enr.seq,
+      payloadType: 0,
+      customPayload: network1.pingPongPayload(0),
+    },
   })
-  const blacklisted = node1.isBlackListed(node2.discv5.enr.getLocationMultiaddr('udp')!)
+  const res = await network1?.sendMessage(
+    node2.discv5.enr.toENR(),
+    pingMsg,
+    NetworkId.HistoryNetwork,
+  )
+
+  it('should fail to ping peer with version conflict', async () => {
+    assert.deepEqual(res, Uint8Array.from([]))
+  })
+  const blacklisted = node2.isBlackListed(node1.discv5.enr.getLocationMultiaddr('udp')!)
   it('should blacklist peer with version conflict', async () => {
     assert.isTrue(blacklisted)
   })
-  const compare = await node1.highestCommonVersion(node2.discv5.enr.toENR())
+
   it('should compare versions', async () => {
     try {
       await node1.highestCommonVersion(node2.discv5.enr.toENR())

--- a/packages/portalnetwork/test/integration/blacklist.spec.ts
+++ b/packages/portalnetwork/test/integration/blacklist.spec.ts
@@ -128,6 +128,11 @@ describe('version conflict', async () => {
   })
   const compare = await node1.highestCommonVersion(node2.discv5.enr.toENR())
   it('should compare versions', async () => {
-    assert.equal(compare, -1)
+    try {
+      await node1.highestCommonVersion(node2.discv5.enr.toENR())
+      assert.fail('should have thrown')
+    } catch (e) {
+      assert.equal(e.message, `No common version found with ${enr2.nodeId}`)
+    }
   })
 })

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -327,7 +327,7 @@ describe('Offer/Accept', () => {
       '0x00' + generateRandomNodeIdAtDistance(node2.discv5.enr.nodeId, 256),
     )
     const res = await network1.sendOffer(node2.discv5.enr.toENR(), [veryFarFakeContentKey])
-    assert.deepEqual(res, [], 'no accepts should be received')
+    assert.deepEqual(res, BitArray.fromBoolArray([false]), 'no accepts should be received')
   })
   it('should send offer and get correct number of accepted content keys', async () => {
     const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/3092`)

--- a/packages/portalnetwork/test/integration/versions.spec.ts
+++ b/packages/portalnetwork/test/integration/versions.spec.ts
@@ -7,38 +7,40 @@ import { keys } from '@libp2p/crypto'
 import { SignableENR } from '@chainsafe/enr'
 import { multiaddr } from '@multiformats/multiaddr'
 import { NetworkId, TransportLayer, createPortalNetwork, HistoryNetwork } from '../../src/index.js'
+const testdata = yaml.load(
+  readFileSync(
+    resolve(__dirname, '../../../portal-spec-tests/tests/mainnet/history/receipts/14764013.yaml'),
+    {
+      encoding: 'utf-8',
+    },
+  ),
+) as {
+  content_key: string
+  content_value: string
+}
+
+const privateKeys = [
+  '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
+  '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
+]
+
+const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
+const enr1 = SignableENR.createFromPrivateKey(pk1)
+const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
+const enr2 = SignableENR.createFromPrivateKey(pk2)
+let port = 8000
 
 describe('FindContent versions', async () => {
-  const testdata = yaml.load(
-    readFileSync(
-      resolve(__dirname, '../../../portal-spec-tests/tests/mainnet/history/receipts/14764013.yaml'),
-      {
-        encoding: 'utf-8',
-      },
-    ),
-  ) as {
-    content_key: string
-    content_value: string
-  }
   it('should get test content', () => {
     assert.exists(testdata.content_key)
     assert.exists(testdata.content_value)
   })
 
-  const privateKeys = [
-    '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
-    '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
-  ]
-
-  const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
-  const enr1 = SignableENR.createFromPrivateKey(pk1)
-  const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
-  const enr2 = SignableENR.createFromPrivateKey(pk2)
 
   it('works with 0 / 0', async () => {
-    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8000`)
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr1.setLocationMultiaddr(initMa)
-    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8001`)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await createPortalNetwork({
       transport: TransportLayer.NODE,
@@ -87,9 +89,9 @@ describe('FindContent versions', async () => {
     'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
   })
   it('works with 0 / [0, 1]', async () => {
-    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8002`)
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr1.setLocationMultiaddr(initMa)
-    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8003`)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await createPortalNetwork({
       transport: TransportLayer.NODE,
@@ -137,9 +139,9 @@ describe('FindContent versions', async () => {
     'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
   })
   it('works with [0, 1] / 0', async () => {
-    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8004`)
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr1.setLocationMultiaddr(initMa)
-    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8005`)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await createPortalNetwork({
       transport: TransportLayer.NODE,
@@ -187,9 +189,9 @@ describe('FindContent versions', async () => {
     'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
   })
   it('works with [0, 1] / [0, 1]', async () => {
-    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8006`)
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr1.setLocationMultiaddr(initMa)
-    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8007`)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await createPortalNetwork({
       transport: TransportLayer.NODE,
@@ -237,9 +239,9 @@ describe('FindContent versions', async () => {
     'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
   })
   it('fails with version mismatch', async () => {
-    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8008`)
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr1.setLocationMultiaddr(initMa)
-    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8009`)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/${port++}`)
     enr2.setLocationMultiaddr(initMa2)
     const node1 = await createPortalNetwork({
       transport: TransportLayer.NODE,

--- a/packages/portalnetwork/test/integration/versions.spec.ts
+++ b/packages/portalnetwork/test/integration/versions.spec.ts
@@ -1,0 +1,289 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import yaml from 'js-yaml'
+import { describe, it, assert, expect } from 'vitest'
+import { hexToBytes } from '@ethereumjs/util'
+import { keys } from '@libp2p/crypto'
+import { SignableENR } from '@chainsafe/enr'
+import { multiaddr } from '@multiformats/multiaddr'
+import { NetworkId, TransportLayer, createPortalNetwork, HistoryNetwork } from '../../src/index.js'
+
+describe('FindContent versions', async () => {
+  const testdata = yaml.load(
+    readFileSync(
+      resolve(__dirname, '../../../portal-spec-tests/tests/mainnet/history/receipts/14764013.yaml'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  ) as {
+    content_key: string
+    content_value: string
+  }
+  it('should get test content', () => {
+    assert.exists(testdata.content_key)
+    assert.exists(testdata.content_value)
+  })
+
+  const privateKeys = [
+    '0x0a2700250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c12250802122102273097673a2948af93317235d2f02ad9cf3b79a34eeb37720c5f19e09f11783c1a2408021220aae0fff4ac28fdcdf14ee8ecb591c7f1bc78651206d86afe16479a63d9cb73bd',
+    '0x0a27002508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd743764122508021221039909a8a7e81dbdc867480f0eeb7468189d1e7a1dd7ee8a13ee486c8cbd7437641a2408021220c6eb3ae347433e8cfe7a0a195cc17fc8afcd478b9fb74be56d13bccc67813130',
+  ]
+
+  const pk1 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[0]).slice(-36))
+  const enr1 = SignableENR.createFromPrivateKey(pk1)
+  const pk2 = keys.privateKeyFromProtobuf(hexToBytes(privateKeys[1]).slice(-36))
+  const enr2 = SignableENR.createFromPrivateKey(pk2)
+
+  it('works with 0 / 0', async () => {
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8000`)
+    enr1.setLocationMultiaddr(initMa)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8001`)
+    enr2.setLocationMultiaddr(initMa2)
+    const node1 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr1,
+        bindAddrs: {
+          ip4: initMa,
+        },
+        privateKey: pk1,
+      },
+      supportedVersions: [0],
+    })
+
+    const node2 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr2,
+        bindAddrs: {
+          ip4: initMa2,
+        },
+        privateKey: pk2,
+      },
+      supportedVersions: [0],
+    })
+
+    await node1.start()
+    await node2.start()
+    const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+
+    await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
+
+    const stored = await network1.findContentLocally(hexToBytes(testdata.content_key))
+    assert.exists(stored)
+    assert.deepEqual(stored, hexToBytes(testdata.content_value))
+
+
+    const found = await network2.sendFindContent(
+      node1.discv5.enr.toENR(),
+      hexToBytes(testdata.content_key),
+    )
+    assert.exists(found)
+    assert.isTrue('content' in found)
+    'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
+  })
+  it('works with 0 / [0, 1]', async () => {
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8002`)
+    enr1.setLocationMultiaddr(initMa)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8003`)
+    enr2.setLocationMultiaddr(initMa2)
+    const node1 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr1,
+        bindAddrs: {
+          ip4: initMa,
+        },
+        privateKey: pk1,
+      },
+      supportedVersions: [0],
+    })
+
+    const node2 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr2,
+        bindAddrs: {
+          ip4: initMa2,
+        },
+        privateKey: pk2,
+      },
+      supportedVersions: [0, 1],
+    })
+
+    await node1.start()
+    await node2.start()
+    const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+
+    await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
+
+    const stored = await network1.findContentLocally(hexToBytes(testdata.content_key))
+    assert.exists(stored)
+    assert.deepEqual(stored, hexToBytes(testdata.content_value))
+
+    const found = await network2.sendFindContent(
+      node1.discv5.enr.toENR(),
+      hexToBytes(testdata.content_key),
+    )
+    assert.exists(found)
+    assert.isTrue('content' in found)
+    'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
+  })
+  it('works with [0, 1] / 0', async () => {
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8004`)
+    enr1.setLocationMultiaddr(initMa)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8005`)
+    enr2.setLocationMultiaddr(initMa2)
+    const node1 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr1,
+        bindAddrs: {
+          ip4: initMa,
+        },
+        privateKey: pk1,
+      },
+      supportedVersions: [0, 1],
+    })
+
+    const node2 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr2,
+        bindAddrs: {
+          ip4: initMa2,
+        },
+        privateKey: pk2,
+      },
+      supportedVersions: [0],
+    })
+
+    await node1.start()
+    await node2.start()
+    const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+
+    await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
+
+    const stored = await network1.findContentLocally(hexToBytes(testdata.content_key))
+    assert.exists(stored)
+    assert.deepEqual(stored, hexToBytes(testdata.content_value))
+
+    const found = await network2.sendFindContent(
+      node1.discv5.enr.toENR(),
+      hexToBytes(testdata.content_key),
+    )
+    assert.exists(found)
+    assert.isTrue('content' in found)
+    'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
+  })
+  it('works with [0, 1] / [0, 1]', async () => {
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8006`)
+    enr1.setLocationMultiaddr(initMa)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8007`)
+    enr2.setLocationMultiaddr(initMa2)
+    const node1 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr1,
+        bindAddrs: {
+          ip4: initMa,
+        },
+        privateKey: pk1,
+      },
+      supportedVersions: [0, 1],
+    })
+
+    const node2 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr2,
+        bindAddrs: {
+          ip4: initMa2,
+        },
+        privateKey: pk2,
+      },
+      supportedVersions: [0, 1],
+    })
+
+    await node1.start()
+    await node2.start()
+    const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+
+    await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
+
+    const stored = await network1.findContentLocally(hexToBytes(testdata.content_key))
+    assert.exists(stored)
+    assert.deepEqual(stored, hexToBytes(testdata.content_value))
+
+    const found = await network2.sendFindContent(
+      node1.discv5.enr.toENR(),
+      hexToBytes(testdata.content_key),
+    )
+    assert.exists(found)
+    assert.isTrue('content' in found)
+    'content' in found && assert.deepEqual(found.content, hexToBytes(testdata.content_value))
+  })
+  it('fails with version mismatch', async () => {
+    const initMa: any = multiaddr(`/ip4/127.0.0.1/udp/8008`)
+    enr1.setLocationMultiaddr(initMa)
+    const initMa2: any = multiaddr(`/ip4/127.0.0.1/udp/8009`)
+    enr2.setLocationMultiaddr(initMa2)
+    const node1 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr1,
+        bindAddrs: {
+          ip4: initMa,
+        },
+        privateKey: pk1,
+      },
+      supportedVersions: [0],
+    })
+
+    const node2 = await createPortalNetwork({
+      transport: TransportLayer.NODE,
+      supportedNetworks: [{ networkId: NetworkId.HistoryNetwork }],
+      config: {
+        enr: enr2,
+        bindAddrs: {
+          ip4: initMa2,
+        },
+        privateKey: pk2,
+      },
+      supportedVersions: [1],
+    })
+
+    await node1.start()
+    await node2.start()
+    const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
+
+    await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
+
+    const stored = await network1.findContentLocally(hexToBytes(testdata.content_key))
+    assert.exists(stored)
+    assert.deepEqual(stored, hexToBytes(testdata.content_value))
+
+
+    const found = await network2.sendFindContent(
+      node1.discv5.enr.toENR(),
+      hexToBytes(testdata.content_key),
+    )
+    assert.notExists(found)
+
+  })
+})

--- a/packages/portalnetwork/test/integration/versions.spec.ts
+++ b/packages/portalnetwork/test/integration/versions.spec.ts
@@ -1,13 +1,14 @@
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
-import yaml from 'js-yaml'
-import { describe, it, assert, expect } from 'vitest'
+import { SignableENR } from '@chainsafe/enr'
+import { BitArray } from '@chainsafe/ssz'
 import { hexToBytes } from '@ethereumjs/util'
 import { keys } from '@libp2p/crypto'
-import { SignableENR } from '@chainsafe/enr'
 import { multiaddr } from '@multiformats/multiaddr'
-import { NetworkId, TransportLayer, createPortalNetwork, HistoryNetwork, AcceptCode } from '../../src/index.js'
-import { BitArray } from '@chainsafe/ssz'
+import { readFileSync } from 'fs'
+import yaml from 'js-yaml'
+import { resolve } from 'path'
+import { assert, describe, it } from 'vitest'
+import type { HistoryNetwork } from '../../src/index.js'
+import { AcceptCode, NetworkId, TransportLayer, createPortalNetwork } from '../../src/index.js'
 const testdata = yaml.load(
   readFileSync(
     resolve(__dirname, '../../../portal-spec-tests/tests/mainnet/history/receipts/14764013.yaml'),
@@ -322,7 +323,6 @@ describe('Offer/Accept versions', async () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
 
     await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
 
@@ -370,7 +370,6 @@ describe('Offer/Accept versions', async () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
 
     await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
 
@@ -382,7 +381,6 @@ describe('Offer/Accept versions', async () => {
       hexToBytes(testdata.content_key),
     ])
     assert.exists(offer)
-    console.log(offer)
     assert.isTrue(offer instanceof Uint8Array)
   })
   it('defaults to lowest common version', async () => {
@@ -419,7 +417,6 @@ describe('Offer/Accept versions', async () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
 
     await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
 
@@ -467,7 +464,6 @@ describe('Offer/Accept versions', async () => {
     await node1.start()
     await node2.start()
     const network1 = node1.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
-    const network2 = node2.networks.get(NetworkId.HistoryNetwork) as HistoryNetwork
 
     await network1.store(hexToBytes(testdata.content_key), hexToBytes(testdata.content_value))
 

--- a/packages/portalnetwork/test/wire/types.spec.ts
+++ b/packages/portalnetwork/test/wire/types.spec.ts
@@ -312,4 +312,17 @@ describe('message encoding should match test vectors', () => {
     testVector = '0x070102060000000101'
     assert.equal(bytesToHex(payload), testVector, 'accept message encodes correctly')
   })
+  it('should encode v1 ACCEPT message correctly', () => {
+    connectionId = Uint8Array.from([0x01, 0x02])
+    const acceptMessageContentKeys: Uint8Array = Uint8Array.from([ 0, 1, 2, 3, 4, 5, 1, 1])
+    payload = PortalWireMessageType[1].serialize({
+      selector: MessageCodes.ACCEPT,
+      value: {
+        connectionId,
+        contentKeys: acceptMessageContentKeys,
+      },
+    })
+    testVector = '0x070102060000000001020304050101'
+    assert.equal(bytesToHex(payload), testVector, 'accept message encodes correctly')
+  })
 })

--- a/packages/portalnetwork/test/wire/types.spec.ts
+++ b/packages/portalnetwork/test/wire/types.spec.ts
@@ -14,6 +14,8 @@ import {
   clientInfoStringToBytes,
 } from '../../src/wire/index.js'
 
+const version = 0
+
 describe('ping pong message encoding', () => {
   it('should encode type 0 ping with client info', () => {
     const params = {
@@ -27,7 +29,7 @@ describe('ping pong message encoding', () => {
       DataRadius: params.dataRadius,
       Capabilities: params.capabilities,
     })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version]  .serialize({
       selector: MessageCodes.PING,
       value: {
         enrSeq: params.enrSeq,
@@ -50,7 +52,7 @@ describe('ping pong message encoding', () => {
       DataRadius: params.dataRadius,
       Capabilities: params.capabilities,
     })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PING,
       value: {
         enrSeq: params.enrSeq,
@@ -73,7 +75,7 @@ describe('ping pong message encoding', () => {
       DataRadius: params.dataRadius,
       Capabilities: params.capabilities,
     })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PONG,
       value: {
         enrSeq: params.enrSeq,
@@ -96,7 +98,7 @@ describe('ping pong message encoding', () => {
       DataRadius: params.dataRadius,
       Capabilities: params.capabilities,
     })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PONG,
       value: {
         enrSeq: params.enrSeq,
@@ -113,7 +115,7 @@ describe('ping pong message encoding', () => {
       dataRadius: 2n ** 256n - 2n,
     }
     const payload = BasicRadius.serialize({ dataRadius: params.dataRadius })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PING,
       value: {
         enrSeq: params.enrSeq,
@@ -130,7 +132,7 @@ describe('ping pong message encoding', () => {
       dataRadius: 2n ** 256n - 2n,
     }
     const payload = BasicRadius.serialize({ dataRadius: params.dataRadius })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PONG,
       value: {
         enrSeq: params.enrSeq,
@@ -148,7 +150,7 @@ describe('ping pong message encoding', () => {
       ephemeralHeaderCount: 4242
     }
     const payload = HistoryRadius.serialize({ dataRadius: params.dataRadius, ephemeralHeadersCount: params.ephemeralHeaderCount })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PING,
       value: {
         enrSeq: params.enrSeq,
@@ -166,7 +168,7 @@ describe('ping pong message encoding', () => {
       ephemeralHeaderCount: 4242
     }
     const payload = HistoryRadius.serialize({ dataRadius: params.dataRadius, ephemeralHeadersCount: params.ephemeralHeaderCount })
-    const pingMessage = PortalWireMessageType.serialize({
+    const pingMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PONG,
       value: {
         enrSeq: params.enrSeq,
@@ -184,7 +186,7 @@ describe('ping pong message encoding', () => {
       message: 'hello world'
     }
     const payload = ErrorPayload.serialize({ errorCode: params.errorCode, message: utf8ToBytes(params.message) })
-    const pongMessage = PortalWireMessageType.serialize({
+    const pongMessage = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PONG,
       value: {
         enrSeq: params.enrSeq,
@@ -204,7 +206,7 @@ describe('message encoding should match test vectors', () => {
   let payload: Uint8Array
   let testVector: string
   it('should encode PING message correctly', () => {
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.PING,
       value: {
         enrSeq,
@@ -221,7 +223,7 @@ describe('message encoding should match test vectors', () => {
   const distances = Array.from([256, 255])
 
   it('should encode FINDNODES message correctly', () => {
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.FINDNODES,
       value: { distances },
     })
@@ -230,7 +232,7 @@ describe('message encoding should match test vectors', () => {
   })
 
   it('should encode PONG message correctly', () => {
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.NODES,
       value: {
         total: 1,
@@ -249,7 +251,7 @@ describe('message encoding should match test vectors', () => {
   const enrs = [ENR.decodeTxt(enr1).encode(), ENR.decodeTxt(enr2).encode()]
 
   it('should encode NODES message correctly', () => {
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.NODES,
       value: {
         total,
@@ -265,7 +267,7 @@ describe('message encoding should match test vectors', () => {
   const contentKey = hexToBytes('0x706f7274616c')
 
   it('should encode FINDCONTENT message correctly', () => {
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.FINDCONTENT,
       value: { contentKey },
     })
@@ -288,7 +290,7 @@ describe('message encoding should match test vectors', () => {
   // Validate OFFER message encoding
   it('should encode OFFER message correctly', () => {
     const contentKeys = [hexToBytes('0x010203')]
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.OFFER,
       value: { contentKeys },
     })
@@ -300,7 +302,7 @@ describe('message encoding should match test vectors', () => {
   it('should encode ACCEPT message correctly', () => {
     connectionId = Uint8Array.from([0x01, 0x02])
     const acceptMessageContentKeys: BitArray = BitArray.fromSingleBit(8, 0)
-    payload = PortalWireMessageType.serialize({
+    payload = PortalWireMessageType[version].serialize({
       selector: MessageCodes.ACCEPT,
       value: {
         connectionId,


### PR DESCRIPTION
WIP

Implements first version update utilizing new protocol versioning mechanism.

- Accept Codes
  - Implements accept codes update for OFFER/ACCEPT 
  - v1 ACCEPT message contains `bytelist` instead of `bitlist`
  - `bytelist` usage like previous `bitlist` usage, with each `byte` in the list corresponding to a response to an offered content key
  - Different byte values correspond to different ACCEPT or DECLINE messages
  - Clients can communicate reason for DECLINE

- Versioning
  - versioned types for ACCEPT payload
  - versioned types for SSZ portal wire messages
    - currently only difference between v1 and v2 is `AcceptMessageType`
  - versioned types for `uTP` `ContentRequest`
    - version 1 reads prefix on FindContent 
  - version determines varint prefix for FindContent contents

- FindContent varint prefix
  - version 1 content will have prefix when sent over `uTP`
  - matches version 0 offer/accept content encoding
  - https://github.com/ethereum/portal-network-specs/pull/383/files