### PR TITLE
Update @Chainsafe dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -428,12 +428,12 @@
 			}
 		},
 		"node_modules/@chainsafe/discv5": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.0.tgz",
-			"integrity": "sha512-g/x79Y5b7g6CrNuWazSzXTtnNguC0Sl8xkf9CPMlZ0BrsXmXPzwTp3zgtAiuJcG9x7zDUSDFOejrb4iFcJ0/FQ==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.1.tgz",
+			"integrity": "sha512-pTtWr1GtjT57AEmDytu6tmd3jJDnsC9Kbsgzxvtwh7u/aXd28Ibg8b0SO4woOaN0e0L2wpAKC2yzAr5QI4Z2fQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chainsafe/enr": "^5.0.0",
+				"@chainsafe/enr": "^5.0.1",
 				"@ethereumjs/rlp": "^5.0.2",
 				"@libp2p/crypto": "^5.0.1",
 				"@libp2p/interface": "^2.0.1",
@@ -458,9 +458,9 @@
 			}
 		},
 		"node_modules/@chainsafe/enr": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@chainsafe/enr/-/enr-5.0.0.tgz",
-			"integrity": "sha512-xqWBsdFFHy/sLqddsyCT4BH/5PFheyK8Grho27tmiwg/a95nANYANsqXXUP8/HbgCx3F5VDl0/xFacV3Ik7kDA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@chainsafe/enr/-/enr-5.0.1.tgz",
+			"integrity": "sha512-RP5XxJOSYt0f775ne6NqlaG33Qia+IaMjWlP7PlWagz6SOpXlfbm+vaqHx3by6lKPb9aW4UQtO+fiRxz85XwaQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ethereumjs/rlp": "^5.0.2",
@@ -2454,12 +2454,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@libp2p/crypto": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.15.tgz",
-			"integrity": "sha512-28xYMOn3fs8flsNgCVVxp27gEmDTtZHbz+qEVv3v7cWfGRipaVhNXFV9tQJHWXHQ8mN8v/PQvgcfCcWu5jkrTg==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.1.tgz",
+			"integrity": "sha512-feByJ5ypBfl7Dp+jLBmieHDY/249hqCiDn8u6DNSZrpDhefn2l/NE03fS2mW6pLOnY3QIqB372TfLtx3/EPU+w==",
 			"license": "Apache-2.0 OR MIT",
 			"dependencies": {
-				"@libp2p/interface": "^2.7.0",
+				"@libp2p/interface": "^2.9.0",
 				"@noble/curves": "^1.7.0",
 				"@noble/hashes": "^1.6.1",
 				"multiformats": "^13.3.1",
@@ -2469,9 +2469,9 @@
 			}
 		},
 		"node_modules/@libp2p/interface": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.7.0.tgz",
-			"integrity": "sha512-lWmfIGzbSaw//yoEWWJh8dXNDGSCwUyXwC7P1Q6jCFWNoEtCaB1pvwOGBtri7Db/aNFZryMzN5covoq5ulldnA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.9.0.tgz",
+			"integrity": "sha512-L/0Z5H0mjaECA0jkZG+OJmEhB/OIJ07gzZYljU7C19XjL3dSkBvhA9il+G3FpHyHgqAOVGuQU5qkbv2Edj8FIA==",
 			"license": "Apache-2.0 OR MIT",
 			"dependencies": {
 				"@multiformats/multiaddr": "^12.3.3",
@@ -2483,13 +2483,13 @@
 			}
 		},
 		"node_modules/@libp2p/peer-id": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.0.tgz",
-			"integrity": "sha512-9Xob9DDg1uBboM2QvJ5nyPbsjxsNS9obmGAYeAtLSx5aHAIC4AweJQFHssUUCfW7mufkzX/s3zyR62XPR4SYyQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.2.tgz",
+			"integrity": "sha512-K4tjLi+OIHJSeMMqw28xnBxDfklfWCsR423Jm6GxZ5avIj2xm7WIq5oUhCntGGDIQWW/8qdf8v3tYK36JxwLOA==",
 			"license": "Apache-2.0 OR MIT",
 			"dependencies": {
-				"@libp2p/crypto": "^5.0.15",
-				"@libp2p/interface": "^2.7.0",
+				"@libp2p/crypto": "^5.1.1",
+				"@libp2p/interface": "^2.9.0",
 				"multiformats": "^13.3.1",
 				"uint8arrays": "^5.1.0"
 			}
@@ -9520,8 +9520,8 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@chainsafe/discv5": "^11.0.0",
-				"@chainsafe/enr": "^5.0.0",
+				"@chainsafe/discv5": "^11.0.1",
+				"@chainsafe/enr": "^5.0.1",
 				"@chainsafe/persistent-merkle-tree": "^0.8.0",
 				"@chainsafe/ssz": "^0.17.1",
 				"@ethereumjs/block": "^10.0.0-rc.1",
@@ -9744,8 +9744,8 @@
 			"dependencies": {
 				"@chainsafe/as-sha256": "^0.5.0",
 				"@chainsafe/blst": "^2.0.3",
-				"@chainsafe/discv5": "^11.0.0",
-				"@chainsafe/enr": "^5.0.0",
+				"@chainsafe/discv5": "^11.0.1",
+				"@chainsafe/enr": "^5.0.1",
 				"@chainsafe/persistent-merkle-tree": "^0.8.0",
 				"@chainsafe/ssz": "^0.17.1",
 				"@ethereumjs/block": "^10.0.0-rc.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,8 +21,8 @@
     "vitest": "^3.0.2"
   },
   "dependencies": {
-    "@chainsafe/discv5": "^11.0.0",
-    "@chainsafe/enr": "^5.0.0",
+    "@chainsafe/discv5": "^11.0.1",
+    "@chainsafe/enr": "^5.0.1",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/ssz": "^0.17.1",
     "@ethereumjs/block": "^10.0.0-rc.1",

--- a/packages/portal-client/package-lock.json
+++ b/packages/portal-client/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@chainsafe/bls": "^8.1.0",
-        "@chainsafe/discv5": "^11.0.0",
-        "@chainsafe/enr": "^5.0.0",
+        "@chainsafe/discv5": "^11.0.1",
+        "@chainsafe/enr": "^5.0.1",
         "@ethereumjs/common": "^10.0.0-rc.1",
         "@ethereumjs/util": "^10.0.0-rc.1",
         "@kuyoonjo/tauri-plugin-udp": "^0.1.1",
@@ -608,12 +608,12 @@
       }
     },
     "node_modules/@chainsafe/discv5": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.0.tgz",
-      "integrity": "sha512-g/x79Y5b7g6CrNuWazSzXTtnNguC0Sl8xkf9CPMlZ0BrsXmXPzwTp3zgtAiuJcG9x7zDUSDFOejrb4iFcJ0/FQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.1.tgz",
+      "integrity": "sha512-pTtWr1GtjT57AEmDytu6tmd3jJDnsC9Kbsgzxvtwh7u/aXd28Ibg8b0SO4woOaN0e0L2wpAKC2yzAr5QI4Z2fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chainsafe/enr": "^5.0.0",
+        "@chainsafe/enr": "^5.0.1",
         "@ethereumjs/rlp": "^5.0.2",
         "@libp2p/crypto": "^5.0.1",
         "@libp2p/interface": "^2.0.1",
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@chainsafe/enr": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/enr/-/enr-5.0.0.tgz",
-      "integrity": "sha512-xqWBsdFFHy/sLqddsyCT4BH/5PFheyK8Grho27tmiwg/a95nANYANsqXXUP8/HbgCx3F5VDl0/xFacV3Ik7kDA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/enr/-/enr-5.0.1.tgz",
+      "integrity": "sha512-RP5XxJOSYt0f775ne6NqlaG33Qia+IaMjWlP7PlWagz6SOpXlfbm+vaqHx3by6lKPb9aW4UQtO+fiRxz85XwaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
@@ -1503,12 +1503,12 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.15.tgz",
-      "integrity": "sha512-28xYMOn3fs8flsNgCVVxp27gEmDTtZHbz+qEVv3v7cWfGRipaVhNXFV9tQJHWXHQ8mN8v/PQvgcfCcWu5jkrTg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.1.tgz",
+      "integrity": "sha512-feByJ5ypBfl7Dp+jLBmieHDY/249hqCiDn8u6DNSZrpDhefn2l/NE03fS2mW6pLOnY3QIqB372TfLtx3/EPU+w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/interface": "^2.9.0",
         "@noble/curves": "^1.7.0",
         "@noble/hashes": "^1.6.1",
         "multiformats": "^13.3.1",
@@ -1518,9 +1518,9 @@
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.7.0.tgz",
-      "integrity": "sha512-lWmfIGzbSaw//yoEWWJh8dXNDGSCwUyXwC7P1Q6jCFWNoEtCaB1pvwOGBtri7Db/aNFZryMzN5covoq5ulldnA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.9.0.tgz",
+      "integrity": "sha512-L/0Z5H0mjaECA0jkZG+OJmEhB/OIJ07gzZYljU7C19XjL3dSkBvhA9il+G3FpHyHgqAOVGuQU5qkbv2Edj8FIA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/multiaddr": "^12.3.3",
@@ -1532,13 +1532,13 @@
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.0.tgz",
-      "integrity": "sha512-9Xob9DDg1uBboM2QvJ5nyPbsjxsNS9obmGAYeAtLSx5aHAIC4AweJQFHssUUCfW7mufkzX/s3zyR62XPR4SYyQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.2.tgz",
+      "integrity": "sha512-K4tjLi+OIHJSeMMqw28xnBxDfklfWCsR423Jm6GxZ5avIj2xm7WIq5oUhCntGGDIQWW/8qdf8v3tYK36JxwLOA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
         "multiformats": "^13.3.1",
         "uint8arrays": "^5.1.0"
       }

--- a/packages/portal-client/package.json
+++ b/packages/portal-client/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@chainsafe/bls": "^8.1.0",
-    "@chainsafe/discv5": "^11.0.0",
-    "@chainsafe/enr": "^5.0.0",
+    "@chainsafe/discv5": "^11.0.1",
+    "@chainsafe/enr": "^5.0.1",
     "@ethereumjs/common": "^10.0.0-rc.1",
     "@ethereumjs/util": "^10.0.0-rc.1",
     "@kuyoonjo/tauri-plugin-udp": "^0.1.1",

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.5.0",
     "@chainsafe/blst": "^2.0.3",
-    "@chainsafe/discv5": "^11.0.0",
-    "@chainsafe/enr": "^5.0.0",
+    "@chainsafe/discv5": "^11.0.1",
+    "@chainsafe/enr": "^5.0.1",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/ssz": "^0.17.1",
     "@ethereumjs/common": "^10.0.0-rc.1",

--- a/packages/portalnetwork/src/client/client.ts
+++ b/packages/portalnetwork/src/client/client.ts
@@ -374,11 +374,11 @@ export class PortalNetwork extends EventEmitter<PortalNetworkEvents> {
 
   public sendPortalNetworkResponse = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     payload: Uint8Array,
   ) => {
     this.eventLog &&
-      this.emit('SendTalkResp', src.nodeId, requestId.toString(16), bytesToHex(payload))
+      this.emit('SendTalkResp', src.nodeId, bytesToHex(requestId), bytesToHex(payload))
     try {
       await this.discv5.sendTalkResp(src, requestId, payload)
     } catch (err: any) {

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -569,7 +569,7 @@ export class BeaconNetwork extends BaseNetwork {
 
   protected override handleFindContent = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     decodedContentMessage: FindContentMessage,
   ) => {
     this.portal.metrics?.contentMessagesSent.inc()
@@ -910,7 +910,7 @@ export class BeaconNetwork extends BaseNetwork {
    * @param requestId request ID passed in OFFER message
    * @param msg OFFER message containing a list of offered content keys
    */
-  override handleOffer = async (src: INodeAddress, requestId: bigint, msg: OfferMessage) => {
+  override handleOffer = async (src: INodeAddress, requestId: Uint8Array, msg: OfferMessage) => {
     this.logger.extend('OFFER')(
       `Received from ${shortId(src.nodeId, this.routingTable)} with ${
         msg.contentKeys.length

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -380,7 +380,7 @@ export class HistoryNetwork extends BaseNetwork {
 
   protected override handleFindContent = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     decodedContentMessage: FindContentMessage,
   ) => {
     this.portal.metrics?.contentMessagesSent.inc()

--- a/packages/portalnetwork/src/networks/network.ts
+++ b/packages/portalnetwork/src/networks/network.ts
@@ -160,7 +160,7 @@ export abstract class BaseNetwork extends EventEmitter {
     }
   }
 
-  sendResponse(src: INodeAddress, requestId: bigint, payload: Uint8Array): Promise<void> {
+  sendResponse(src: INodeAddress, requestId: Uint8Array, payload: Uint8Array): Promise<void> {
     return this.portal.sendPortalNetworkResponse(src, requestId, payload)
   }
   findEnr(nodeId: string): ENR | undefined {
@@ -407,7 +407,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   handlePing = async (
     src: INodeAddress,
-    id: bigint,
+    id: Uint8Array,
     pingMessage: PingMessage,
     _version: Version,
   ) => {
@@ -479,7 +479,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   sendPong = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     customPayload: Uint8Array,
     payloadType: number,
   ) => {
@@ -542,7 +542,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   private handleFindNodes = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     payload: FindNodesMessage,
     version: Version,
   ) => {
@@ -699,7 +699,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   protected handleOffer = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     msg: OfferMessage,
     version: Version,
   ) => {
@@ -819,7 +819,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   protected sendAccept = async <V extends Version>(
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     desiredContentAccepts: V extends 0 ? boolean[] : V extends 1 ? number[] : never,
     desiredContentKeys: Uint8Array[],
     version = 0,
@@ -896,7 +896,7 @@ export abstract class BaseNetwork extends EventEmitter {
 
   protected handleFindContent = async (
     src: INodeAddress,
-    requestId: bigint,
+    requestId: Uint8Array,
     decodedContentMessage: FindContentMessage,
     _version: Version,
   ) => {
@@ -980,7 +980,7 @@ export abstract class BaseNetwork extends EventEmitter {
     }
   }
 
-  protected enrResponse = async (contentKey: Uint8Array, src: INodeAddress, requestId: bigint) => {
+  protected enrResponse = async (contentKey: Uint8Array, src: INodeAddress, requestId: Uint8Array) => {
     const lookupKey = this.contentKeyToId(contentKey)
     // Discv5 calls for maximum of 16 nodes per NODES message
     const ENRs = this.routingTable.nearest(lookupKey, 16)


### PR DESCRIPTION
Updates @chainsafe/discv5 and @chainsafe/enr to latest versions.

Latest versions include fixes for issues exposed by hive discv5 tests for:
- RequestId encoding/decoding
- WHOAREYOU challenges
- Bytes <> BigInt conversions