### PR TITLE
Move all event handling to PortalNetwork class

### DIFF
--- a/packages/portalnetwork/src/client/types.ts
+++ b/packages/portalnetwork/src/client/types.ts
@@ -17,10 +17,27 @@ export interface INodeAddress {
   nodeId: NodeId
 }
 
-export interface PortalNetworkEvents {
-  NodeAdded: (nodeId: NodeId, networkId: NetworkId) => void
-  NodeRemoved: (nodeId: NodeId, networkId: NetworkId) => void
-  ContentAdded: (key: Uint8Array, contentType: number, content: string) => void
+type ContentAddedEventName = `${NetworkId}:ContentAdded`
+type ContentAddedEventType = (key: Uint8Array, content: Uint8Array) => Promise<void | { content: Uint8Array; utp: boolean }>
+type ContentAddedEvents = {
+  [K in ContentAddedEventName]: ContentAddedEventType
+}
+
+type NodeAddedEventName = `${NetworkId}:NodeAdded`
+type NodeAddedEventType = (nodeId: NodeId) => void
+type NodeAddedEvents = {
+  [K in NodeAddedEventName]: NodeAddedEventType
+}
+
+type NodeRemovedEventName = `${NetworkId}:NodeRemoved`
+type NodeRemovedEventType = (nodeId: NodeId) => void
+type NodeRemovedEvents = {
+  [K in NodeRemovedEventName]: NodeRemovedEventType
+}
+
+type NetworkEvents = ContentAddedEvents & NodeAddedEvents & NodeRemovedEvents
+
+export interface PortalNetworkEvents extends NetworkEvents {
   Verified: (key: Uint8Array, verified: boolean) => void
   SendTalkReq: (nodeId: string, requestId: string, payload: string) => void
   SendTalkResp: (nodeId: string, requestId: string, payload: string) => void

--- a/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
+++ b/packages/portalnetwork/src/networks/beacon/ultralightTransport.ts
@@ -227,7 +227,7 @@ export class UltralightTransport implements LightClientTransport {
   }
 
   onOptimisticUpdate(handler: (optimisticUpdate: LightClientOptimisticUpdate) => void): void {
-    this.network.on('ContentAdded', (contentKey: Uint8Array, content: Uint8Array) => {
+    this.network.portal.on(`${this.network.networkId}:ContentAdded`, (contentKey: Uint8Array, content: Uint8Array) => {
       const contentType = contentKey[0]
       if (contentType === BeaconNetworkContentType.LightClientOptimisticUpdate) {
         const forkhash = content.slice(0, 4)
@@ -240,11 +240,14 @@ export class UltralightTransport implements LightClientTransport {
           this.logger('something went wrong trying to process Optimistic Update')
           this.logger(err)
         }
-      }
-    })
+        }
+      },
+    )
   }
   onFinalityUpdate(handler: (finalityUpdate: LightClientFinalityUpdate) => void): void {
-    this.network.on('ContentAdded', (contentKey: Uint8Array, content: Uint8Array) => {
+    this.network.portal.on(
+      `${this.network.networkId}:ContentAdded`,
+      (contentKey: Uint8Array, content: Uint8Array) => {
       const contentType = contentKey[0]
       if (contentType === BeaconNetworkContentType.LightClientFinalityUpdate) {
         const forkhash = content.slice(0, 4)

--- a/packages/portalnetwork/src/networks/history/history.ts
+++ b/packages/portalnetwork/src/networks/history/history.ts
@@ -355,7 +355,7 @@ export class HistoryNetwork extends BaseNetwork {
             this.logger.extend('FOUNDCONTENT')(`received uTP Connection ID ${id}`)
             response = await new Promise((resolve, _reject) => {
               // TODO: Figure out how to clear this listener
-              this.on('ContentAdded', (contentKey: Uint8Array, value) => {
+              this.portal.on(`${this.networkId}:ContentAdded`, (contentKey: Uint8Array, value: Uint8Array) => {
                 if (equalsBytes(contentKey, key) === true) {
                   this.logger.extend('FOUNDCONTENT')(`received content for uTP Connection ID ${id}`)
                   resolve({ content: value, utp: true })
@@ -646,7 +646,7 @@ export class HistoryNetwork extends BaseNetwork {
       }
     }
 
-    this.emit('ContentAdded', contentKey, value)
+    this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, value)
     if (this.routingTable.values().length > 0) {
       if (
         contentType !== HistoryNetworkContentType.EphemeralHeader &&
@@ -692,7 +692,7 @@ export class HistoryNetwork extends BaseNetwork {
     const bodyContentKey = getContentKey(HistoryNetworkContentType.BlockBody, hashKey)
     if (block instanceof Block) {
       await this.put(bodyContentKey, bytesToHex(bodyBytes))
-      this.emit('ContentAdded', bodyContentKey, bodyBytes)
+      this.portal.emit(`${this.networkId}:ContentAdded`, bodyContentKey, bodyBytes)
 
       // TODO: Decide when and if to build and store receipts.
       //       Doing this here caused a bottleneck when same receipt is gossiped via uTP at the same time.
@@ -703,7 +703,7 @@ export class HistoryNetwork extends BaseNetwork {
       this.logger('Could not verify block content')
       this.logger('Adding anyway for testing...')
       await this.put(bodyContentKey, bytesToHex(bodyBytes))
-      this.emit('ContentAdded', bodyContentKey, bodyBytes)
+      this.portal.emit(`${this.networkId}:ContentAdded`, bodyContentKey, bodyBytes)
       // TODO: Decide what to do here.  We shouldn't be storing block bodies without a corresponding header
       // as it's against spec
       return

--- a/packages/portalnetwork/src/networks/state/state.ts
+++ b/packages/portalnetwork/src/networks/state/state.ts
@@ -111,7 +111,7 @@ export class StateNetwork extends BaseNetwork {
             this.logger.extend('FOUNDCONTENT')(`received uTP Connection ID ${id}`)
             response = await new Promise((resolve, _reject) => {
               // TODO: Figure out how to clear this listener
-              this.on('ContentAdded', (contentKey: Uint8Array, value) => {
+              this.portal.on(`${this.networkId}:ContentAdded`, (contentKey, value) => {
                 if (equalsBytes(contentKey, key) === true) {
                   this.logger.extend('FOUNDCONTENT')(`received content for uTP Connection ID ${id}`)
                   resolve({ content: value, utp: true })
@@ -192,7 +192,7 @@ export class StateNetwork extends BaseNetwork {
         await this.db.put(contentKey, content)
       }
       this.logger(`content added for: ${bytesToHex(contentKey)}`)
-      this.emit('ContentAdded', contentKey, content)
+      this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, content)
       this.gossipManager.add(contentKey)
     } catch (err: any) {
       this.logger(`Error storing content: ${err.message}`)
@@ -257,7 +257,7 @@ export class StateNetwork extends BaseNetwork {
     }
     for (const { contentKey, dbContent } of interested) {
       await this.db.put(contentKey, dbContent)
-      this.emit('ContentAdded', contentKey, dbContent)
+      this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, dbContent)
     }
     return { interested, notInterested }
   }
@@ -281,7 +281,7 @@ export class StateNetwork extends BaseNetwork {
       node: curRlp,
     })
     await this.db.put(contentKey, dbContent)
-    this.emit('ContentAdded', contentKey, dbContent)
+    this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, dbContent)
   }
 
   async storeStorageTrieNode(contentKey: Uint8Array, content: Uint8Array) {
@@ -291,7 +291,7 @@ export class StateNetwork extends BaseNetwork {
       node: curRlp,
     })
     await this.db.put(contentKey, dbContent)
-    this.emit('ContentAdded', contentKey, dbContent)
+    this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, dbContent)
   }
 
   async receiveStorageTrieNodeOffer(
@@ -362,7 +362,7 @@ export class StateNetwork extends BaseNetwork {
     }
     for (const { contentKey, dbContent } of interested) {
       await this.db.put(contentKey, dbContent)
-      this.emit('ContentAdded', contentKey, dbContent)
+      this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, dbContent)
     }
     return { interested, notInterested }
   }
@@ -394,7 +394,7 @@ export class StateNetwork extends BaseNetwork {
     const codeContent = ContractRetrieval.serialize({ code })
     this.manager.trie.db.local.set(bytesToUnprefixedHex(codeHash), bytesToHex(contentKey))
     await this.db.put(contentKey, codeContent)
-    this.emit('ContentAdded', contentKey, codeContent)
+    this.portal.emit(`${this.networkId}:ContentAdded`, contentKey, codeContent)
     await this.receiveAccountTrieNodeOffer(
       ...extractAccountProof(addressHash, accountProof, blockHash),
     )

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -343,7 +343,7 @@ describe('OFFER/ACCEPT tests', () => {
     )
 
     await new Promise((resolve) => {
-      network2.on('ContentAdded', (contentKey: Uint8Array) => {
+      node2.on(`${network2.networkId}:ContentAdded`, (contentKey: Uint8Array) => {
         const contentType = contentKey[0]
         if (contentType === BeaconNetworkContentType.LightClientOptimisticUpdate)
           // Update the light client stub to report the new "optimistic head"
@@ -522,7 +522,7 @@ describe('OFFER/ACCEPT tests', () => {
     await network1.sendOffer(network2.enr.toENR(), [bootstrapKey])
 
     await new Promise((resolve) => {
-      network2.on('ContentAdded', (key: Uint8Array) => {
+      node2.on(`${network2.networkId}:ContentAdded`, (key: Uint8Array) => {
         assert.deepEqual(key, bootstrapKey, 'successfully gossipped bootstrap')
         resolve(undefined)
       })
@@ -753,7 +753,7 @@ describe('beacon light client sync tests', () => {
     )
 
     await new Promise((resolve) => {
-      network2.portal.on('NodeAdded', (_nodeId) => {
+      node2.on(`${network2.networkId}:NodeAdded`, (_nodeId) => {
         if (network2['bootstrapFinder'].values.length > 0) {
           resolve('undefined)')
         }

--- a/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
+++ b/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
@@ -232,7 +232,7 @@ describe('should offer headers to peers', () => {
     await node1.start()
     await node2.start()
     const history1 = node1.network()['0x500b']
-    const history2 = node2.network()['0x500b']
+    const history2 = node2.network()['0x500b']!
     await history2?.sendPing(node1.discv5.enr.toENR())
     await node1
       .network()
@@ -263,7 +263,7 @@ describe('should offer headers to peers', () => {
     )
     await new Promise((resolve) => {
       let count = 0
-      history2?.on('ContentAdded', async (key, value) => {
+      node2.on(`${history2.networkId}:ContentAdded`, async (key, value) => {
         count++
         if (count === 3) {
           const header = await history2.get(getEphemeralHeaderDbKey(headers[2].hash()))

--- a/packages/portalnetwork/test/integration/integration.spec.ts
+++ b/packages/portalnetwork/test/integration/integration.spec.ts
@@ -94,11 +94,10 @@ describe('gossip test', async () => {
   // Fancy workaround to allow us to "await" an event firing as expected following this - https://github.com/ljharb/tape/pull/503#issuecomment-619358911
   const end = new EventEmitter()
   const addedHeaders: [string, string][] = []
-  network2.on('ContentAdded', async (key: Uint8Array, content: Uint8Array) => {
+  node2.on(`${network2.networkId}:ContentAdded`, async (key: Uint8Array, content: Uint8Array) => {
     network2.logger.extend('ContentAdded')(`Added Content for ${bytesToHex(key)}`)
     addedHeaders.push([bytesToHex(key), bytesToHex(content)])
     if (addedHeaders.length === headersWithProofs.length) {
-      node2.removeAllListeners()
       void node1.stop()
       void node2.stop()
       end.emit('end()')
@@ -218,7 +217,6 @@ describe('FindContent', async () => {
     setHardfork: true,
   })
 
-  node2.removeAllListeners()
   void node1.stop()
   void node2.stop()
   it('should find content', () => {

--- a/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
@@ -259,7 +259,7 @@ describe('constructor/initialization tests', async () => {
       },
     })
     const beacon = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconNetwork
-    const listeners = beacon.portal.listeners('NodeAdded')
+    const listeners = beacon.portal.listeners(`${beacon.networkId}:NodeAdded`)
     assert.equal(listeners.length, 1, 'bootstrap vote listener is running')
     assert.equal(listeners[0], beacon['getBootStrapVote'])
   })
@@ -278,7 +278,7 @@ describe('constructor/initialization tests', async () => {
       trustedBlockRoot: bytesToHex(randomBytes(32)),
     })
     const beacon = node1.networks.get(NetworkId.BeaconChainNetwork) as BeaconNetwork
-    const listeners = beacon.portal.listeners('NodeAdded')
+    const listeners = beacon.portal.listeners(`${beacon.networkId}:NodeAdded`)
     assert.equal(listeners.length, 1, 'bootstrap listener is running')
     assert.equal(listeners[0], beacon['getBootstrap'])
   })
@@ -316,7 +316,7 @@ describe('constructor/initialization tests', async () => {
     await beacon.initializeLightClient(trustedBlockRoot)
     assert.equal((beacon.lightClient as any).checkpointRoot, trustedBlockRoot)
     expect(beacon.lightClient!.start).toHaveBeenCalled()
-    const listeners = beacon.portal.listeners('NodeAdded')
+    const listeners = beacon.portal.listeners(`${beacon.networkId}:NodeAdded`)
 
     assert.equal(listeners.length, 0, 'bootstrap listener is not running')
     vi.resetAllMocks()


### PR DESCRIPTION
his PR removes direct EventEmitter inheritance from Network classes and restructurs how events are handled across the Portal Network implementation. 
The changes introduce namespaced events and centralize event handling through the PortalNetwork class

## Changes
- Remove EventEmitter inheritance from Network classes
- Implement namespaced events using network IDs (e.g., `${networkId}:ContentAdded`)
- Move event handling from Network classes to PortalNetwork class
- Update event listeners and emitters across all network implementations
- Update tests

- **BaseNetwork classes**
   - Removed EventEmitter inheritance
   - Events now emitted through `this.portal` instead of directly
   - Event names prefixed with network IDs for better isolation

- **Event Handling**
   - All events are now namespaced with their network ID
   - Removed redundant network ID checks in event handlers
