### PR TITLE
Support partial ranges in FOUNDCONTENT response for `LightClientUpdate`

### DIFF
--- a/packages/cli/scripts/beaconBridge.ts
+++ b/packages/cli/scripts/beaconBridge.ts
@@ -13,7 +13,7 @@ import {
   LightClientOptimisticUpdateKey,
   LightClientUpdatesByRange,
   LightClientUpdatesByRangeKey,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from 'portalnetwork'
 
 const { Client } = jayson
@@ -34,7 +34,7 @@ const main = async () => {
   console.log(
     `Retrieved latest optimistic update for slot ${BigInt(optimisticUpdate.signatureSlot)}`,
   )
-  const optimisticUpdateKey = getBeaconContentKey(
+  const optimisticUpdateKey = encodeBeaconContentKey(
     BeaconNetworkContentType.LightClientOptimisticUpdate,
     LightClientOptimisticUpdateKey.serialize({
       signatureSlot: BigInt(optimisticUpdate.signatureSlot),
@@ -58,7 +58,7 @@ const main = async () => {
     )
   }
   const serializedRange = LightClientUpdatesByRange.serialize(range)
-  const rangeKey = getBeaconContentKey(
+  const rangeKey = encodeBeaconContentKey(
     BeaconNetworkContentType.LightClientUpdatesByRange,
     LightClientUpdatesByRangeKey.serialize({ startPeriod: BigInt(oldPeriod), count: 3n }),
   )
@@ -77,7 +77,7 @@ const main = async () => {
     `Retrieved bootstrap for finalized checkpoint ${bootstrapRoot} from starting sync period ${oldPeriod}...`,
   )
   const res = await ultralight.request('portal_beaconStore', [
-    getBeaconContentKey(
+    encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientBootstrap,
       LightClientBootstrapKey.serialize({ blockHash: hexToBytes(bootstrapRoot) }),
     ),
@@ -114,14 +114,14 @@ const main = async () => {
     console.log('Caught interrupt signal.  Shutting down...')
     process.exit(0)
   })
-   
+
   while (true) {
     await new Promise((resolve) => setTimeout(() => resolve(undefined), 13000))
     const optimisticUpdate = ssz.capella.LightClientOptimisticUpdate.fromJson(
       (await (await fetch(beaconNode + 'eth/v1/beacon/light_client/optimistic_update')).json())
         .data,
     )
-    const optimisticUpdateKey = getBeaconContentKey(
+    const optimisticUpdateKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientOptimisticUpdate,
       LightClientOptimisticUpdateKey.serialize({
         signatureSlot: BigInt(optimisticUpdate.signatureSlot),
@@ -143,7 +143,7 @@ const main = async () => {
     const finalityUpdate = ssz.capella.LightClientFinalityUpdate.fromJson(
       (await (await fetch(beaconNode + 'eth/v1/beacon/light_client/finality_update')).json()).data,
     )
-    const finalityUpdateKey = getBeaconContentKey(
+    const finalityUpdateKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientFinalityUpdate,
       LightClientFinalityUpdateKey.serialize({
         finalitySlot: BigInt(finalityUpdate.finalizedHeader.beacon.slot),

--- a/packages/cli/scripts/bootstrapFinder.ts
+++ b/packages/cli/scripts/bootstrapFinder.ts
@@ -11,7 +11,7 @@ import {
   LightClientOptimisticUpdateKey,
   LightClientUpdatesByRange,
   LightClientUpdatesByRangeKey,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from 'portalnetwork'
 
 import type { ForkLightClient } from '@lodestar/params'
@@ -36,7 +36,7 @@ const main = async () => {
 
   console.log('Retrieving bootstrap and updates from Beacon node...')
   const optimisticUpdate = (await api.lightclient.getOptimisticUpdate()).response!
-  const optimisticUpdateKey = getBeaconContentKey(
+  const optimisticUpdateKey = encodeBeaconContentKey(
     BeaconNetworkContentType.LightClientOptimisticUpdate,
     LightClientOptimisticUpdateKey.serialize({
       signatureSlot: BigInt(optimisticUpdate.data.attestedHeader.beacon.slot),
@@ -53,14 +53,14 @@ const main = async () => {
         beaconConfig.forkName2ForkDigest(update.version as ForkLightClient),
         (
           ssz.allForksLightClient[
-            update.version as LightClientForkName
+          update.version as LightClientForkName
           ] as allForks.AllForksLightClientSSZTypes
         ).LightClientUpdate.serialize(update.data),
       ),
     )
   }
   const serializedRange = LightClientUpdatesByRange.serialize(range)
-  const rangeKey = getBeaconContentKey(
+  const rangeKey = encodeBeaconContentKey(
     BeaconNetworkContentType.LightClientUpdatesByRange,
     LightClientUpdatesByRangeKey.serialize({ startPeriod: BigInt(oldPeriod), count: 4n }),
   )
@@ -72,7 +72,7 @@ const main = async () => {
     )
     const bootstrap = (await api.lightclient.getBootstrap(bootstrapRoot)).response!
     await ultralights[Math.floor(Math.random() * 10)].request('portal_beaconStore', [
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientBootstrap,
         LightClientBootstrapKey.serialize({ blockHash: hexToBytes(bootstrapRoot) }),
       ),
@@ -81,15 +81,14 @@ const main = async () => {
           beaconConfig.forkName2ForkDigest(bootstrap.version),
           (
             ssz.allForksLightClient[
-              bootstrap.version as LightClientForkName
+            bootstrap.version as LightClientForkName
             ] as allForks.AllForksLightClientSSZTypes
           ).LightClientBootstrap.serialize(bootstrap.data),
         ),
       ),
     ])
     console.log(
-      `Retrieved bootstrap for finalized checkpoint ${bootstrapRoot} from sync period ${
-        oldPeriod + x
+      `Retrieved bootstrap for finalized checkpoint ${bootstrapRoot} from sync period ${oldPeriod + x
       } and seeding to network...`,
     )
   }
@@ -119,7 +118,7 @@ const main = async () => {
         beaconConfig.forkName2ForkDigest(optimisticUpdate.version),
         (
           ssz.allForksLightClient[
-            optimisticUpdate.version as LightClientForkName
+          optimisticUpdate.version as LightClientForkName
           ] as allForks.AllForksLightClientSSZTypes
         ).LightClientOptimisticUpdate.serialize(optimisticUpdate.data),
       ),
@@ -134,12 +133,12 @@ const main = async () => {
     console.log('Caught interrupt signal.  Shuttind down...')
     process.exit(0)
   })
-   
+
   while (true) {
     await new Promise((resolve) => setTimeout(() => resolve(undefined), 13000))
     const optimisticUpdate = (await api.lightclient.getOptimisticUpdate()).response!
     console.log('new update')
-    const optimisticUpdateKey = getBeaconContentKey(
+    const optimisticUpdateKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientOptimisticUpdate,
       LightClientOptimisticUpdateKey.serialize({
         signatureSlot: BigInt(optimisticUpdate.data.attestedHeader.beacon.slot),
@@ -152,7 +151,7 @@ const main = async () => {
           beaconConfig.forkName2ForkDigest(optimisticUpdate.version),
           (
             ssz.allForksLightClient[
-              optimisticUpdate.version as LightClientForkName
+            optimisticUpdate.version as LightClientForkName
             ] as allForks.AllForksLightClientSSZTypes
           ).LightClientOptimisticUpdate.serialize(optimisticUpdate.data),
         ),

--- a/packages/cli/scripts/postCapellaBlockBridge.ts
+++ b/packages/cli/scripts/postCapellaBlockBridge.ts
@@ -6,7 +6,7 @@ import jayson from 'jayson/promise/index.js'
 import {
   BeaconNetworkContentType,
   BlockHeaderWithProof,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
   getContentKey,
   HistoricalSummariesBlockProof,
   HistoricalSummariesKey,
@@ -54,7 +54,7 @@ const main = async () => {
   console.log(
     `Retrieved latest optimistic update for slot ${BigInt(optimisticUpdate.signatureSlot)}`,
   )
-  const optimisticUpdateKey = getBeaconContentKey(
+  const optimisticUpdateKey = encodeBeaconContentKey(
     BeaconNetworkContentType.LightClientOptimisticUpdate,
     LightClientOptimisticUpdateKey.serialize({
       signatureSlot: BigInt(optimisticUpdate.signatureSlot),
@@ -85,7 +85,7 @@ const main = async () => {
   // Push the bootstrap into the Portal Network
   let res = await ultralight.request('portal_beaconStore', [
     bytesToHex(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientBootstrap,
         LightClientBootstrapKey.serialize({ blockHash: hexToBytes(bootstrapRoot) }),
       ),
@@ -110,7 +110,7 @@ const main = async () => {
   console.log('Retrieving latest historical summaries...')
   const res2 = await fetch(
     beaconNode +
-      `/eth/v1/lodestar/historical_summaries/${finalityUpdate.finalizedHeader.beacon.slot}`,
+    `/eth/v1/lodestar/historical_summaries/${finalityUpdate.finalizedHeader.beacon.slot}`,
   )
   const res2Json = await res2.json()
 
@@ -125,7 +125,7 @@ const main = async () => {
 
   res = await ultralight.request('portal_beaconStore', [
     bytesToHex(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.HistoricalSummaries,
         HistoricalSummariesKey.serialize({ epoch: BigInt(finalityEpoch) }),
       ),

--- a/packages/cli/src/rpc/modules/beacon.ts
+++ b/packages/cli/src/rpc/modules/beacon.ts
@@ -10,7 +10,7 @@ import {
   NetworkIdByChain,
   type PortalNetwork,
   computeLightClientKeyFromPeriod,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from 'portalnetwork'
 
 import { INTERNAL_ERROR } from '../error-code.js'
@@ -89,7 +89,7 @@ export class beacon {
 
   async getLightClientUpdate(params: [string]) {
     const period = Number(BigInt(params[0]))
-    const rangeKey = getBeaconContentKey(
+    const rangeKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientUpdate,
       hexToBytes(computeLightClientKeyFromPeriod(period) as PrefixedHexString),
     )
@@ -101,7 +101,7 @@ export class beacon {
     }
     const lookup = new ContentLookup(
       this._beacon,
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientUpdatesByRange,
         LightClientUpdatesByRangeKey.serialize({ startPeriod: BigInt(params[0]), count: 1n }),
       ),

--- a/packages/cli/test/rpc/beacon/getLightClientUpdate.spec.ts
+++ b/packages/cli/test/rpc/beacon/getLightClientUpdate.spec.ts
@@ -4,7 +4,7 @@ import { ssz } from '@lodestar/types'
 import {
   BeaconNetworkContentType,
   computeLightClientKeyFromPeriod,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from 'portalnetwork'
 import { assert, afterAll, beforeAll, describe, it } from 'vitest'
 
@@ -14,7 +14,7 @@ describe(`${method} tests`, () => {
   let ultralight, rpc
 
   beforeAll(async () => {
-    ;({ ultralight, rpc } = await startRpc({ networks: ['beacon'], rpcPort: 8548, port: 9003 }))
+    ; ({ ultralight, rpc } = await startRpc({ networks: ['beacon'], rpcPort: 8548, port: 9003 }))
   })
 
   afterAll(() => {
@@ -23,7 +23,7 @@ describe(`${method} tests`, () => {
 
   it('should retrieve a light client update', async () => {
     const rangeJson = require('./range.json')[0]
-    const rangeKey = getBeaconContentKey(
+    const rangeKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientUpdate,
       hexToBytes(
         computeLightClientKeyFromPeriod(

--- a/packages/cli/test/rpc/portal/beaconLocalContent.spec.ts
+++ b/packages/cli/test/rpc/portal/beaconLocalContent.spec.ts
@@ -2,7 +2,7 @@ import { bytesToHex } from '@ethereumjs/util'
 import {
   BeaconNetworkContentType,
   LightClientOptimisticUpdateKey,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from 'portalnetwork'
 import { assert, afterAll, beforeAll, describe, it } from 'vitest'
 
@@ -24,7 +24,7 @@ describe(`${method} tests`, () => {
     it('should not find any local content', async () => {
       const key = LightClientOptimisticUpdateKey.serialize({ signatureSlot: 7807053n })
       const res = await rp.request(method, [
-        bytesToHex(getBeaconContentKey(BeaconNetworkContentType.LightClientOptimisticUpdate, key)),
+        bytesToHex(encodeBeaconContentKey(BeaconNetworkContentType.LightClientOptimisticUpdate, key)),
       ])
       console.log(res)
       assert.equal(res.error.code, -32009)

--- a/packages/portalnetwork/src/networks/beacon/beacon.ts
+++ b/packages/portalnetwork/src/networks/beacon/beacon.ts
@@ -50,7 +50,7 @@ import {
   SyncStrategy,
 } from './types.js'
 import { UltralightTransport } from './ultralightTransport.js'
-import { getBeaconContentKey } from './util.js'
+import { encodeBeaconContentKey } from './util.js'
 
 import type { BeaconConfig } from '@lodestar/config'
 import type { LightClientUpdate } from '@lodestar/types'
@@ -181,7 +181,7 @@ export class BeaconNetwork extends BaseNetwork {
       )
 
       // Request the range of Light Client Updates extending back 4 sync periods
-      const rangeKey = getBeaconContentKey(
+      const rangeKey = encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientUpdatesByRange,
         LightClientUpdatesByRangeKey.serialize({ startPeriod: currentPeriod - 3n, count: 4n }),
       )
@@ -233,7 +233,7 @@ export class BeaconNetwork extends BaseNetwork {
           // If we go through all of the possible checkpoint roots that receive a simple majority
           // vote by the polled nodes, stop looking and clear out votes.
           if (results[x][1] < Math.floor(MIN_BOOTSTRAP_VOTES / 2 + 1)) break
-          const bootstrapKey = getBeaconContentKey(
+          const bootstrapKey = encodeBeaconContentKey(
             BeaconNetworkContentType.LightClientBootstrap,
             LightClientBootstrapKey.serialize({
               blockHash: hexToBytes(results[x][0] as PrefixedHexString),

--- a/packages/portalnetwork/src/networks/beacon/util.ts
+++ b/packages/portalnetwork/src/networks/beacon/util.ts
@@ -5,7 +5,7 @@ import {
   LightClientBootstrapKey,
   LightClientFinalityUpdateKey,
   LightClientOptimisticUpdateKey,
-  LightClientUpdatesByRange,
+  LightClientUpdatesByRangeKey,
 } from './types.js'
 
 /**
@@ -37,7 +37,7 @@ export const decodeBeaconContentKey = (serializedKey: Uint8Array) => {
     case BeaconNetworkContentType.LightClientFinalityUpdate:
       return LightClientFinalityUpdateKey.deserialize(contentKeyBytes)
     case BeaconNetworkContentType.LightClientUpdatesByRange:
-      return LightClientUpdatesByRange.deserialize(contentKeyBytes)
+      return LightClientUpdatesByRangeKey.deserialize(contentKeyBytes)
     default:
       throw new Error(`unknown content type ${selector}`)
   }

--- a/packages/portalnetwork/src/networks/beacon/util.ts
+++ b/packages/portalnetwork/src/networks/beacon/util.ts
@@ -14,7 +14,7 @@ import {
  * @param serializedKey the SSZ encoded key corresponding to the `BeaconNetworkContentType`
  * @returns the content key encoded as a hex string
  */
-export const getBeaconContentKey = (
+export const encodeBeaconContentKey = (
   contentType: BeaconNetworkContentType,
   serializedKey: Uint8Array,
 ) => {

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -22,7 +22,7 @@ import {
   TransportLayer,
   createPortalNetwork,
   decodeBeaconContentKey,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from '../../src/index.js'
 
 import { BitArray } from '@chainsafe/ssz'
@@ -259,7 +259,7 @@ describe('Find Content tests', () => {
     await network1.storeUpdateRange(hexToBytes(updatesByRange.content_value))
 
     const rangeKey = hexToBytes(updatesByRange.content_key)
-    const truncatedRangeKey = getBeaconContentKey(BeaconNetworkContentType.LightClientUpdatesByRange, LightClientUpdatesByRangeKey.serialize({
+    const truncatedRangeKey = encodeBeaconContentKey(BeaconNetworkContentType.LightClientUpdatesByRange, LightClientUpdatesByRangeKey.serialize({
       startPeriod: 816n,
       count: 2n,
     }),
@@ -366,7 +366,7 @@ describe('OFFER/ACCEPT tests', () => {
       'node1 added node2 to routing table',
     )
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({ signatureSlot: 6718463n }),
       ),
@@ -392,7 +392,7 @@ describe('OFFER/ACCEPT tests', () => {
       })
     })
     const content = await network2.findContentLocally(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({ signatureSlot: 6718463n }),
       ),
@@ -473,7 +473,7 @@ describe('OFFER/ACCEPT tests', () => {
       'node1 added node2 to routing table',
     )
 
-    const staleOptimisticUpdateContentKey = getBeaconContentKey(
+    const staleOptimisticUpdateContentKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientOptimisticUpdate,
       LightClientOptimisticUpdateKey.serialize({ signatureSlot: 6718463n }),
     )
@@ -536,7 +536,7 @@ describe('OFFER/ACCEPT tests', () => {
 
     await network1.sendPing(network2?.enr.toENR())
 
-    const bootstrapKey = getBeaconContentKey(
+    const bootstrapKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientBootstrap,
       LightClientBootstrapKey.serialize({
         blockHash: ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
@@ -636,7 +636,7 @@ describe('beacon light client sync tests', () => {
     const optimisticUpdate = ssz.capella.LightClientOptimisticUpdate.fromJson(optimisticUpdateJson)
 
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientBootstrap,
         LightClientBootstrapKey.serialize({
           blockHash: ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
@@ -650,7 +650,7 @@ describe('beacon light client sync tests', () => {
     await network1.storeUpdateRange(updatesByRange)
 
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({
           signatureSlot: BigInt(optimisticUpdate.signatureSlot),
@@ -757,14 +757,14 @@ describe('beacon light client sync tests', () => {
       ),
     )
 
-    const rangeKey = getBeaconContentKey(
+    const rangeKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientUpdatesByRange,
       LightClientUpdatesByRangeKey.serialize({
         startPeriod: BigInt(computeSyncPeriodAtSlot(range[0].data.attested_header.beacon.slot)),
         count: 3n,
       }),
     )
-    const bootstrapKey = getBeaconContentKey(
+    const bootstrapKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientBootstrap,
       LightClientBootstrapKey.serialize({
         blockHash: ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
@@ -842,7 +842,7 @@ describe('historicalSummaries verification', () => {
     const capellaForkDigest = network1.beaconConfig.forkName2ForkDigest(ForkName.electra)
     console.log(bytesToHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon)))
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientBootstrap,
         LightClientBootstrapKey.serialize({
           blockHash: ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
@@ -852,7 +852,7 @@ describe('historicalSummaries verification', () => {
     )
 
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientOptimisticUpdate,
         LightClientOptimisticUpdateKey.serialize({
           signatureSlot: BigInt(optimisticUpdate.signatureSlot),
@@ -881,7 +881,7 @@ describe('historicalSummaries verification', () => {
     )
 
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.LightClientFinalityUpdate,
         LightClientFinalityUpdateKey.serialize({
           finalitySlot: BigInt(finalityUpdate.signatureSlot),
@@ -907,7 +907,7 @@ describe('historicalSummaries verification', () => {
       proof: historicalSummariesJson.data.proof,
     })
     await network1.store(
-      getBeaconContentKey(
+      encodeBeaconContentKey(
         BeaconNetworkContentType.HistoricalSummaries,
         HistoricalSummariesKey.serialize({ epoch }),
       ),

--- a/packages/portalnetwork/test/integration/beacon.spec.ts
+++ b/packages/portalnetwork/test/integration/beacon.spec.ts
@@ -198,7 +198,7 @@ describe('Find Content tests', () => {
     await node2.stop()
   }, 15000)
 
-  it.only('should find LightClientUpdatesByRange update', async () => {
+  it('should find LightClientUpdatesByRange update', async () => {
     const updatesByRange = specTestVectors.updateByRange['6684738']
     const initMa: any = multiaddr('/ip4/127.0.0.1/udp/3004')
     enr1.setLocationMultiaddr(initMa)

--- a/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
+++ b/packages/portalnetwork/test/integration/ephemeralHeaders.spec.ts
@@ -18,7 +18,7 @@ import {
   LightClientBootstrapKey,
   NetworkId,
   createPortalNetwork,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
   getContentKey,
   getEphemeralHeaderDbKey,
 } from '../../src/index.js'
@@ -175,7 +175,7 @@ describe('should offer headers to peers', () => {
     const bootstrapJson = await import('./testdata/postDenebData/bootstrap.json')
     const bootstrap = ssz.deneb.LightClientBootstrap.fromJson(bootstrapJson.data)
     const bootstrapRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon)
-    const bootstrapKey = getBeaconContentKey(
+    const bootstrapKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientBootstrap,
       LightClientBootstrapKey.serialize({
         blockHash: ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
@@ -236,16 +236,16 @@ describe('should offer headers to peers', () => {
     await history2?.sendPing(node1.discv5.enr.toENR())
     await node1
       .network()
-      ['0x500c']!.store(
-        bootstrapKey,
-        concatBytes(forkDigest, ssz.deneb.LightClientBootstrap.serialize(bootstrap)),
-      )
+    ['0x500c']!.store(
+      bootstrapKey,
+      concatBytes(forkDigest, ssz.deneb.LightClientBootstrap.serialize(bootstrap)),
+    )
     await node2
       .network()
-      ['0x500c']!.store(
-        bootstrapKey,
-        concatBytes(forkDigest, ssz.deneb.LightClientBootstrap.serialize(bootstrap)),
-      )
+    ['0x500c']!.store(
+      bootstrapKey,
+      concatBytes(forkDigest, ssz.deneb.LightClientBootstrap.serialize(bootstrap)),
+    )
     await history1?.store(
       offerPayload[0],
       EphemeralHeaderOfferPayload.serialize({ header: headers[0].serialize() }),

--- a/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
+++ b/packages/portalnetwork/test/integration/eth/getBlockByNumber.spec.ts
@@ -19,7 +19,7 @@ import {
   addRLPSerializedBlock,
   createPortalNetwork,
   generatePreMergeHeaderProof,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from '../../../src/index.js'
 
 import type { BeaconNetwork, HistoryNetwork } from '../../../src/index.js'
@@ -141,7 +141,7 @@ describe(
 //   const optimisticUpdate = ssz.capella.LightClientOptimisticUpdate.fromJson(optimisticUpdateJson)
 
 //   await beacon.store(
-//     getBeaconContentKey(
+//     encodeBeaconContentKey(
 //       BeaconNetworkContentType.LightClientBootstrap,
 //       LightClientBootstrapKey.serialize({
 //         blockHash: ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon),
@@ -171,7 +171,7 @@ describe(
 //   await beacon.storeUpdateRange(updatesByRange)
 
 //   await beacon.store(
-//     getBeaconContentKey(
+//     encodeBeaconContentKey(
 //       BeaconNetworkContentType.LightClientOptimisticUpdate,
 //       LightClientOptimisticUpdateKey.serialize({
 //         signatureSlot: BigInt(optimisticUpdate.signatureSlot),

--- a/packages/portalnetwork/test/integration/postCapellaHeaderProof.spec.ts
+++ b/packages/portalnetwork/test/integration/postCapellaHeaderProof.spec.ts
@@ -18,7 +18,7 @@ import {
   LightClientBootstrapKey,
   NetworkId,
   createPortalNetwork,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
   getContentKey
 } from '../../src/index.js'
 
@@ -65,7 +65,7 @@ describe('Block Bridge Data Test', () => {
 
     // Store bootstrap
 
-    const bootstrapKey = getBeaconContentKey(
+    const bootstrapKey = encodeBeaconContentKey(
       BeaconNetworkContentType.LightClientBootstrap,
       LightClientBootstrapKey.serialize({ blockHash: bootstrapRoot }),
     )
@@ -90,7 +90,7 @@ describe('Block Bridge Data Test', () => {
       historical_summaries: historicalSummariesJson.data.historical_summaries,
       proof: historicalSummariesJson.data.proof,
     })
-    const summariesKey = getBeaconContentKey(
+    const summariesKey = encodeBeaconContentKey(
       BeaconNetworkContentType.HistoricalSummaries,
       HistoricalSummariesKey.serialize({ epoch: BigInt(historicalSummariesEpoch) }),
     )

--- a/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
+++ b/packages/portalnetwork/test/networks/beacon/beacon.spec.ts
@@ -10,7 +10,7 @@ import {
   NetworkId,
   TransportLayer,
   createPortalNetwork,
-  getBeaconContentKey,
+  encodeBeaconContentKey,
 } from '../../../src/index.js'
 import {
   BeaconNetworkContentType,
@@ -217,7 +217,7 @@ describe('API tests', async () => {
       },
     }
     const epoch = BigInt(finalityUpdateJson.finalized_header.beacon.slot) / 8192n
-    const historicalSummariesKey = getBeaconContentKey(
+    const historicalSummariesKey = encodeBeaconContentKey(
       BeaconNetworkContentType.HistoricalSummaries,
       HistoricalSummariesKey.serialize({
         epoch,


### PR DESCRIPTION
This addresses #790 
- Respond with a partial range of `LightClientUpdate`s if we only have a partial set of the requested range
- Fixes a bug in `decodeBeaconContentKey` for decoding `LightClientUpdatesByRange` keys
- Rename `getBeaconContentKey` to `decodeBeaconContentKey` to harmonize with `encodeBeaconContentKey`
- Don't respond with `LightClientOptimisticUpdate` when requested slot is newer than one currently in DB
