### PR TITLE
Create Chain-Specific Database on Startup

### DIFF
--- a/packages/portalnetwork/src/util/config.ts
+++ b/packages/portalnetwork/src/util/config.ts
@@ -69,7 +69,7 @@ export const cliConfig = async (args: PortalClientOpts) => {
   enr.set('pv', SupportedVersions.serialize(args.supportedVersions ?? [0]))
   let db
   if (args.dataDir !== undefined) {
-    db = new Level<string, string>(args.dataDir)
+    db = new Level<string, string>(args.dataDir + '/' + chainId, { createIfMissing: true })
   }
   const config = {
     chainId,

--- a/packages/portalnetwork/src/util/config.ts
+++ b/packages/portalnetwork/src/util/config.ts
@@ -93,8 +93,8 @@ export const cliConfig = async (args: PortalClientOpts) => {
     let networkdb
     if (args.dataDir !== undefined) {
       networkdb = {
-        db: new Level<string, string>(args.dataDir + '/' + network, { createIfMissing: true }),
-        path: args.dataDir + '/' + network,
+        db: new Level<string, string>(args.dataDir + '/' + chainId + '/' + network, { createIfMissing: true }),
+        path: args.dataDir + '/' + chainId + '/' + network,
       }
     }
     networks.push({


### PR DESCRIPTION
# Create Chain-Specific Database on Startup

## Description
This PR modifies the database initialization logic to create chain-specific databases on startup. Instead of using a single database for all chains, each chain now gets its own dedicated database directory.  This prevents potential data conflicts between different chains

## Changes
- Modified `config.ts` to append the chain ID to the database directory path
- Added `createIfMissing: true` option to ensure the database directory is created if it doesn't exist
- Client database path now follows the pattern: `{dataDir}/{chainId}`
- Network database paths now follow the pattern: `{dataDir}/{chainId}/{network}`

## Impact
Existing databases will need to be migrated to the new directory structure if upgrading from a previous version.