### PR TITLE
upgrade node engine settings to ^22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 RUN apk update && apk add --no-cache bash g++ make git python3 && rm -rf /var/cache/apk/*
 RUN apk add --virtual .build-deps alpine-sdk jq

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "typescript": "^5.8.2"
       },
       "engines": {
-        "node": "^20",
-        "npm": "^10"
+        "node": "^22",
+        "npm": "^11"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -11492,7 +11492,7 @@
         "vitest": "^3.0.2"
       },
       "engines": {
-        "node": "^20"
+        "node": "^22"
       },
       "peerDependencies": {
         "alchemy-sdk": "^3.0.0-beta.3"
@@ -11557,7 +11557,7 @@
         "vitest": "^3.0.2"
       },
       "engines": {
-        "node": "^20"
+        "node": "^22"
       },
       "peerDependencies": {
         "@frontall/capacitor-udp": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "./packages/cli"
   ],
   "engines": {
-    "npm": "^10",
-    "node": "^20"
+    "npm": "^11",
+    "node": "^22"
   },
   "scripts": {
     "biome": "npx @biomejs/biome check --write",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": "^20"
+    "node": "^22"
   },
   "devDependencies": {
     "@lodestar/api": "^1.12.0",

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -9,7 +9,7 @@
     "default": "./dist/index.js"
   },
   "engines": {
-    "node": "^20"
+    "node": "^22"
   },
   "scripts": {
     "dev": "tsc --watch",


### PR DESCRIPTION
Upgrade requirements to Node 22 (current LTS)

Node 23 is in active development, and has interesting features that we could take advantage of.  We should upgrade once LTS is available.