### PR TITLE
update discv5 to 11.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -428,9 +428,9 @@
 			}
 		},
 		"node_modules/@chainsafe/discv5": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.1.tgz",
-			"integrity": "sha512-pTtWr1GtjT57AEmDytu6tmd3jJDnsC9Kbsgzxvtwh7u/aXd28Ibg8b0SO4woOaN0e0L2wpAKC2yzAr5QI4Z2fQ==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.2.tgz",
+			"integrity": "sha512-ta5JWRM2snBuvZUArVx8AaYUw1RH7HGSGJdDpYTWl9HH/ZqZztmdynGpBJgaiqREweEldGLuZY4zlD3vETAOdg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@chainsafe/enr": "^5.0.1",
@@ -9950,7 +9950,7 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@chainsafe/discv5": "^11.0.1",
+				"@chainsafe/discv5": "^11.0.2",
 				"@chainsafe/enr": "^5.0.1",
 				"@chainsafe/persistent-merkle-tree": "^0.8.0",
 				"@chainsafe/ssz": "^0.17.1",
@@ -10221,7 +10221,7 @@
 			"dependencies": {
 				"@chainsafe/as-sha256": "^0.5.0",
 				"@chainsafe/blst": "^2.0.3",
-				"@chainsafe/discv5": "^11.0.1",
+				"@chainsafe/discv5": "^11.0.2",
 				"@chainsafe/enr": "^5.0.1",
 				"@chainsafe/persistent-merkle-tree": "^0.8.0",
 				"@chainsafe/ssz": "^0.17.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "vitest": "^3.0.2"
   },
   "dependencies": {
-    "@chainsafe/discv5": "^11.0.1",
+    "@chainsafe/discv5": "^11.0.2",
     "@chainsafe/enr": "^5.0.1",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/ssz": "^0.17.1",

--- a/packages/portal-client/package-lock.json
+++ b/packages/portal-client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@chainsafe/bls": "^8.1.0",
-        "@chainsafe/discv5": "^11.0.1",
+        "@chainsafe/discv5": "^11.0.2",
         "@chainsafe/enr": "^5.0.1",
         "@ethereumjs/common": "^10.0.0-rc.1",
         "@ethereumjs/util": "^10.0.0-rc.1",
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@chainsafe/discv5": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.1.tgz",
-      "integrity": "sha512-pTtWr1GtjT57AEmDytu6tmd3jJDnsC9Kbsgzxvtwh7u/aXd28Ibg8b0SO4woOaN0e0L2wpAKC2yzAr5QI4Z2fQ==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/discv5/-/discv5-11.0.2.tgz",
+      "integrity": "sha512-ta5JWRM2snBuvZUArVx8AaYUw1RH7HGSGJdDpYTWl9HH/ZqZztmdynGpBJgaiqREweEldGLuZY4zlD3vETAOdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@chainsafe/enr": "^5.0.1",

--- a/packages/portal-client/package.json
+++ b/packages/portal-client/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@chainsafe/bls": "^8.1.0",
-    "@chainsafe/discv5": "^11.0.1",
+    "@chainsafe/discv5": "^11.0.2",
     "@chainsafe/enr": "^5.0.1",
     "@ethereumjs/common": "^10.0.0-rc.1",
     "@ethereumjs/util": "^10.0.0-rc.1",

--- a/packages/portalnetwork/package.json
+++ b/packages/portalnetwork/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.5.0",
     "@chainsafe/blst": "^2.0.3",
-    "@chainsafe/discv5": "^11.0.1",
+    "@chainsafe/discv5": "^11.0.2",
     "@chainsafe/enr": "^5.0.1",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/ssz": "^0.17.1",


### PR DESCRIPTION
Updates discv5 to v11.0.2 which includes fix for handling oversized requestId 