### PR TITLE
ContentLookup bug fix

### DIFF
--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -25,6 +25,7 @@ export class ContentLookup {
   private finished: boolean
   private content: ContentLookupResponse
   private pending: Set<NodeId>
+  private queuedPeers: Set<NodeId>
   private completedRequests?: Map<NodeId, NodeId[]>
   private contentTrace?: ContentTrace
   constructor(network: BaseNetwork, contentKey: Uint8Array, trace = false) {
@@ -37,6 +38,7 @@ export class ContentLookup {
     this.finished = false
     this.meta = new Map()
     this.pending = new Set()
+    this.queuedPeers = new Set()
     this.completedRequests = trace ? new Map() : undefined
     this.contentTrace = trace
       ? {

--- a/packages/portalnetwork/src/networks/contentLookup.ts
+++ b/packages/portalnetwork/src/networks/contentLookup.ts
@@ -86,7 +86,8 @@ export class ContentLookup {
       if (this.lookupPeers.length > 0) {
         // Ask more peers (up to 5) for content
         const peerBatch: LookupPeer[] = []
-        while (this.lookupPeers.peek() && peerBatch.length < 5) {
+        const availableSlots = 5 - this.pending.size
+        while (this.lookupPeers.peek() && peerBatch.length < availableSlots) {
           const next = this.lookupPeers.pop()!
           peerBatch.push(next)
         }


### PR DESCRIPTION
Fix for ContentLookup bug described in #711 

Concurrent requets should be limited to 5, however, we were often seeing logs like: 
```
7e7fd:Portal:BeaconNetwork:LOOKUP:0x10f090… Have 19 peers left to ask and 10 pending requests
```

This happened because any time a peer request returned (without content), it would trigger the next recursive round of requets, which would add 5 new requests to the batch.

However, we do want to avoid the need to wait for full batches of 5 to complete before continuing the recursive search.

The solution is to check the number of pending requests before adding more to the batch, and to limit the total number of requests in the new batch and old to 5.  We accomplish this with this line:
```
        const peerBatch: LookupPeer[] = []
        const availableSlots = 5 - this.pending.size
        while (this.lookupPeers.peek() && peerBatch.length < availableSlots) {
          const next = this.lookupPeers.pop()!
          peerBatch.push(next)
        }
```

----

This solution did limit the total pending requests to 5, but did not solve another underlying issue of incomplete requests hanging open.  Because of this, we will simply end up with a set of 5 pending requests that never close.

To solve this, we couple each request with an `abortPromise` using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController), and `AbortSignal`.  The promise will reject when the signal is aborted.  The actual content request is raced against this abort promise.  If the signal is aborted, the request is cancelled and cleaned up, and the pending request is removed from the tracking set.  

This seems to solve the hanging request issue, which should also solve some memory leaks and resource exhaustion issues.